### PR TITLE
[Draft] [D3D] Support variable refresh rate displays (vsync off) in borderless windowed

### DIFF
--- a/sources/Renderer/Direct3D11/D3D11RenderSystem.cpp
+++ b/sources/Renderer/Direct3D11/D3D11RenderSystem.cpp
@@ -551,8 +551,25 @@ void D3D11RenderSystem::ClearStateForAllContexts()
 void D3D11RenderSystem::CreateFactory()
 {
     /* Create DXGI factory */
-    HRESULT hr = CreateDXGIFactory(IID_PPV_ARGS(factory_.ReleaseAndGetAddressOf()));
+#if LLGL_D3D11_ENABLE_FEATURELEVEL >= 2
+
+    HRESULT hr = CreateDXGIFactory2(0, IID_PPV_ARGS(&factory2_));
+    DXThrowIfCreateFailed(hr, "IDXGIFactory2");
+    factory2_.As(&factory_);
+    factory2_.As(&factory1_);
+
+#elif LLGL_D3D11_ENABLE_FEATURELEVEL >= 1
+
+    HRESULT hr = CreateDXGIFactory1(IID_PPV_ARGS(&factory1_));
+    DXThrowIfCreateFailed(hr, "IDXGIFactory1");
+    factory1_.As(&factory_);
+
+#else
+
+    HRESULT hr = CreateDXGIFactory(IID_PPV_ARGS(&factory_));
     DXThrowIfCreateFailed(hr, "IDXGIFactory");
+
+#endif
 }
 
 void D3D11RenderSystem::QueryVideoAdapters(long flags, ComPtr<IDXGIAdapter>& outPreferredAdatper)

--- a/sources/Renderer/Direct3D11/D3D11RenderSystem.cpp
+++ b/sources/Renderer/Direct3D11/D3D11RenderSystem.cpp
@@ -551,25 +551,29 @@ void D3D11RenderSystem::ClearStateForAllContexts()
 void D3D11RenderSystem::CreateFactory()
 {
     /* Create DXGI factory */
+    HRESULT hr = S_OK;
+
 #if LLGL_D3D11_ENABLE_FEATURELEVEL >= 2
-
-    HRESULT hr = CreateDXGIFactory2(0, IID_PPV_ARGS(&factory2_));
-    DXThrowIfCreateFailed(hr, "IDXGIFactory2");
-    factory2_.As(&factory_);
-    factory2_.As(&factory1_);
-
-#elif LLGL_D3D11_ENABLE_FEATURELEVEL >= 1
-
-    HRESULT hr = CreateDXGIFactory1(IID_PPV_ARGS(&factory1_));
-    DXThrowIfCreateFailed(hr, "IDXGIFactory1");
-    factory1_.As(&factory_);
-
-#else
-
-    HRESULT hr = CreateDXGIFactory(IID_PPV_ARGS(&factory_));
-    DXThrowIfCreateFailed(hr, "IDXGIFactory");
-
+    hr = CreateDXGIFactory2(0, IID_PPV_ARGS(&factory2_));
+    if (SUCCEEDED(hr))
+    {
+        factory2_.As(&factory_);
+        factory2_.As(&factory1_);
+        return;
+    }
 #endif
+
+#if LLGL_D3D11_ENABLE_FEATURELEVEL >= 1
+    hr = CreateDXGIFactory1(IID_PPV_ARGS(&factory1_));
+    if (SUCCEEDED(hr))
+    {
+        factory1_.As(&factory_);
+        return;
+    }
+#endif
+
+    hr = CreateDXGIFactory(IID_PPV_ARGS(&factory_));
+    DXThrowIfCreateFailed(hr, "IDXGIFactory");
 }
 
 void D3D11RenderSystem::QueryVideoAdapters(long flags, ComPtr<IDXGIAdapter>& outPreferredAdatper)
