### PR TITLE
Fix crash in D3D12 when using LLGL::RenderingDebugger.

### DIFF
--- a/sources/Renderer/Direct3D12/Shader/D3D12Shader.cpp
+++ b/sources/Renderer/Direct3D12/Shader/D3D12Shader.cpp
@@ -652,6 +652,9 @@ HRESULT D3D12Shader::ReflectShaderByteCode(ShaderReflection& reflection) const
         if (FAILED(hr))
             return hr;
     }
+    #else
+        if (FAILED(hr))
+            return hr;
     #endif // /LLGL_D3D12_ENABLE_DXCOMPILER
 
     D3D12_SHADER_DESC shaderDesc;


### PR DESCRIPTION
Caught this mistake (that I made) while tinkering tonight.

It's exactly what it says on the tin: when using LLGL::RenderingDebugger, LLGL will attempt to reflect into the shader. Without `LLGL_D3D12_ENABLE_DXCOMPILER`, a crash occurs.

Crash was due to a lack of graceful HRESULT handling.