### PR TITLE
Fixed some win32 compile errors.

### DIFF
--- a/include/LLGL/Display.h
+++ b/include/LLGL/Display.h
@@ -13,7 +13,7 @@
 #include "DisplayFlags.h"
 #include <vector>
 #include <memory>
-
+#include <string>
 
 namespace LLGL
 {

--- a/sources/Platform/Win32/Win32Window.cpp
+++ b/sources/Platform/Win32/Win32Window.cpp
@@ -212,13 +212,13 @@ Extent2D Win32Window::GetSize(bool useClientArea) const
 
 void Win32Window::SetTitle(const std::wstring& title)
 {
-    SetWindowText(wnd_, title.c_str());
+    SetWindowTextW(wnd_, title.c_str());
 }
 
 std::wstring Win32Window::GetTitle() const
 {
     wchar_t title[MAX_PATH];
-    GetWindowText(wnd_, title, MAX_PATH);
+    GetWindowTextW(wnd_, title, MAX_PATH);
     return std::wstring(title);
 }
 
@@ -369,7 +369,7 @@ HWND Win32Window::CreateWindowHandle(const WindowDescriptor& desc)
     }
 
     /* Create frame window object */
-    HWND wnd = CreateWindow(
+    HWND wnd = CreateWindowW(
         windowClass->GetName(),
         desc.title.c_str(),
         appearance.style,

--- a/sources/Platform/Win32/Win32WindowClass.cpp
+++ b/sources/Platform/Win32/Win32WindowClass.cpp
@@ -21,7 +21,7 @@ namespace LLGL
 Win32WindowClass::Win32WindowClass()
 {
     /* Setup window class information */
-    WNDCLASS wc;
+    WNDCLASSW wc;
     InitMemory(wc);
 
     wc.style            = (CS_HREDRAW | CS_VREDRAW | CS_OWNDC | CS_DBLCLKS);
@@ -40,13 +40,13 @@ Win32WindowClass::Win32WindowClass()
     wc.lpszClassName    = GetName();
 
     /* Register window class */
-    if (!RegisterClass(&wc))
+    if (!RegisterClassW(&wc))
         throw std::runtime_error("failed to register window class");
 }
 
 Win32WindowClass::~Win32WindowClass()
 {
-    UnregisterClass(GetName(), GetModuleHandle(nullptr));
+    UnregisterClassW(GetName(), GetModuleHandle(nullptr));
 }
 
 Win32WindowClass* Win32WindowClass::Instance()


### PR DESCRIPTION
* added include <string> for std::wstring definition;
* changed win32 api to use 'W' version to fix compile errors when using 'Use Multi-Byte Character Set' option. When that option is used strings are expected to be char instead of wchar_t. see https://docs.microsoft.com/en-us/windows/desktop/LearnWin32/working-with-strings