### PR TITLE
Fix misspelled OpenGL extension

### DIFF
--- a/sources/Renderer/OpenGL/Profile/GLCompat/GLCompatProfileCaps.cpp
+++ b/sources/Renderer/OpenGL/Profile/GLCompat/GLCompatProfileCaps.cpp
@@ -33,7 +33,7 @@ static std::uint32_t GLGetUInt(GLenum param)
 static std::uint32_t GLGetUIntIndexed(GLenum param, GLuint index)
 {
     GLint attr = 0;
-    #if EXT_draw_buffers2
+    #if GL_EXT_draw_buffers2
     if (HasExtension(GLExt::EXT_draw_buffers2))
         glGetIntegeri_v(param, index, &attr);
     #endif

--- a/sources/Renderer/OpenGL/Profile/GLCore/GLCoreProfileCaps.cpp
+++ b/sources/Renderer/OpenGL/Profile/GLCore/GLCoreProfileCaps.cpp
@@ -33,7 +33,7 @@ static std::uint32_t GLGetUInt(GLenum param)
 static std::uint32_t GLGetUIntIndexed(GLenum param, GLuint index)
 {
     GLint attr = 0;
-    #if EXT_draw_buffers2
+    #if GL_EXT_draw_buffers2
     if (HasExtension(GLExt::EXT_draw_buffers2))
         glGetIntegeri_v(param, index, &attr);
     #endif


### PR DESCRIPTION
The `maxComputeShader*` limits in `RenderingLimits` were always zero, because there was a misspelled define in the `if` directive in the `GLGetUIntIndexed` function.