### PR TITLE
Correctly handling Retina displays on the Mac

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -44,6 +44,8 @@ endmacro()
 macro(ADD_EXAMPLE_PROJECT TEST_NAME TEST_FILES LIB_FILES)
     if(APPLE)
         add_executable(${TEST_NAME} MACOSX_BUNDLE ${TEST_FILES})
+        set_target_properties(${TEST_NAME} PROPERTIES
+            MACOSX_BUNDLE_INFO_PLIST ${EXAMPLE_PROJECTS_DIR}/MacOS/HighResolution.plist)
     elseif(LLGL_ANDROID_PLATFORM)
         add_library(${TEST_NAME} SHARED ${TEST_FILES})
         target_link_libraries(${TEST_NAME} log)

--- a/examples/Cpp/ExampleBase/ExampleBase.h
+++ b/examples/Cpp/ExampleBase/ExampleBase.h
@@ -170,7 +170,7 @@ protected:
 
     ExampleBase(
         const std::wstring&     title,
-        const LLGL::Extent2D&   resolution  = { 800, 600 },
+        const LLGL::Extent2D&   contentSize = { 800, 600 },
         std::uint32_t           samples     = 8,
         bool                    vsync       = true,
         bool                    debugger    = true

--- a/examples/Cpp/MacOS/HighResolution.plist
+++ b/examples/Cpp/MacOS/HighResolution.plist
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>NSHighResolutionCapable</key>
+	<true/>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>English</string>
+	<key>CFBundleExecutable</key>
+	<string>${MACOSX_BUNDLE_EXECUTABLE_NAME}</string>
+	<key>CFBundleGetInfoString</key>
+	<string>${MACOSX_BUNDLE_INFO_STRING}</string>
+	<key>CFBundleIconFile</key>
+	<string>${MACOSX_BUNDLE_ICON_FILE}</string>
+	<key>CFBundleIdentifier</key>
+	<string>${MACOSX_BUNDLE_GUI_IDENTIFIER}</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleLongVersionString</key>
+	<string>${MACOSX_BUNDLE_LONG_VERSION_STRING}</string>
+	<key>CFBundleName</key>
+	<string>${MACOSX_BUNDLE_BUNDLE_NAME}</string>
+	<key>CFBundlePackageType</key>
+	<string>APPL</string>
+	<key>CFBundleShortVersionString</key>
+	<string>${MACOSX_BUNDLE_SHORT_VERSION_STRING}</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>CFBundleVersion</key>
+	<string>${MACOSX_BUNDLE_BUNDLE_VERSION}</string>
+	<key>CSResourcesFileMapped</key>
+	<true/>
+	<key>NSHumanReadableCopyright</key>
+	<string>${MACOSX_BUNDLE_COPYRIGHT}</string>
+</dict>
+</plist>

--- a/include/LLGL/RenderContext.h
+++ b/include/LLGL/RenderContext.h
@@ -126,6 +126,15 @@ class LLGL_EXPORT RenderContext : public RenderTarget
         }
 
         /**
+        \brief Set the resolution, in pixels, of the drawing buffers. Call this routine when processing
+        a resize event to update the  drawables for the new surface size.
+        \param[in] resolution Specifies the desired resolution of the drawing buffers.
+        \return True on success, otherwise the previous resolution remains.
+        \see Surface::GetPixelResolution
+         */
+        bool SetDrawableResolution(const Extent2D& resolution);
+
+        /**
         \brief Sets the new vertical-sychronization (V-sync) configuration for this render context.
         \param[in] vsyncDesc Specifies the descriptor of the new V-sync configuration.
         \return True on success, otherwise the specified V-sync is invalid.
@@ -158,6 +167,14 @@ class LLGL_EXPORT RenderContext : public RenderTarget
         \see Surface::AdaptForVideoMode
         */
         virtual bool OnSetVideoMode(const VideoModeDescriptor& videoModeDesc) = 0;
