### PR TITLE
Include cstdint to fix build on some platforms

### DIFF
--- a/sources/Renderer/Null/RenderState/NullFence.h
+++ b/sources/Renderer/Null/RenderState/NullFence.h
@@ -12,7 +12,7 @@
 #include <LLGL/Fence.h>
 #include <string>
 #include <atomic>
-
+#include <cstdint>
 
 namespace LLGL
 {


### PR DESCRIPTION
Add cstdint include to fix the build on some platforms. I wasn't able to build LLGL without that include on my Linux machine.