### PR TITLE
Fix DLLGL_DX_ENABLE_D3D12 causing multiple same-signature function destruction.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1009,8 +1009,7 @@ if(WIN32)
         
         SET_RENDERER_PROJECT_PROPERTIES(LLGL_Direct3D12)
         target_link_libraries(LLGL_Direct3D12 LLGL d3d12 dxgi D3DCompiler)
-        target_compile_definitions(LLGL_Direct3D12 PUBLIC -DLLGL_DX_ENABLE_D3D12)
-        
+
         ADD_DEFINE(LLGL_BUILD_RENDERER_DIRECT3D12)
         
         list(APPEND LLGL_ALL_TARGETS LLGL_Direct3D12)

--- a/sources/Renderer/DXCommon/DXCore.cpp
+++ b/sources/Renderer/DXCommon/DXCore.cpp
@@ -104,10 +104,8 @@ static const char* DXErrorToStr(const HRESULT hr)
         LLGL_CASE_TO_STR( D3D11_ERROR_TOO_MANY_UNIQUE_VIEW_OBJECTS );
         LLGL_CASE_TO_STR( D3D11_ERROR_DEFERRED_CONTEXT_MAP_WITHOUT_INITIAL_DISCARD );
 
-        #ifdef LLGL_DX_ENABLE_D3D12
         LLGL_CASE_TO_STR( D3D12_ERROR_ADAPTER_NOT_FOUND );
         LLGL_CASE_TO_STR( D3D12_ERROR_DRIVER_VERSION_MISMATCH );
-        #endif
     }
     return nullptr;
 }
@@ -289,9 +287,7 @@ static std::vector<ShadingLanguage> DXGetHLSLVersions(D3D_FEATURE_LEVEL featureL
     if (featureLevel >= D3D_FEATURE_LEVEL_10_0) { languages.push_back(ShadingLanguage::HLSL_4_0); }
     if (featureLevel >= D3D_FEATURE_LEVEL_10_1) { languages.push_back(ShadingLanguage::HLSL_4_1); }
     if (featureLevel >= D3D_FEATURE_LEVEL_11_0) { languages.push_back(ShadingLanguage::HLSL_5_0); }
-    #ifdef LLGL_DX_ENABLE_D3D12
     if (featureLevel >= D3D_FEATURE_LEVEL_12_0) { languages.push_back(ShadingLanguage::HLSL_5_1); }
-    #endif
 
     return languages;
 }
@@ -395,10 +391,8 @@ std::vector<D3D_FEATURE_LEVEL> DXGetFeatureLevels(D3D_FEATURE_LEVEL maxFeatureLe
 {
     std::vector<D3D_FEATURE_LEVEL> featureLevels =
     {
-        #ifdef LLGL_DX_ENABLE_D3D12
         D3D_FEATURE_LEVEL_12_1,
         D3D_FEATURE_LEVEL_12_0,
-        #endif
         D3D_FEATURE_LEVEL_11_1,
         D3D_FEATURE_LEVEL_11_0,
         D3D_FEATURE_LEVEL_10_1,
@@ -424,10 +418,8 @@ const char* DXFeatureLevelToVersion(D3D_FEATURE_LEVEL featureLevel)
 {
     switch (featureLevel)
     {
-        #ifdef LLGL_DX_ENABLE_D3D12
         case D3D_FEATURE_LEVEL_12_1:    return "12.1";
         case D3D_FEATURE_LEVEL_12_0:    return "12.0";
-        #endif
         case D3D_FEATURE_LEVEL_11_1:    return "11.1";
         case D3D_FEATURE_LEVEL_11_0:    return "11.0";
         case D3D_FEATURE_LEVEL_10_1:    return "10.1";
@@ -443,10 +435,8 @@ const char* DXFeatureLevelToShaderModel(D3D_FEATURE_LEVEL featureLevel)
 {
     switch (featureLevel)
     {
-        #ifdef LLGL_DX_ENABLE_D3D12
         case D3D_FEATURE_LEVEL_12_1:    /*pass*/
         case D3D_FEATURE_LEVEL_12_0:    /*pass*/
-        #endif
         case D3D_FEATURE_LEVEL_11_1:    /*pass*/
         case D3D_FEATURE_LEVEL_11_0:    return "5.0";
         case D3D_FEATURE_LEVEL_10_1:    return "4.1";

--- a/sources/Renderer/DXCommon/DXTypes.cpp
+++ b/sources/Renderer/DXCommon/DXTypes.cpp
@@ -349,9 +349,7 @@ SystemValue Unmap(const D3D_NAME name)
         case D3D_NAME_RENDER_TARGET_ARRAY_INDEX:    return SystemValue::RenderTargetIndex;
         case D3D_NAME_COVERAGE:                     return SystemValue::SampleMask;
         case D3D_NAME_SAMPLE_INDEX:                 return SystemValue::SampleID;
-        #if defined LLGL_DX_ENABLE_D3D12 || LLGL_D3D11_ENABLE_FEATURELEVEL >= 3
         case D3D_NAME_STENCIL_REF:                  return SystemValue::Stencil;
-        #endif
         case D3D_NAME_VERTEX_ID:                    return SystemValue::VertexID;
         case D3D_NAME_VIEWPORT_ARRAY_INDEX:         return SystemValue::ViewportIndex;
         default:                                    return SystemValue::Undefined;


### PR DESCRIPTION
# The Problem
LLGL's macro `LLGL_DX_ENABLE_D3D12` is used to provide differentiation between D3D11 and D3D12 for `DXCore.cpp` and `DXTypes.cpp`. When compiled statically, multiple versions with identical signatures of the functions in DXCore.cpp are created. This results in the linker's first-come-first-serve approach to multiply-defined, same-signature behavior to kick in.

The practical result of this is that when statically compiled `LLGL_Direct3D11` and `LLGL_Direct3D12` coexist in the same project, and you query `LLGL::RenderSystem::GetRendererInfo()` on D3D12, the returned value for `LLGL::RendererInfo::rendererName` is something like `DirectX 11.2`, and not `DirectX 12.1`.

# The (Proposed) Solution
Remove `LLGL_DX_ENABLE_D3D12`. LLGL's shared DX code is very robust and in my testing I have found that Occam's Razor works in this problem's favor. The symbols that are wrapped with LLGL_DX_ENABLE_D3D12 macros exist across versions of DirectX in the `dxcommon.h` header file, so D3D11 and D3D12 both pass and the symbols are able to kumbaya.

One thing of note is I am unsure if VS2015 (used by @LukasBanana) also keeps the variables that are currently wrapped in LLGL_DX_ENABLE_D3D12 in `dxcommon.h`, and I don't see a CI job for VS2015 compiles.