### PR TITLE
Use relative path fo loadModule on Linux

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,7 +7,6 @@ project(LLGL)
 set(CMAKE_CXX_STANDARD 11)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
-
 # === Build path ===
 
 set(OUTPUT_DIR ${CMAKE_CURRENT_BINARY_DIR}/build)
@@ -647,6 +646,8 @@ endif()
 
 if(LLGL_BUILD_RENDERER_OPENGL)
     # OpenGL Renderer
+    # set OpenGL preference
+    set(OpenGL_GL_PREFERENCE "GLVND")
     find_package(OpenGL REQUIRED)
     if(OpenGL_FOUND)
         include_directories(${OPENGL_INCLUDE_DIR})

--- a/sources/Platform/Linux/LinuxModule.cpp
+++ b/sources/Platform/Linux/LinuxModule.cpp
@@ -36,7 +36,7 @@ static std::string GetProgramPath()
 std::string Module::GetModuleFilename(const char* moduleName)
 {
     /* Extend module name to Linux shared library name (SO) */
-    std::string s = GetProgramPath();
+    std::string s = ""; //GetProgramPath();
     s += "libLLGL_";
     s += moduleName;
     #ifdef LLGL_DEBUG


### PR DESCRIPTION
Allows installation of LLGL as system lib. If we use absolute path, the lib loader will only look in the current directory, and won't look in standard path.