### PR TITLE
allow using vulkan on macos

### DIFF
--- a/.github/workflows/ci_macos.yml
+++ b/.github/workflows/ci_macos.yml
@@ -2,7 +2,7 @@ name: Apple macOS
 
 on:
   push:
-    branches: [ "master" ]
+    branches: [ "*" ]
   pull_request:
     branches: [ "master" ]
 

--- a/.github/workflows/ci_macos.yml
+++ b/.github/workflows/ci_macos.yml
@@ -53,7 +53,7 @@ jobs:
 
     - name: Upload Binaries
       uses: actions/upload-artifact@v4
-      if: ${{ always() && matrix.ext == 'Full' && matrix.lib == 'Shared' && matrix.config == 'Release' }}
+      if: ${{ matrix.ext == 'Full' && matrix.lib == 'Shared' && matrix.config == 'Release' }}
       with:
         name: LLGL-macOS-${{ matrix.config }}-x86_64
         path: |

--- a/.github/workflows/ci_macos.yml
+++ b/.github/workflows/ci_macos.yml
@@ -29,7 +29,7 @@ jobs:
     
     - name: Install dependencies
       run: >
-        brew install vulkan-sdk
+        brew install vulkan-tools
 
     - name: Configure CMake
       run: >

--- a/.github/workflows/ci_macos.yml
+++ b/.github/workflows/ci_macos.yml
@@ -53,7 +53,7 @@ jobs:
 
     - name: Upload Binaries
       uses: actions/upload-artifact@v4
-      if: ${{ matrix.ext == 'Full' && matrix.lib == 'Shared' && matrix.config == 'Release' }}
+      if: ${{ matrix.ext == 'Full' && matrix.lib == 'Static' && matrix.config == 'Release' }}
       with:
         name: LLGL-macOS-${{ matrix.config }}-x86_64
         path: |

--- a/.github/workflows/ci_macos.yml
+++ b/.github/workflows/ci_macos.yml
@@ -2,7 +2,7 @@ name: Apple macOS
 
 on:
   push:
-    branches: [ "*" ]
+    branches: [ "master" ]
   pull_request:
     branches: [ "master" ]
 
@@ -53,7 +53,7 @@ jobs:
 
     - name: Upload Binaries
       uses: actions/upload-artifact@v4
-      if: matrix.lib == 'Static' && matrix.config == 'Release'
+      if: ${{ always() && matrix.ext == 'Full' && matrix.lib == 'Shared' && matrix.config == 'Release' }}
       with:
         name: LLGL-macOS-${{ matrix.config }}-x86_64
         path: |

--- a/.github/workflows/ci_macos.yml
+++ b/.github/workflows/ci_macos.yml
@@ -10,6 +10,7 @@ jobs:
   build_macos:
     strategy:
       matrix:
+        ext: [Full, Limited]
         lib: [Shared, Static]
         config: [Release, Debug]
       fail-fast: false
@@ -18,12 +19,17 @@ jobs:
 
     env:
       README: ${{ github.workspace }}/README.txt
+      EXT_FULL: ${{ matrix.ext == 'Full' && 'ON' || 'OFF' }}
 
     steps:
     - name: Checkout Repository
       uses: actions/checkout@v4
       with:
         submodules: recursive
+    
+    - name: Install dependencies
+      run: >
+        brew install vulkan-sdk
 
     - name: Configure CMake
       run: >
@@ -32,6 +38,7 @@ jobs:
         -DLLGL_BUILD_STATIC_LIB=${{ matrix.lib == 'Static' && 'ON' || 'OFF' }}
         -DLLGL_BUILD_RENDERER_OPENGL=ON
         -DLLGL_BUILD_RENDERER_METAL=ON
+        -DLLGL_BUILD_RENDERER_VULKAN=${{ env.EXT_FULL }}
         -DLLGL_BUILD_EXAMPLES=ON
         -DLLGL_BUILD_TESTS=ON
         -DLLGL_BUILD_WRAPPER_C99=ON

--- a/sources/Renderer/Vulkan/VKSwapChain.cpp
+++ b/sources/Renderer/Vulkan/VKSwapChain.cpp
@@ -393,6 +393,18 @@ void VKSwapChain::CreateGpuSurface()
     VkResult result = vkCreateAndroidSurfaceKHR(instance_, &createInfo, nullptr, surface_.ReleaseAndGetAddressOf());
     VKThrowIfFailed(result, "failed to create Android surface for Vulkan swap-chain");
 
+    #elif defined LLGL_OS_MACOS
+
+    VkMacOSSurfaceCreateInfoMVK createInfo;
+    {
+        createInfo.sType    = VK_STRUCTURE_TYPE_MACOS_SURFACE_CREATE_INFO_MVK;
+        createInfo.pNext    = nullptr;
+        createInfo.flags    = 0;
+        createInfo.pView    = nativeHandle.responder;
+    }
+    VkResult result = vkCreateMacOSSurfaceMVK(instance_, &createInfo, nullptr, surface_.ReleaseAndGetAddressOf());
+    VKThrowIfFailed(result, "failed to create Macos surface for Vulkan swap-chain");
+
     #else
 
     #error Platform not supported for Vulkan backend

--- a/sources/Renderer/Vulkan/Vulkan.h
+++ b/sources/Renderer/Vulkan/Vulkan.h
@@ -17,6 +17,8 @@
 #   define VK_USE_PLATFORM_XLIB_KHR
 #elif defined LLGL_OS_ANDROID
 #   define VK_USE_PLATFORM_ANDROID_KHR
+#elif defined LLGL_OS_MACOS
+#   define VK_USE_PLATFORM_MACOS_MVK
 #else
 #   error unsupported platform for Vulkan
 #endif


### PR DESCRIPTION
It's just allow macos to use vulkan when LLGL_BUILD_RENDERER_VULKAN are enable, I only test it here https://github.com/coco875/test-llgl/tree/216881a74cdfa4202bd607d09aa7253ba4920c43 and it compile but can't try completly because imgui need more setup.