@@ -688,9 +692,10 @@ void D3D11RenderSystem::QueryDXDeviceVersion()
 {
     LLGL_ASSERT_PTR(device_);
 
+    HRESULT hr = S_OK;
     /* Try to get an extended D3D11 device */
     #if LLGL_D3D11_ENABLE_FEATURELEVEL >= 3
-    HRESULT hr = device_->QueryInterface(IID_PPV_ARGS(&device3_));
+    hr = device_->QueryInterface(IID_PPV_ARGS(&device3_));
     if (FAILED(hr))
     #endif
     {

--- a/sources/Renderer/Direct3D11/D3D11RenderSystem.h
+++ b/sources/Renderer/Direct3D11/D3D11RenderSystem.h
@@ -114,7 +114,15 @@ class D3D11RenderSystem final : public RenderSystem
 
         /* ----- Common objects ----- */
 
-        ComPtr<IDXGIFactory>                    factory_;
+        ComPtr<IDXGIFactory> factory_;
+
+#if LLGL_D3D11_ENABLE_FEATURELEVEL >= 1
+        ComPtr<IDXGIFactory1> factory1_;
+#endif
+
+#if LLGL_D3D11_ENABLE_FEATURELEVEL >= 2
+        ComPtr<IDXGIFactory2> factory2_;
+#endif
 
         ComPtr<ID3D11Device>                    device_;
 

--- a/sources/Renderer/Direct3D11/D3D11SwapChain.cpp
+++ b/sources/Renderer/Direct3D11/D3D11SwapChain.cpp
@@ -13,6 +13,9 @@
 #include <LLGL/Platform/NativeHandle.h>
 #include <LLGL/Log.h>
 
+#if LLGL_D3D11_ENABLE_FEATURELEVEL >= 3
+#include <dxgi1_5.h>
+#endif
 
 namespace LLGL
 {
@@ -34,6 +37,7 @@ D3D11SwapChain::D3D11SwapChain(
     SetOrCreateSurface(surface, desc.resolution, desc.fullscreen, nullptr);
 
     /* Create D3D objects */
+    CheckTearingSupport(factory);
     CreateSwapChain(factory, GetResolution(), desc.samples, desc.swapBuffers);
     CreateBackBuffer();
 
@@ -71,7 +75,9 @@ void D3D11SwapChain::SetDebugName(const char* name)
 
 void D3D11SwapChain::Present()
 {
-    swapChain_->Present(swapChainInterval_, 0);
+    bool tearingEnabled = tearingSupported_ && swapChainInterval_ == 0; // TODO: disable if fullscreen exclusive mode is enabled
+    UINT presentFlags = tearingEnabled ? DXGI_PRESENT_ALLOW_TEARING : 0u;
+    swapChain_->Present(swapChainInterval_, presentFlags);
 }
 
 std::uint32_t D3D11SwapChain::GetCurrentSwapIndex() const
@@ -260,18 +266,44 @@ static UINT GetPrimaryDisplayRefreshRate()
 
 void D3D11SwapChain::CreateSwapChain(IDXGIFactory* factory, const Extent2D& resolution, std::uint32_t samples, std::uint32_t swapBuffers)
 {
-    /* Get current settings */
-    const DXGI_RATIONAL refreshRate{ GetPrimaryDisplayRefreshRate(), 1 };
-
     /* Pick and store color format */
     colorFormat_ = DXGI_FORMAT_R8G8B8A8_UNORM;//DXGI_FORMAT_B8G8R8A8_UNORM
+    /* Clamp buffer count between 1 and max buffers */
+    swapBuffers = std::max(1u, std::min<std::uint32_t>(swapBuffers, DXGI_MAX_SWAP_CHAIN_BUFFERS));
 
     /* Find suitable multi-samples for color format */
-    swapChainSampleDesc_ = D3D11RenderSystem::FindSuitableSampleDesc(device_.Get(), colorFormat_, samples);
+    swapChainSampleDesc_ = D3D11RenderSystem::FindSuitableSampleDesc(device_.Get(), colorFormat_, 1); // TODO: resolve multi-sampling
 
     /* Create swap chain for window handle */
     NativeHandle wndHandle = {};
     GetSurface().GetNativeHandle(&wndHandle, sizeof(wndHandle));
+
+#if LLGL_D3D11_ENABLE_FEATURELEVEL >= 3
+
+    DXGI_SWAP_CHAIN_DESC1 swapChainDesc = {};
+    {
+            swapChainDesc.Width         = resolution.width;
+            swapChainDesc.Height        = resolution.height;
+            swapChainDesc.Format        = colorFormat_;
+            swapChainDesc.SampleDesc    = swapChainSampleDesc_;
+            swapChainDesc.BufferUsage   = DXGI_USAGE_RENDER_TARGET_OUTPUT;
+            swapChainDesc.BufferCount   = swapBuffers;
+            swapChainDesc.SwapEffect    = DXGI_SWAP_EFFECT_FLIP_DISCARD; // TODO: requires BufferCount >= 2 && SampleDesc.Count == 1
+            swapChainDesc.Flags         = (tearingSupported_ ? DXGI_SWAP_CHAIN_FLAG_ALLOW_TEARING : 0u);
+    }
+
+    ComPtr<IDXGIFactory2> factory2;
+    HRESULT hr = factory->QueryInterface(IID_PPV_ARGS(&factory2));
+    DXThrowIfFailed(hr, "failed to query IDXGIFactory2 interface");
+
+    ComPtr<IDXGISwapChain1> swapChain;
+    hr = factory2->CreateSwapChainForHwnd(device_.Get(), wndHandle.window, &swapChainDesc, nullptr, nullptr, &swapChain);
+    DXThrowIfFailed(hr, "failed to create DXGI swap chain");
+    DXThrowIfFailed(swapChain.As(&swapChain_), "failed to downcast swap chain");
+
+#else
+
+    const DXGI_RATIONAL refreshRate{ GetPrimaryDisplayRefreshRate(), 1 };
 
     DXGI_SWAP_CHAIN_DESC swapChainDesc = {};
     {
@@ -288,6 +320,8 @@ void D3D11SwapChain::CreateSwapChain(IDXGIFactory* factory, const Extent2D& reso
     }
     HRESULT hr = factory->CreateSwapChain(device_.Get(), &swapChainDesc, swapChain_.ReleaseAndGetAddressOf());
     DXThrowIfFailed(hr, "failed to create DXGI swap chain");
+
+#endif
 }
 
 void D3D11SwapChain::CreateBackBuffer()
@@ -348,7 +382,10 @@ void D3D11SwapChain::ResizeBackBuffer(const Extent2D& resolution)
     depthStencilView_.Reset();
 
     /* Resize swap-chain buffers, let DXGI find out the client area, and preserve buffer count and format */
-    HRESULT hr = swapChain_->ResizeBuffers(0, resolution.width, resolution.height, DXGI_FORMAT_UNKNOWN, 0);
+    DXGI_SWAP_CHAIN_DESC desc;
+    swapChain_->GetDesc(&desc);
+
+    HRESULT hr = swapChain_->ResizeBuffers(0, resolution.width, resolution.height, DXGI_FORMAT_UNKNOWN, desc.Flags);
     DXThrowIfFailed(hr, "failed to resize DXGI swap-chain buffers");
 
     /* Recreate back buffer and reset default render target */
@@ -379,6 +416,23 @@ void D3D11SwapChain::RestoreDebugNames(const std::string (&debugNames)[4])
         D3D11SetObjectName(depthBuffer_.Get(), debugNames[2].c_str());
         D3D11SetObjectName(depthStencilView_.Get(), debugNames[3].c_str());
     }
+}
+
+void D3D11SwapChain::CheckTearingSupport([[maybe_unused]] IDXGIFactory* factory)
+{
+#if LLGL_D3D11_ENABLE_FEATURELEVEL >= 3
+    ComPtr<IDXGIFactory5> factory5;
+    HRESULT hr = factory->QueryInterface(IID_PPV_ARGS(&factory5));
+
+    if (SUCCEEDED(hr))
+    {
+        BOOL allowTearing = FALSE;
+        hr = factory5->CheckFeatureSupport(DXGI_FEATURE_PRESENT_ALLOW_TEARING, &allowTearing, sizeof(allowTearing));
+        tearingSupported_ = SUCCEEDED(hr) && allowTearing;
+    }
+#else
+    tearingSupported_ = false;
+#endif
 }
 
 

--- a/sources/Renderer/Direct3D11/D3D11SwapChain.cpp
+++ b/sources/Renderer/Direct3D11/D3D11SwapChain.cpp
@@ -267,9 +267,11 @@ static UINT GetPrimaryDisplayRefreshRate()
 
 void D3D11SwapChain::CreateSwapChain(IDXGIFactory* factory, const Extent2D& resolution, std::uint32_t samples, std::uint32_t swapBuffers)
 {
+    HRESULT hr = S_OK;
+
 #if LLGL_D3D11_ENABLE_FEATURELEVEL >= 3
     ComPtr<IDXGIFactory2> factory2;
-    HRESULT hr = factory->QueryInterface(IID_PPV_ARGS(&factory2));
+    hr = factory->QueryInterface(IID_PPV_ARGS(&factory2));
 
     if (SUCCEEDED(hr)) {
         CreateSwapChain1(factory2.Get(), resolution, samples, swapBuffers);

--- a/sources/Renderer/Direct3D11/D3D11SwapChain.cpp
+++ b/sources/Renderer/Direct3D11/D3D11SwapChain.cpp
@@ -75,7 +75,7 @@ void D3D11SwapChain::SetDebugName(const char* name)
 
 void D3D11SwapChain::Present()
 {
-    bool tearingEnabled = tearingSupported_ && swapChainInterval_ == 0; // TODO: disable if fullscreen exclusive mode is enabled
+    bool tearingEnabled = tearingSupported_ && windowedMode_ && swapChainInterval_ == 0;
     UINT presentFlags = tearingEnabled ? DXGI_PRESENT_ALLOW_TEARING : 0u;
     swapChain_->Present(swapChainInterval_, presentFlags);
 }
@@ -387,6 +387,10 @@ void D3D11SwapChain::ResizeBackBuffer(const Extent2D& resolution)
 
     HRESULT hr = swapChain_->ResizeBuffers(0, resolution.width, resolution.height, DXGI_FORMAT_UNKNOWN, desc.Flags);
     DXThrowIfFailed(hr, "failed to resize DXGI swap-chain buffers");
+
+    BOOL fullscreenState;
+    DXThrowIfFailed(swapChain_->GetFullscreenState(&fullscreenState, nullptr), "failed to get fullscreen state");
+    windowedMode_ = !fullscreenState;
 
     /* Recreate back buffer and reset default render target */
     CreateBackBuffer();

--- a/sources/Renderer/Direct3D11/D3D11SwapChain.h
+++ b/sources/Renderer/Direct3D11/D3D11SwapChain.h
@@ -107,6 +107,7 @@ class D3D11SwapChain final : public SwapChain
 
         bool                            hasDebugName_           = false;
         bool                            tearingSupported_       = false;
+        bool                            windowedMode_           = false;
 
 };
 

--- a/sources/Renderer/Direct3D11/D3D11SwapChain.h
+++ b/sources/Renderer/Direct3D11/D3D11SwapChain.h
@@ -8,12 +8,14 @@
 #ifndef LLGL_D3D11_SWAP_CHAIN_H
 #define LLGL_D3D11_SWAP_CHAIN_H
 
-
-#include <LLGL/SwapChain.h>
 #include "../DXCommon/ComPtr.h"
+#include <LLGL/SwapChain.h>
 #include <d3d11.h>
 #include <dxgi.h>
 
+#if LLGL_D3D11_ENABLE_FEATURELEVEL >= 3
+#include <dxgi1_2.h>
+#endif
 
 namespace LLGL
 {
@@ -80,6 +82,11 @@ class D3D11SwapChain final : public SwapChain
         bool SetPresentSyncInterval(UINT syncInterval);
 
         void CreateSwapChain(IDXGIFactory* factory, const Extent2D& resolution, std::uint32_t samples, std::uint32_t swapBuffers);
+
+#if LLGL_D3D11_ENABLE_FEATURELEVEL >= 3
+        void CreateSwapChain1(IDXGIFactory2* factory2, const Extent2D& resolution, std::uint32_t samples, std::uint32_t swapBuffers);
+#endif
+
         void CreateBackBuffer();
         void ResizeBackBuffer(const Extent2D& resolution);
 

--- a/sources/Renderer/Direct3D11/D3D11SwapChain.h
+++ b/sources/Renderer/Direct3D11/D3D11SwapChain.h
@@ -85,6 +85,8 @@ class D3D11SwapChain final : public SwapChain
 
         void StoreDebugNames(std::string (&debugNames)[4]);
         void RestoreDebugNames(const std::string (&debugNames)[4]);
+        
+        void CheckTearingSupport(IDXGIFactory* factory);
 
     private:
 
@@ -102,7 +104,9 @@ class D3D11SwapChain final : public SwapChain
 
         DXGI_FORMAT                     colorFormat_            = DXGI_FORMAT_UNKNOWN;
         DXGI_FORMAT                     depthStencilFormat_     = DXGI_FORMAT_UNKNOWN;
+
         bool                            hasDebugName_           = false;
+        bool                            tearingSupported_       = false;
 
 };
 

--- a/sources/Renderer/Direct3D12/D3D12RenderSystem.cpp
+++ b/sources/Renderer/Direct3D12/D3D12RenderSystem.cpp
@@ -26,8 +26,8 @@
 
 #include "Texture/D3D12MipGenerator.h"
 
-#include "RenderState/D3D12ComputePSO.h"
 #include "RenderState/D3D12GraphicsPSO.h"
+#include "RenderState/D3D12ComputePSO.h"
 
 #include <LLGL/Backend/Direct3D12/NativeHandle.h>
 

--- a/sources/Renderer/Direct3D12/D3D12RenderSystem.cpp
+++ b/sources/Renderer/Direct3D12/D3D12RenderSystem.cpp
@@ -19,7 +19,6 @@
 #include <LLGL/Utils/ForRange.h>
 #include <LLGL/Backend/Direct3D12/NativeHandle.h>
 #include <limits.h>
-#include <codecvt>
 
 #include "Buffer/D3D12Buffer.h"
 #include "Buffer/D3D12BufferArray.h"
@@ -27,11 +26,12 @@
 
 #include "Texture/D3D12MipGenerator.h"
 
-#include "RenderState/D3D12GraphicsPSO.h"
 #include "RenderState/D3D12ComputePSO.h"
+#include "RenderState/D3D12GraphicsPSO.h"
 
 #include <LLGL/Backend/Direct3D12/NativeHandle.h>
 
+#include <dxgi1_5.h>
 
 namespace LLGL
 {
@@ -456,6 +456,21 @@ ComPtr<IDXGISwapChain1> D3D12RenderSystem::CreateDXSwapChain(const DXGI_SWAP_CHA
     DXThrowIfFailed(hr, "failed to create DXGI swap chain");
 
     return swapChain;
+}
+
+bool D3D12RenderSystem::IsTearingSupported() const
+{
+    ComPtr<IDXGIFactory5> factory5;
+    HRESULT hr = factory_->QueryInterface(IID_PPV_ARGS(&factory5));
+
+    if (SUCCEEDED(hr))
+    {
+        BOOL allowTearing = FALSE;
+        hr = factory5->CheckFeatureSupport(DXGI_FEATURE_PRESENT_ALLOW_TEARING, &allowTearing, sizeof(allowTearing));
+        return SUCCEEDED(hr) && allowTearing;
+    }
+
+    return false;
 }
 
 void D3D12RenderSystem::SyncGPU()

--- a/sources/Renderer/Direct3D12/D3D12RenderSystem.h
+++ b/sources/Renderer/Direct3D12/D3D12RenderSystem.h
@@ -71,6 +71,8 @@ class D3D12RenderSystem final : public RenderSystem
 
         ComPtr<IDXGISwapChain1> CreateDXSwapChain(const DXGI_SWAP_CHAIN_DESC1& swapChainDescDXGI, HWND wnd);
 
+        bool IsTearingSupported() const;
+
         // Internal fence
         void SignalFenceValue(UINT64& fenceValue);
         void WaitForFenceValue(UINT64 fenceValue);

--- a/sources/Renderer/Direct3D12/D3D12SwapChain.cpp
+++ b/sources/Renderer/Direct3D12/D3D12SwapChain.cpp
@@ -455,7 +455,7 @@ HRESULT D3D12SwapChain::CreateResolutionDependentResources(const Extent2D& resol
         swapChain.As(&swapChainDXGI_);
     }
 
-    BOOL fullscreenState;
+    BOOL fullscreenState = false;
     DXThrowIfFailed(swapChainDXGI_->GetFullscreenState(&fullscreenState, nullptr), "failed to get fullscreen state");
     windowedMode_ = !fullscreenState;
 

--- a/sources/Renderer/Direct3D12/D3D12SwapChain.cpp
+++ b/sources/Renderer/Direct3D12/D3D12SwapChain.cpp
@@ -104,7 +104,7 @@ void D3D12SwapChain::SetDebugName(const char* name)
 void D3D12SwapChain::Present()
 {
     /* Present swap-chain with vsync interval */
-    bool tearingEnabled = tearingSupported_ && syncInterval_ == 0;
+    bool tearingEnabled = tearingSupported_ && windowedMode_ && syncInterval_ == 0;
     UINT presentFlags = tearingEnabled ? DXGI_PRESENT_ALLOW_TEARING : 0u;
 
     HRESULT hr = swapChainDXGI_->Present(syncInterval_, presentFlags);
@@ -454,6 +454,10 @@ HRESULT D3D12SwapChain::CreateResolutionDependentResources(const Extent2D& resol
 
         swapChain.As(&swapChainDXGI_);
     }
+
+    BOOL fullscreenState;
+    DXThrowIfFailed(swapChainDXGI_->GetFullscreenState(&fullscreenState, nullptr), "failed to get fullscreen state");
+    windowedMode_ = !fullscreenState;
 
     /* Create color buffer render target views (RTV) */
     CreateColorBufferRTVs(device, resolution);

--- a/sources/Renderer/Direct3D12/D3D12SwapChain.cpp
+++ b/sources/Renderer/Direct3D12/D3D12SwapChain.cpp
@@ -35,8 +35,8 @@ D3D12SwapChain::D3D12SwapChain(
 :
     SwapChain           { desc                                                            },
     renderSystem_       { renderSystem                                                    },
-    frameFence_         { renderSystem.GetDXDevice()                                      },
     depthStencilFormat_ { DXPickDepthStencilFormat(desc.depthBits, desc.stencilBits)      },
+    frameFence_         { renderSystem.GetDXDevice()                                      },
     numColorBuffers_    { Clamp(desc.swapBuffers, 1u, D3D12SwapChain::maxNumColorBuffers) }
 {
     /* Store reference to command queue */
@@ -46,6 +46,7 @@ D3D12SwapChain::D3D12SwapChain(
     SetOrCreateSurface(surface, desc.resolution, desc.fullscreen, nullptr);
 
     /* Create device resources and window dependent resource */
+    tearingSupported_ = renderSystem.IsTearingSupported();
     CreateDescriptorHeaps(renderSystem.GetDevice(), desc.samples);
     CreateResolutionDependentResources(GetResolution());
 
@@ -103,7 +104,10 @@ void D3D12SwapChain::SetDebugName(const char* name)
 void D3D12SwapChain::Present()
 {
     /* Present swap-chain with vsync interval */
-    HRESULT hr = swapChainDXGI_->Present(syncInterval_, 0);
+    bool tearingEnabled = tearingSupported_ && syncInterval_ == 0;
+    UINT presentFlags = tearingEnabled ? DXGI_PRESENT_ALLOW_TEARING : 0u;
+
+    HRESULT hr = swapChainDXGI_->Present(syncInterval_, presentFlags);
     DXThrowIfFailed(hr, "failed to present DXGI swap chain");
 
     /* Advance frame counter */
@@ -405,13 +409,16 @@ HRESULT D3D12SwapChain::CreateResolutionDependentResources(const Extent2D& resol
     /* Get framebuffer size */
     if (swapChainDXGI_)
     {
+        DXGI_SWAP_CHAIN_DESC desc;
+        swapChainDXGI_->GetDesc(&desc);
+
         /* Resize swap chain */
         HRESULT hr = swapChainDXGI_->ResizeBuffers(
             numColorBuffers_,
             resolution.width,
             resolution.height,
             colorFormat_,
-            0
+            desc.Flags
         );
 
         if (hr == DXGI_ERROR_DEVICE_REMOVED || hr == DXGI_ERROR_DEVICE_RESET)
@@ -441,7 +448,7 @@ HRESULT D3D12SwapChain::CreateResolutionDependentResources(const Extent2D& resol
             swapChainDesc.Scaling               = DXGI_SCALING_NONE;
             swapChainDesc.SwapEffect            = DXGI_SWAP_EFFECT_FLIP_DISCARD;
             swapChainDesc.AlphaMode             = DXGI_ALPHA_MODE_IGNORE;
-            swapChainDesc.Flags                 = 0;
+            swapChainDesc.Flags                 = (tearingSupported_ ? DXGI_SWAP_CHAIN_FLAG_ALLOW_TEARING : 0u);
         }
         auto swapChain = renderSystem_.CreateDXSwapChain(swapChainDesc, wndHandle.window);
 

--- a/sources/Renderer/Direct3D12/D3D12SwapChain.h
+++ b/sources/Renderer/Direct3D12/D3D12SwapChain.h
@@ -136,6 +136,7 @@ class D3D12SwapChain final : public SwapChain
 
         bool                            hasDebugName_                           = false;
         bool                            tearingSupported_                       = false;
+        bool                            windowedMode_                           = false;
 
 };
 

--- a/sources/Renderer/Direct3D12/D3D12SwapChain.h
+++ b/sources/Renderer/Direct3D12/D3D12SwapChain.h
@@ -135,6 +135,7 @@ class D3D12SwapChain final : public SwapChain
         UINT                            currentColorBuffer_                     = 0;
 
         bool                            hasDebugName_                           = false;
+        bool                            tearingSupported_                       = false;
 
 };
 


### PR DESCRIPTION
I made an attempt to improve support for vsync off in borderless windowed mode. (See https://learn.microsoft.com/en-us/windows/win32/direct3ddxgi/variable-refresh-rate-displays)

The [documentation recommends](https://learn.microsoft.com/en-us/windows/win32/direct3ddxgi/for-best-performance--use-dxgi-flip-model) we no longer use `DXGI_SWAP_EFFECT_DISCARD` and switch to `DXGI_SWAP_EFFECT_FLIP_*` instead. 

Still TODO:
- [ ] MSAA is not supported in this model. The dx11 implementation will need to be updated to support this. There is a detailed explaination on how to resolve that [here](https://learn.microsoft.com/en-us/windows/win32/api/dxgi/ne-dxgi-dxgi_swap_effect#remarks). (Would love your help with this one, I assume we can use an almost exact copy of the dx12 implementation?)
- [x] Disable tearing if fullscreen exclusive mode is active
- [x] Verify the code will work under different configurations
- [ ] Update the dx11 code so it matches the dx12 version? (Aka. use device to create swap chain, and move tearing support check to device as well)

Let me know what you think, would love your feedback :)
