### PR TITLE
Fixed large memory leaks in the Metal sample programs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -380,6 +380,10 @@ if(LLGL_ANDROID_PLATFORM)
     set(FilesAndroidNativeAppGlue "${ANDROID_APP_GLUE_DIR}/android_native_app_glue.c" "${ANDROID_APP_GLUE_DIR}/android_native_app_glue.h")
 endif()
 
+if(APPLE)
+    set_source_files_properties(${EXAMPLE_PROJECTS_DIR}/ExampleBase/ExampleBase.cpp PROPERTIES COMPILE_FLAGS -xobjective-c++)
+endif()
+
 set(FilesExample_HelloTriangle ${EXAMPLE_PROJECTS_DIR}/HelloTriangle/Example.cpp)
 set(FilesExample_Tessellation ${EXAMPLE_PROJECTS_DIR}/Tessellation/Example.cpp)
 set(FilesExample_Texturing ${EXAMPLE_PROJECTS_DIR}/Texturing/Example.cpp)

--- a/examples/Cpp/ExampleBase/ExampleBase.cpp
+++ b/examples/Cpp/ExampleBase/ExampleBase.cpp
@@ -230,7 +230,14 @@ void ExampleBase::Run()
         }
 
         // Draw current frame
+        #ifdef LLGL_OS_MACOS
+        @autoreleasepool
+        {
+            OnDrawFrame();
+        }
+        #else
         OnDrawFrame();
+        #endif
 
         // Check if resolution has changed
         auto currentResolution = context->GetResolution();

--- a/sources/Platform/MacOS/MacOSWindow.mm
+++ b/sources/Platform/MacOS/MacOSWindow.mm
@@ -496,23 +496,26 @@ NSWindow* MacOSWindow::CreateNSWindow(const WindowDescriptor& desc)
 
 void MacOSWindow::OnProcessEvents()
 {
-    NSEvent* event = nil;
-
-    /* Process NSWindow events with latest event types */
-    while ((event = [wnd_ nextEventMatchingMask:g_EventMaskAny untilDate:nil inMode:NSDefaultRunLoopMode dequeue:YES]) != nil)
-        ProcessEvent(event);
-
-    /* Check for window signales */
-    if ([(MacOSWindowDelegate*)[wnd_ delegate] popResizeSignal])
+    @autoreleasepool
     {
-        /* Get size of the NSWindow's content view */
-        NSRect frame = [[wnd_ contentView] frame];
+        NSEvent* event = nil;
 
-        auto w = static_cast<std::uint32_t>(frame.size.width);
-        auto h = static_cast<std::uint32_t>(frame.size.height);
+        /* Process NSWindow events with latest event types */
+        while ((event = [wnd_ nextEventMatchingMask:g_EventMaskAny untilDate:nil inMode:NSDefaultRunLoopMode dequeue:YES]) != nil)
+            ProcessEvent(event);
 
-        /* Notify event listeners about resize */
-        PostResize({ w, h });
+        /* Check for window signales */
+        if ([(MacOSWindowDelegate*)[wnd_ delegate] popResizeSignal])
+        {
+            /* Get size of the NSWindow's content view */
+            NSRect frame = [[wnd_ contentView] frame];
+
+            auto w = static_cast<std::uint32_t>(frame.size.width);
+            auto h = static_cast<std::uint32_t>(frame.size.height);
+
+            /* Notify event listeners about resize */
+            PostResize({ w, h });
+        }
     }
 }
 

--- a/sources/Renderer/Metal/MTEncoderScheduler.mm
+++ b/sources/Renderer/Metal/MTEncoderScheduler.mm
@@ -101,6 +101,7 @@ void MTEncoderScheduler::ResumeRenderEncoder()
             renderPassDesc.stencilAttachment.loadAction = MTLLoadActionLoad;
         }
         BindRenderEncoder(renderPassDesc);
+        [renderPassDesc release];
         isRenderEncoderPaused_ = false;
     }
 }


### PR DESCRIPTION
The sample programs were leaking memory on every frame because autorelease pools were not being created or drained so Metal objects were not being released. I added a DrawNow call to the RenderContext to give the platform context an opportunity to set up the correct environment for drawing and clean up after the drawing is done.

I also added an autorelease pool inside OnProcessEvents and fixed a bug in MTEncodeScheduler that was leaking copied
RenderPassDescriptors.