### PR TITLE
Add method "SetMousePosition" to window class.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .DS_Store
 CMakeFiles
 tests/Output
+/Projects

--- a/include/LLGL/Window.h
+++ b/include/LLGL/Window.h
@@ -147,6 +147,9 @@ class LLGL_EXPORT Window : public Surface
         //! Queries a window descriptor, which describes the attributes of this window.
         virtual WindowDescriptor GetDesc() const = 0;
 
+        //! Sets the mouse cursor position
+        virtual void SetMousePosition(const Offset2D& Pos);
+        
         //! Sets the new window behavior.
         virtual void SetBehavior(const WindowBehavior& behavior);
 

--- a/sources/Platform/Win32/Win32Window.cpp
+++ b/sources/Platform/Win32/Win32Window.cpp
@@ -222,6 +222,14 @@ std::wstring Win32Window::GetTitle() const
     return std::wstring(title);
 }
 
+void Win32Window::SetMousePosition(const Offset2D & Pos)
+{
+    POINT pos = { Pos.x, Pos.y };
+    ClientToScreen(wnd_, &pos);
+    SetCursorPos(pos.x, pos.y);
+    PostGlobalMotion(Pos);
+}
+
 void Win32Window::Show(bool show)
 {
     ShowWindow(wnd_, (show ? SW_NORMAL : SW_HIDE));

--- a/sources/Platform/Win32/Win32Window.h
+++ b/sources/Platform/Win32/Win32Window.h
@@ -40,6 +40,8 @@ class Win32Window : public Window
         void SetTitle(const std::wstring& title) override;
         std::wstring GetTitle() const override;
 
+        void SetMousePosition(const Offset2D& Pos) override;
+
         void Show(bool show = true) override;
         bool IsShown() const override;
 

--- a/sources/Platform/Window.cpp
+++ b/sources/Platform/Window.cpp
@@ -81,6 +81,12 @@ void Window::EventListener::OnTimer(Window& sender, std::uint32_t timerID)
 }
 
 
+void Window::SetMousePosition(const Offset2D & Pos)
+{
+    // dummy
+}
+
+
 /* ----- Window class ----- */
 
 #define FOREACH_LISTENER_CALL(FUNC) \


### PR DESCRIPTION
I noticed there's no function to change mouse position manually when I was trying to make ImGui use LLGL.

Notes:
-Works only for Windows.
-I wanted to implement it in Input, but I needed the window handle, some platform specific functions and also needed to call PostGlobalMotion, so I implemented it in window class instead.