+
+        /**
+        \brief Callback to change the pixel size of the drawing buffers.
+        \param[in] resolution Specifies the new drawing buffer resolution.
+        \return True on success, otherwise the previous resolution  remains.
+        \see SetDrawableResolution
+        */
+        virtual bool OnSetDrawableResolution(const Extent2D& resolution) = 0;
 
         /**
         \brief Callback when the V-sync is about to get changed.

--- a/include/LLGL/Surface.h
+++ b/include/LLGL/Surface.h
@@ -65,6 +65,29 @@ class LLGL_EXPORT Surface : public Interface
         virtual Extent2D GetContentSize() const = 0;
 
         /**
+        \brief Returns the resolution of the surface content area in pixels.
+        \return The pixel resolution of the surface.
+        \remarks On Retina Macs the pixel resolution of the surface may be larger than the content size. The drawables
+        of the surface must be sized to the pixel resolution to ensure the highest resolution drawing. The pixel resolution
+        of a surface may change even when the content size does not e.g. when the surface is moved to a different
+        monitor. If this occurs a resize event will be sent.
+        \see Surface::GetContentSizeForPixelResolution
+        \see RenderContext::SetDrawableResolution
+        */
+        virtual Extent2D GetPixelResolution() const;
+
+        /**
+        \brief Returns the content size of the surface for a given pixel resolution.
+        \param[in] resolution The desired pixel resolution for the surface.
+        \return The content size at which the surface will have the given pixel resolution.
+        \remarks On Retina Macs the pixel resolution of the surface may be larger than the content size. This call
+        maps from a resolution to the equivalent content size. The mapping may change over time e.g. if the surface
+        is moved from one monitor to another.
+        \see Surface::GetPixelResolution
+        */
+        virtual Extent2D GetContentSizeForPixelResolution(const Extent2D& contentSize) const;
+
+        /**
         \brief Adapts the surface to fits the needs for the specified video mode descriptor.
         \param[in,out] videoModeDesc Specifies the input and output video mode descriptor.
         \return If the video mode descriptor has been accepted with no modifications and this surface has been updated then the return value is true.

--- a/sources/Platform/MacOS/MacOSWindow.h
+++ b/sources/Platform/MacOS/MacOSWindow.h
@@ -30,6 +30,9 @@ class MacOSWindow : public Window
 
         Extent2D GetContentSize() const override;
 
+        Extent2D GetPixelResolution() const override;
+        Extent2D GetContentSizeForPixelResolution(const Extent2D& resolution) const override;
+
         void SetPosition(const Offset2D& position) override;
         Offset2D GetPosition() const override;
 

--- a/sources/Platform/Surface.cpp
+++ b/sources/Platform/Surface.cpp
@@ -1,0 +1,31 @@
+/*
+ * Surface.cpp
+ * 
+ * This file is part of the "LLGL" project (Copyright (c) 2015-2019 by Lukas Hermanns)
+ * See "LICENSE.txt" for license information.
+ */
+
+#include <LLGL/Surface.h>
+
+
+namespace LLGL
+{
+
+
+/* ----- Surface class ----- */
+
+Extent2D Surface::GetPixelResolution() const
+{
+    return GetContentSize();
+}
+
+Extent2D Surface::GetContentSizeForPixelResolution(const Extent2D& contentSize) const
+{
+    return GetContentSize();
+}
+
+} // /namespace LLGL
+
+
+
+// ================================================================================

--- a/sources/Platform/Win32/Win32Window.cpp
+++ b/sources/Platform/Win32/Win32Window.cpp
@@ -284,8 +284,9 @@ void Win32Window::SetDesc(const WindowDescriptor& desc)
     /* Check if anything changed */
     auto position           = GetPosition();
     auto size               = GetSize();
+    auto newPosition        = (desc.centered ? GetScreenCenteredPosition(desc.size) : desc.position);
 
-    bool positionChanged    = (desc.position.x != position.x || desc.position.y != position.y);
+    bool positionChanged    = (newPosition.x != position.x || newPosition.y != position.y);
     bool sizeChanged        = (desc.size.width != size.width || desc.size.height != size.height);
 
     if (flagsChanged || positionChanged || sizeChanged)

--- a/sources/Platform/Window.cpp
+++ b/sources/Platform/Window.cpp
@@ -117,7 +117,7 @@ bool Window::AdaptForVideoMode(VideoModeDescriptor& videoModeDesc)
     auto windowDesc = GetDesc();
 
     /* Adapt window size and position */
-    windowDesc.size = videoModeDesc.resolution;
+    windowDesc.size = GetContentSizeForPixelResolution(videoModeDesc.resolution);
 
     if (videoModeDesc.fullscreen)
     {

--- a/sources/Renderer/DebugLayer/DbgRenderContext.cpp
+++ b/sources/Renderer/DebugLayer/DbgRenderContext.cpp
@@ -55,6 +55,13 @@ bool DbgRenderContext::OnSetVideoMode(const VideoModeDescriptor& videoModeDesc)
     return result;
 }
 
