### PR TITLE
fix create a vulkan instance with moltenvk

### DIFF
--- a/sources/Renderer/Vulkan/Ext/VKExtensionRegistry.cpp
+++ b/sources/Renderer/Vulkan/Ext/VKExtensionRegistry.cpp
@@ -80,6 +80,9 @@ static bool IsVulkanInstanceExtOptional(const StringView& name)
     return
     (
         name == VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME
+#ifdef VK_KHR_PORTABILITY_ENUMERATION_EXTENSION_NAME
+        || name == VK_KHR_PORTABILITY_ENUMERATION_EXTENSION_NAME
+#endif
     );
 }
 

--- a/sources/Renderer/Vulkan/VKRenderSystem.cpp
+++ b/sources/Renderer/Vulkan/VKRenderSystem.cpp
@@ -821,15 +821,20 @@ void VKRenderSystem::CreateInstance(const RendererConfigurationVulkan* config)
         );
     };
 
+    /* Setup Vulkan instance descriptor */
+    VkInstanceCreateInfo instanceInfo = {};
+
     for (const VkExtensionProperties& prop : extensionProperties)
     {
         const VKExtSupport extSupport = GetVulkanInstanceExtensionSupport(prop.extensionName);
         if (IsVKExtSupportIncluded(extSupport))
             extensionNames.push_back(prop.extensionName);
+#ifdef VK_KHR_PORTABILITY_ENUMERATION_EXTENSION_NAME
+        if (strcmp(prop.extensionName, VK_KHR_PORTABILITY_ENUMERATION_EXTENSION_NAME) == 0)
+            instanceInfo.flags |= VK_INSTANCE_CREATE_ENUMERATE_PORTABILITY_BIT_KHR;
+            extensionNames.push_back(prop.extensionName);
+#endif
     }
-
-    /* Setup Vulkan instance descriptor */
-    VkInstanceCreateInfo instanceInfo = {};
 
     instanceInfo.sType = VK_STRUCTURE_TYPE_INSTANCE_CREATE_INFO;
 

--- a/sources/Renderer/Vulkan/VKRenderSystem.cpp
+++ b/sources/Renderer/Vulkan/VKRenderSystem.cpp
@@ -832,7 +832,6 @@ void VKRenderSystem::CreateInstance(const RendererConfigurationVulkan* config)
 #ifdef VK_KHR_PORTABILITY_ENUMERATION_EXTENSION_NAME
         if (strcmp(prop.extensionName, VK_KHR_PORTABILITY_ENUMERATION_EXTENSION_NAME) == 0)
             instanceInfo.flags |= VK_INSTANCE_CREATE_ENUMERATE_PORTABILITY_BIT_KHR;
-            extensionNames.push_back(prop.extensionName);
 #endif
     }
 


### PR DESCRIPTION
fix `VK_ERROR_INCOMPATIBLE_DRIVER` when `vkCreateInstance` is call with moltenvk. (based on this https://stackoverflow.com/questions/58732459/vk-error-incompatible-driver-with-mac-os-and-vulkan-moltenvk)