+bool DbgRenderContext::OnSetDrawableResolution(const Extent2D& resolution)
+{
+    auto result = instance.SetDrawableResolution(resolution);
+    ShareSurfaceAndConfig(instance);
+    return result;
+}
+
 bool DbgRenderContext::OnSetVsync(const VsyncDescriptor& vsyncDesc)
 {
     auto result = instance.SetVsync(vsyncDesc);

--- a/sources/Renderer/DebugLayer/DbgRenderContext.h
+++ b/sources/Renderer/DebugLayer/DbgRenderContext.h
@@ -43,6 +43,7 @@ class DbgRenderContext final : public RenderContext
     private:
 
         bool OnSetVideoMode(const VideoModeDescriptor& videoModeDesc) override;
+        bool OnSetDrawableResolution(const Extent2D& resolution) override;
         bool OnSetVsync(const VsyncDescriptor& vsyncDesc) override;
 
 };

--- a/sources/Renderer/Direct3D11/D3D11RenderContext.cpp
+++ b/sources/Renderer/Direct3D11/D3D11RenderContext.cpp
@@ -110,6 +110,15 @@ bool D3D11RenderContext::OnSetVideoMode(const VideoModeDescriptor& videoModeDesc
     return true;
 }
 
+bool D3D11RenderContext::OnSetDrawableResolution(const Extent2D& resolution)
+{
+    //TODO It would be sufficient to resize the existing resources.
+    auto newMode = GetVideoMode();
+    newMode.resolution = resolution;
+    ResizeBackBuffer(newMode);
+    return true;
+}
+
 bool D3D11RenderContext::OnSetVsync(const VsyncDescriptor& vsyncDesc)
 {
     swapChainInterval_ = (vsyncDesc.enabled ? std::max(1u, std::min(vsyncDesc.interval, 4u)) : 0u);

--- a/sources/Renderer/Direct3D11/D3D11RenderContext.h
+++ b/sources/Renderer/Direct3D11/D3D11RenderContext.h
@@ -63,6 +63,7 @@ class D3D11RenderContext final : public RenderContext
     private:
 
         bool OnSetVideoMode(const VideoModeDescriptor& videoModeDesc) override;
+        bool OnSetDrawableResolution(const Extent2D& resolution) override;
         bool OnSetVsync(const VsyncDescriptor& vsyncDesc) override;
 
         void CreateSwapChain(IDXGIFactory* factory, UINT samples);

--- a/sources/Renderer/Direct3D12/D3D12RenderContext.cpp
+++ b/sources/Renderer/Direct3D12/D3D12RenderContext.cpp
@@ -192,6 +192,16 @@ bool D3D12RenderContext::OnSetVideoMode(const VideoModeDescriptor& videoModeDesc
     return true;
 }
 
+bool D3D12RenderContext::OnSetDrawableResolution(const Extent2D& resolution)
+{
+    //TODO It would be sufficient to resize the existing resources.
+    auto newMode = GetVideoMode();
+    newMode.resolution = resolution;
+    /* Re-create resource that depend on the window size */
+    CreateWindowSizeDependentResources(newMode);
+    return true;
+}
+
 bool D3D12RenderContext::OnSetVsync(const VsyncDescriptor& vsyncDesc)
 {
     swapChainInterval_ = (vsyncDesc.enabled ? std::max(1u, std::min(vsyncDesc.interval, 4u)) : 0u);

--- a/sources/Renderer/Direct3D12/D3D12RenderContext.h
+++ b/sources/Renderer/Direct3D12/D3D12RenderContext.h
@@ -73,6 +73,7 @@ class D3D12RenderContext final : public RenderContext
     private:
 
         bool OnSetVideoMode(const VideoModeDescriptor& videoModeDesc) override;
+        bool OnSetDrawableResolution(const Extent2D& resolution) override;
         bool OnSetVsync(const VsyncDescriptor& vsyncDesc) override;
 
         void QueryDeviceParameters(const D3D12Device& device, std::uint32_t samples);

--- a/sources/Renderer/Metal/MTRenderContext.h
+++ b/sources/Renderer/Metal/MTRenderContext.h
@@ -54,6 +54,7 @@ class MTRenderContext final : public RenderContext
     private:
 
         bool OnSetVideoMode(const VideoModeDescriptor& videoModeDesc) override;
+        bool OnSetDrawableResolution(const Extent2D& resolution) override;
         bool OnSetVsync(const VsyncDescriptor& vsyncDesc) override;
 
     private:

--- a/sources/Renderer/Metal/MTRenderContext.mm
+++ b/sources/Renderer/Metal/MTRenderContext.mm
@@ -62,12 +62,18 @@ MTRenderContext::MTRenderContext(
     /* Initialize color and depth buffer */
     //MTLPixelFormat colorFmt = metalLayer_.pixelFormat;
 
+    // We have no need of the internal drawing timer
+    view_.paused                    = YES;
+    view_.autoResizeDrawable        = NO;
+
     view_.colorPixelFormat          = renderPass_.GetColorAttachments()[0].pixelFormat;
     view_.depthStencilPixelFormat   = renderPass_.GetDepthStencilFormat();
     view_.sampleCount               = renderPass_.GetSampleCount();
 
     if (desc.vsync.enabled)
         view_.preferredFramesPerSecond = static_cast<NSInteger>(desc.vsync.refreshRate);
+
+    OnSetDrawableResolution(desc.videoMode.resolution);
 }
 
 void MTRenderContext::Present()
@@ -100,9 +106,34 @@ const RenderPass* MTRenderContext::GetRenderPass() const
  * ======= Private: =======
  */
 
-bool MTRenderContext::OnSetVideoMode(const VideoModeDescriptor& videoModeDesc)
+bool MTRenderContext::OnSetVideoMode(const VideoModeDescriptor &videoModeDesc)
 {
     return true; // do nothing
+}
+
+bool MTRenderContext::OnSetDrawableResolution(const Extent2D& resolution)
+{
+    // We need to establish the scaling from the layer's bounds (which are
+    // controlled by the NSView) to the drawable size in pixels. There is
+    // only one scale factor. Verify that it works on both axes.
+    CGFloat scale = resolution.width / view_.bounds.size.width;
+    uint32_t scaledHeight = view_.bounds.size.height * scale + 0.5;
+    if (scaledHeight != resolution.height)
+        return false;
+
+    if (scale != view_.layer.contentsScale)
+        view_.layer.contentsScale = scale;
+
+    CGSize drawableSize;
+    drawableSize.width = resolution.width;
+    drawableSize.height = resolution.height;
+    if (!CGSizeEqualToSize(drawableSize, view_.drawableSize))
+        view_.drawableSize = drawableSize;
+
+    // Force the view to advance to the next drawable
+    [view_ draw];
+
+    return true;
 }
 
 bool MTRenderContext::OnSetVsync(const VsyncDescriptor& vsyncDesc)

--- a/sources/Renderer/OpenGL/GLRenderContext.cpp
+++ b/sources/Renderer/OpenGL/GLRenderContext.cpp
@@ -101,17 +101,20 @@ bool GLRenderContext::GLMakeCurrent(GLRenderContext* renderContext)
 
 bool GLRenderContext::OnSetVideoMode(const VideoModeDescriptor& videoModeDesc)
 {
-    /* Update context height */
-    contextHeight_ = static_cast<GLint>(videoModeDesc.resolution.height);
-    stateMngr_->NotifyRenderTargetHeight(contextHeight_);
-
-    /* Notify GL context of a resize */
-    context_->Resize(videoModeDesc.resolution);
-
     /* Switch fullscreen mode */
     if (!SetDisplayFullscreenMode(videoModeDesc))
         return false;
+    return true;
+}
 
+bool GLRenderContext::OnSetDrawableResolution(const Extent2D& resolution)
+{
+    /* Update context height */
+    contextHeight_ = static_cast<GLint>(resolution.height);
+    stateMngr_->NotifyRenderTargetHeight(contextHeight_);
+
+    /* Notify GL context of a resize */
+    context_->Resize(resolution);
     return true;
 }
 

--- a/sources/Renderer/OpenGL/GLRenderContext.h
+++ b/sources/Renderer/OpenGL/GLRenderContext.h
@@ -74,6 +74,7 @@ class GLRenderContext final : public RenderContext
     private:
 
         bool OnSetVideoMode(const VideoModeDescriptor& videoModeDesc) override;
+        bool OnSetDrawableResolution(const Extent2D& resolution) override;
         bool OnSetVsync(const VsyncDescriptor& vsyncDesc) override;
 
         void InitRenderStates();

--- a/sources/Renderer/OpenGL/Platform/MacOS/MacOSGLContext.mm
+++ b/sources/Renderer/OpenGL/Platform/MacOS/MacOSGLContext.mm
@@ -43,6 +43,8 @@ MacOSGLContext::MacOSGLContext(
     surface.GetNativeHandle(&nativeHandle, sizeof(nativeHandle));
 
     CreateNSGLContext(nativeHandle, sharedContext);
+
+    Resize(desc.videoMode.resolution);
 }
 
 MacOSGLContext::~MacOSGLContext()
@@ -68,6 +70,11 @@ bool MacOSGLContext::SwapBuffers()
 
 void MacOSGLContext::Resize(const Extent2D& resolution)
 {
+    GLint dim[2];
+    dim[0] = static_cast<GLint>(resolution.width);
+    dim[1] = static_cast<GLint>(resolution.height);
+    [ctx_ setValues:dim forParameter:NSOpenGLContextParameterSurfaceBackingSize];
+
     [ctx_ update];
 }
 

--- a/sources/Renderer/RenderContext.cpp
+++ b/sources/Renderer/RenderContext.cpp
@@ -64,6 +64,19 @@ bool RenderContext::SetVideoMode(const VideoModeDescriptor& videoModeDesc)
     return false;
 }
 
+bool RenderContext::SetDrawableResolution(const Extent2D &resolution)
+{
+    if (resolution != surface_->GetPixelResolution())
+        return false;
+    
+    if (OnSetDrawableResolution(resolution))
+    {
+        videoModeDesc_.resolution = resolution;
+        return true;
+    }
+    return false;
+}
+
 bool RenderContext::SetVsync(const VsyncDescriptor& vsyncDesc)
 {
     if (vsyncDesc_ != vsyncDesc)
@@ -89,7 +102,7 @@ void RenderContext::SetOrCreateSurface(const std::shared_ptr<Surface>& surface, 
     if (surface)
     {
         /* Get and output resolution from specified window */
-        videoModeDesc.resolution = surface->GetContentSize();
+        videoModeDesc.resolution = surface->GetPixelResolution();
         surface_ = surface;
     }
     else
@@ -164,7 +177,6 @@ bool RenderContext::SetDisplayFullscreenMode(const VideoModeDescriptor& videoMod
         return true;
 }
 
-
 /*
  * ======= Private: =======
  */
@@ -203,7 +215,7 @@ bool RenderContext::SetVideoModePrimary(const VideoModeDescriptor& videoModeDesc
 
     if (!videoModeDesc_.fullscreen)
         RestoreSurfacePosition();
-
+    
     return result;
 }
 


### PR DESCRIPTION
I’ve been working on getting Retina support into LLGL. The new code is not done and requires a lot of clean-up but the changes involve re-thinking what SetVideoMode does so I thought you should take a look sooner rather than later.

In Retina mode the size of the surface and the size of the drawables diverge. An NSWindow is sized in a space that roughly approximates 72 dpi and then the drawables are sized upward to a match the actual dpi of the screen. So I needed to alter SetVideoMode to resize the drawables independently of the surface size. I started by stubbing out Window::AdjustForVideoMode and all of the fullscreen handling (more on fullscreen later).

Then I added Surface::GetPreferredResolution() so a surface can advertise a preferred resolution that differs from GetContentSize(). Finally I updated OnSetVideoMode for both Metal and OpenGL to resize the drawables appropriately. And that was pretty much it beyond tweaking Info.plist and updating the sample code a bit.

Basically I’ve pared down SetVideoMode to only update the size of the drawables, roughly equivalent to ResizeBuffer in DirectX. This eliminates the possibility that calling SetVideoMode could generate a resize event while handling a resize event. It also eliminates the code that was trying to re-center the window on every resize event which was making live re-resizing impossible on the Mac.

(BTW, I tweaked the DirectX versions of OnSetVideoMode to allow arbitrary sizes to match the Mac. On Windows the main use would be to to reduce the size of the drawables for performance reasons.)

The next step is to get fullscreen working again. Previously SetVideoMode was called at both ends of the process, first to kick the system into fullscreen mode and then to handle the resulting resize event. I want to avoid that recursion by introducing new RenderContext routines for entering and exiting fullscreen mode. Then clean-up, including adding some capability flags.