### PR TITLE
Allow to not use STL (Part 1)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -143,7 +143,7 @@ option(LLGL_ENABLE_CHECKED_CAST "Enable dynamic checked cast (only in Debug mode
 option(LLGL_ENABLE_DEBUG_LAYER "Enable renderer debug layer (for both Debug and Release mode)" ON)
 option(LLGL_ENABLE_EXCEPTIONS "Enable C++ exceptions" OFF)
 
-option(LLGL_PREFER_STL_CONTAINERS "Prefers C++ STL containers over custom containers, e.g. std::vector over SmallVector<T>" OFF)
+option(LLGL_PREFER_STL_CONTAINERS "Prefers C++ STL containers over custom containers, e.g. vector over SmallVector<T>" OFF)
 
 option(LLGL_BUILD_STATIC_LIB "Build LLGL as static library" OFF)
 option(LLGL_BUILD_TESTS "Include test projects" OFF)

--- a/examples/Cpp/Animation/Example.cpp
+++ b/examples/Cpp/Animation/Example.cpp
@@ -54,7 +54,7 @@ class Example_Animation : public ExampleBase
         float                   frameInterpolator   = 0.0f;
     };
 
-    std::vector<Ball>           balls;
+    vector<Ball>                balls;
 
     const Gs::Vector2f          gridPosFrames[15]
     {
@@ -106,7 +106,7 @@ private:
         vertexFormat.SetStride(sizeof(TexturedVertex));
 
         // Load 3D models
-        std::vector<TexturedVertex> vertices;
+        vector<TexturedVertex> vertices;
         meshStairsTop       = LoadObjModel(vertices, "PenroseStairs-Top.obj");
         meshStairsBottom    = LoadObjModel(vertices, "PenroseStairs-Bottom.obj");
         meshBall            = LoadObjModel(vertices, "IcoSphere.obj");

--- a/examples/Cpp/ClothPhysics/Example.cpp
+++ b/examples/Cpp/ClothPhysics/Example.cpp
@@ -144,9 +144,9 @@ public:
 
     // Generates the grid geometry for the cloth with triangle strip topology
     void GenerateClothGeometry(
-        std::vector<ParticleBase>&  verticesBase,
-        std::vector<Gs::Vector4f>&  verticesPos,
-        std::vector<std::uint32_t>& indices)
+        vector<ParticleBase>&  verticesBase,
+        vector<Gs::Vector4f>&  verticesPos,
+        vector<std::uint32_t>& indices)
     {
         const auto invSegsU = 1.0f / static_cast<float>(clothSegmentsU);
         const auto invSegsV = 1.0f / static_cast<float>(clothSegmentsV);
@@ -275,10 +275,10 @@ public:
         };
 
         // Generate vertex and index data and store number of vertices and indices for draw commands
-        std::vector<ParticleBase> verticesBase;
-        std::vector<Gs::Vector4f> verticesPos;
-        std::vector<Gs::Vector4f> zeroVectors;
-        std::vector<std::uint32_t> indices;
+        vector<ParticleBase> verticesBase;
+        vector<Gs::Vector4f> verticesPos;
+        vector<Gs::Vector4f> zeroVectors;
+        vector<std::uint32_t> indices;
 
         GenerateClothGeometry(verticesBase, verticesPos, indices);
 
@@ -448,7 +448,7 @@ public:
     void CreateGraphicsPipeline()
     {
         // Create graphics shader
-        std::vector<LLGL::VertexFormat> usedVertexFormats;
+        vector<LLGL::VertexFormat> usedVertexFormats;
         #ifndef ENABLE_STORAGE_TEXTURES
         usedVertexFormats = { vertexFormat };
         #endif

--- a/examples/Cpp/ExampleBase/DDSImageReader.cpp
+++ b/examples/Cpp/ExampleBase/DDSImageReader.cpp
@@ -133,7 +133,7 @@ T ReadValue(std::istream& stream)
     return value;
 }
 
-bool DDSImageReader::LoadFromFile(const std::string& filename)
+bool DDSImageReader::LoadFromFile(const string& filename)
 {
     // Open file for reading
     AssetReader reader = ReadAsset(filename);

--- a/examples/Cpp/ExampleBase/DDSImageReader.h
+++ b/examples/Cpp/ExampleBase/DDSImageReader.h
@@ -11,8 +11,8 @@
 
 #include <LLGL/ImageFlags.h>
 #include <LLGL/TextureFlags.h>
-#include <string>
-#include <vector>
+#include <LLGL/Container/String.h>
+#include <LLGL/Container/Vector.h>
 
 
 // Image reader class to load DXT compressed textures from file.
@@ -22,7 +22,7 @@ class DDSImageReader
     public:
 
         // Loads the specified DDS image from file.
-        bool LoadFromFile(const std::string& filename);
+        bool LoadFromFile(const string& filename);
 
         // Returns the image view for the specified MIP-map that can be passed to RenderSystem::CreateTexture or RenderSystem::WriteTexture.
         LLGL::ImageView GetImageView(std::uint32_t mipLevel = 0) const;
@@ -42,8 +42,8 @@ class DDSImageReader
         };
 
         LLGL::TextureDescriptor texDesc_;
-        std::vector<char>       data_;
-        std::vector<MipSection> mips_;
+        vector<char>       data_;
+        vector<MipSection> mips_;
 
 };
 

--- a/examples/Cpp/ExampleBase/ExampleBase.cpp
+++ b/examples/Cpp/ExampleBase/ExampleBase.cpp
@@ -41,10 +41,10 @@ See https://www.gnu.org/software/gnulib/manual/html_node/inttypes_002eh.html
  * Global helper functions
  */
 
-static std::string GetRendererModuleFromUserSelection(int argc, char* argv[])
+static string GetRendererModuleFromUserSelection(int argc, char* argv[])
 {
     /* Find available modules */
-    std::vector<std::string> modules = LLGL::RenderSystem::FindModules();
+    vector<string> modules = LLGL::RenderSystem::FindModules();
 
     if (modules.empty())
     {
@@ -58,7 +58,7 @@ static std::string GetRendererModuleFromUserSelection(int argc, char* argv[])
     }
 
     /* Let user select a renderer */
-    std::string rendererModule;
+    string rendererModule;
 
     while (rendererModule.empty())
     {
@@ -66,14 +66,14 @@ static std::string GetRendererModuleFromUserSelection(int argc, char* argv[])
         LLGL::Log::Printf("select renderer:\n");
 
         int i = 0;
-        for (const std::string& mod : modules)
+        for (const string& mod : modules)
             LLGL::Log::Printf(" %d.) %s\n", ++i, mod.c_str());
 
         /* Wait for user input */
         char selectionBuffer[256] = {};
         (void)::fgets(selectionBuffer, sizeof(selectionBuffer), stdin);
 
-        std::string selectionStr = selectionBuffer;
+        string selectionStr = selectionBuffer;
         selectionStr = selectionStr.substr(0, selectionStr.find_first_not_of("0123456789"));
         if (!selectionStr.empty())
         {
@@ -119,7 +119,7 @@ static const char* GetRendererModuleFromCommandArgs(int argc, char* argv[])
     return nullptr;
 }
 
-static void GetSelectedRendererModuleOrDefault(std::string& rendererModule, int argc, char* argv[])
+static void GetSelectedRendererModuleOrDefault(string& rendererModule, int argc, char* argv[])
 {
     /* Get renderer module name from command line argument */
     if (const char* specificModule = GetRendererModuleFromCommandArgs(argc, argv))
@@ -168,17 +168,17 @@ static const char* GetDefaultRendererModule()
     #endif
 }
 
-static std::string GetPreferredRendererModule()
+static string GetPreferredRendererModule()
 {
     auto modules = LLGL::RenderSystem::FindModules();
     return (modules.empty() ? "Null" : modules.front());
 }
 
-std::string GetSelectedRendererModule(int argc, char* argv[])
+string GetSelectedRendererModule(int argc, char* argv[])
 {
     // Set report callback to standard output
     LLGL::Log::RegisterCallbackStd();
-    std::string rendererModule = GetPreferredRendererModule();
+    string rendererModule = GetPreferredRendererModule();
     GetSelectedRendererModuleOrDefault(rendererModule, argc, argv);
     return rendererModule;
 }
@@ -248,7 +248,7 @@ static bool ParseSamples(std::uint32_t& samples, int argc, char* argv[])
 
 ExampleBase::ShaderDescWrapper::ShaderDescWrapper(
     LLGL::ShaderType    type,
-    const std::string&  filename)
+    const string&  filename)
 :
     type     { type     },
     filename { filename }
@@ -257,9 +257,9 @@ ExampleBase::ShaderDescWrapper::ShaderDescWrapper(
 
 ExampleBase::ShaderDescWrapper::ShaderDescWrapper(
     LLGL::ShaderType    type,
-    const std::string&  filename,
-    const std::string&  entryPoint,
-    const std::string&  profile)
+    const string&  filename,
+    const string&  entryPoint,
+    const string&  profile)
 :
     type       { type       },
     filename   { filename   },
@@ -347,7 +347,7 @@ void ExampleBase::CanvasEventHandler::OnResize(LLGL::Canvas& /*sender*/, const L
 
 struct ExampleConfig
 {
-    std::string     rendererModule  = GetDefaultRendererModule();
+    string          rendererModule  = GetDefaultRendererModule();
     LLGL::Extent2D  windowSize      = { 800, 600 };
     std::uint32_t   samples         = 8;
     bool            vsync           = true;
@@ -692,20 +692,20 @@ LLGL::Shader* ExampleBase::LoadShaderInternal(
     const ShaderDescWrapper&                    shaderDesc,
     const LLGL::ArrayView<LLGL::VertexFormat>&  vertexFormats,
     const LLGL::VertexFormat&                   streamOutputFormat,
-    const std::vector<LLGL::FragmentAttribute>& fragmentAttribs,
+    const vector<LLGL::FragmentAttribute>& fragmentAttribs,
     const LLGL::ShaderMacro*                    defines,
     bool                                        patchClippingOrigin)
 {
     LLGL::Log::Printf("load shader: %s\n", shaderDesc.filename.c_str());
 
     #ifdef LLGL_OS_WASM
-    const std::string filename = "assets/" + shaderDesc.filename;
+    const string filename = "assets/" + shaderDesc.filename;
     #else
-    const std::string filename = shaderDesc.filename;
+    const string filename = shaderDesc.filename;
     #endif
 
-    std::vector<LLGL::Shader*>          shaders;
-    std::vector<LLGL::VertexAttribute>  vertexInputAttribs;
+    vector<LLGL::Shader*>          shaders;
+    vector<LLGL::VertexAttribute>  vertexInputAttribs;
 
     // Store vertex input attributes
     for (const auto& vtxFmt : vertexFormats)
@@ -789,7 +789,7 @@ LLGL::Shader* ExampleBase::LoadShader(
 
 LLGL::Shader* ExampleBase::LoadShader(
     const ShaderDescWrapper&                    shaderDesc,
-    const std::vector<LLGL::FragmentAttribute>& fragmentAttribs,
+    const vector<LLGL::FragmentAttribute>& fragmentAttribs,
     const LLGL::ShaderMacro*                    defines)
 {
     return LoadShaderInternal(shaderDesc, {}, {}, fragmentAttribs, defines, /*patchClippingOrigin:*/ false);
@@ -823,7 +823,7 @@ LLGL::Shader* ExampleBase::LoadStandardVertexShader(
 
 LLGL::Shader* ExampleBase::LoadStandardFragmentShader(
     const char*                                 entryPoint,
-    const std::vector<LLGL::FragmentAttribute>& fragmentAttribs,
+    const vector<LLGL::FragmentAttribute>& fragmentAttribs,
     const LLGL::ShaderMacro*                    defines)
 {
     if (Supported(LLGL::ShadingLanguage::GLSL) || Supported(LLGL::ShadingLanguage::ESSL))
@@ -852,7 +852,7 @@ LLGL::Shader* ExampleBase::LoadStandardComputeShader(
     return nullptr;
 }
 
-ShaderPipeline ExampleBase::LoadStandardShaderPipeline(const std::vector<LLGL::VertexFormat>& vertexFormats)
+ShaderPipeline ExampleBase::LoadStandardShaderPipeline(const vector<LLGL::VertexFormat>& vertexFormats)
 {
     ShaderPipeline shaderPipeline;
     {
@@ -883,7 +883,7 @@ bool ExampleBase::ReportPSOErrors(const LLGL::PipelineState* pso)
     return false;
 }
 
-LLGL::Texture* LoadTextureWithRenderer(LLGL::RenderSystem& renderSys, const std::string& filename, long bindFlags, LLGL::Format format)
+LLGL::Texture* LoadTextureWithRenderer(LLGL::RenderSystem& renderSys, const string& filename, long bindFlags, LLGL::Format format)
 {
     LLGL::Log::Printf("load texture: %s\n", filename.c_str());
 
@@ -902,7 +902,7 @@ LLGL::Texture* LoadTextureWithRenderer(LLGL::RenderSystem& renderSys, const std:
     return tex;
 }
 
-bool SaveTextureWithRenderer(LLGL::RenderSystem& renderSys, LLGL::Texture& texture, const std::string& filename, std::uint32_t mipLevel)
+bool SaveTextureWithRenderer(LLGL::RenderSystem& renderSys, LLGL::Texture& texture, const string& filename, std::uint32_t mipLevel)
 {
     LLGL::Log::Printf("save texture: %s\n", filename.c_str());
 
@@ -910,7 +910,7 @@ bool SaveTextureWithRenderer(LLGL::RenderSystem& renderSys, LLGL::Texture& textu
     const LLGL::Extent3D texSize = texture.GetMipExtent(mipLevel);
 
     // Read texture image data
-    std::vector<LLGL::ColorRGBAub> imageBuffer(texSize.width * texSize.height);
+    vector<LLGL::ColorRGBAub> imageBuffer(texSize.width * texSize.height);
     renderSys.ReadTexture(
         texture,
         LLGL::TextureRegion
@@ -947,12 +947,12 @@ bool SaveTextureWithRenderer(LLGL::RenderSystem& renderSys, LLGL::Texture& textu
     return true;
 }
 
-LLGL::Texture* ExampleBase::LoadTexture(const std::string& filename, long bindFlags, LLGL::Format format)
+LLGL::Texture* ExampleBase::LoadTexture(const string& filename, long bindFlags, LLGL::Format format)
 {
     return LoadTextureWithRenderer(*renderer, filename, bindFlags, format);
 }
 
-bool ExampleBase::SaveTexture(LLGL::Texture& texture, const std::string& filename, std::uint32_t mipLevel)
+bool ExampleBase::SaveTexture(LLGL::Texture& texture, const string& filename, std::uint32_t mipLevel)
 {
     return SaveTextureWithRenderer(*renderer, texture, filename, mipLevel);
 }
@@ -1067,7 +1067,7 @@ bool ExampleBase::Supported(const LLGL::ShadingLanguage shadingLanguage) const
     return (std::find(languages.begin(), languages.end(), shadingLanguage) != languages.end());
 }
 
-const std::string& ExampleBase::GetModuleName()
+const string& ExampleBase::GetModuleName()
 {
     return g_Config.rendererModule;
 }

--- a/examples/Cpp/ExampleBase/ExampleBase.h
+++ b/examples/Cpp/ExampleBase/ExampleBase.h
@@ -18,9 +18,9 @@
 #include <LLGL/Platform/Platform.h>
 #include <LLGL/Trap.h>
 #include <Gauss/Gauss.h>
-#include <vector>
+#include <LLGL/Container/Vector.h>
 #include <random>
-#include <map>
+#include <LLGL/Container/Map.h>
 #include <type_traits>
 #include "GeometryUtils.h"
 #include "Stopwatch.h"
@@ -36,18 +36,18 @@
  */
 
 // Let the user choose a renderer module (using std::cin).
-std::string GetSelectedRendererModule(int argc, char* argv[]);
+string GetSelectedRendererModule(int argc, char* argv[]);
 
 // Load image from file, create texture, upload image into texture, and generate MIP-maps.
 LLGL::Texture* LoadTextureWithRenderer(
     LLGL::RenderSystem& renderSys,
-    const std::string&  filename,
+    const string&  filename,
     long                bindFlags   = (LLGL::BindFlags::Sampled | LLGL::BindFlags::ColorAttachment),
     LLGL::Format        format      = LLGL::Format::RGBA8UNorm
 );
 
 // Save texture image to a PNG file.
-bool SaveTextureWithRenderer(LLGL::RenderSystem& renderSys, LLGL::Texture& texture, const std::string& filename, std::uint32_t mipLevel = 0);
+bool SaveTextureWithRenderer(LLGL::RenderSystem& renderSys, LLGL::Texture& texture, const string& filename, std::uint32_t mipLevel = 0);
 
 
 /*
@@ -90,21 +90,21 @@ protected:
     struct ShaderDescWrapper
     {
         ShaderDescWrapper(
-            LLGL::ShaderType    type,
-            const std::string&  filename
+            LLGL::ShaderType  type,
+            const string&     filename
         );
 
         ShaderDescWrapper(
-            LLGL::ShaderType    type,
-            const std::string&  filename,
-            const std::string&  entryPoint,
-            const std::string&  profile
+            LLGL::ShaderType  type,
+            const string&     filename,
+            const string&     entryPoint,
+            const string&     profile
         );
 
-        LLGL::ShaderType    type;
-        std::string         filename;
-        std::string         entryPoint;
-        std::string         profile;
+        LLGL::ShaderType  type;
+        string            filename;
+        string            entryPoint;
+        string            profile;
     };
 
 private:
@@ -211,7 +211,7 @@ private:
         const ShaderDescWrapper&                    shaderDesc,
         const LLGL::ArrayView<LLGL::VertexFormat>&  vertexFormats,
         const LLGL::VertexFormat&                   streamOutputFormat,
-        const std::vector<LLGL::FragmentAttribute>& fragmentAttribs,
+        const vector<LLGL::FragmentAttribute>&      fragmentAttribs,
         const LLGL::ShaderMacro*                    defines,
         bool                                        patchClippingOrigin
     );
@@ -229,7 +229,7 @@ protected:
     // Loads a shader from file with fragment attributes.
     LLGL::Shader* LoadShader(
         const ShaderDescWrapper&                    shaderDesc,
-        const std::vector<LLGL::FragmentAttribute>& fragmentAttribs,
+        const vector<LLGL::FragmentAttribute>& fragmentAttribs,
         const LLGL::ShaderMacro*                    defines             = nullptr
     );
 
@@ -250,7 +250,7 @@ protected:
     // Loads a fragment shader with standard filename convention.
     LLGL::Shader* LoadStandardFragmentShader(
         const char*                                 entryPoint      = "PS",
-        const std::vector<LLGL::FragmentAttribute>& fragmentAttribs = {},
+        const vector<LLGL::FragmentAttribute>& fragmentAttribs = {},
         const LLGL::ShaderMacro*                    defines         = nullptr
     );
 
@@ -261,20 +261,20 @@ protected:
     );
 
     // Loads a shader pipeline with vertex and fragment shaders and with standard filename convention.
-    ShaderPipeline LoadStandardShaderPipeline(const std::vector<LLGL::VertexFormat>& vertexFormats);
+    ShaderPipeline LoadStandardShaderPipeline(const vector<LLGL::VertexFormat>& vertexFormats);
 
     // Throws an exception if the specified PSO creation failed.
     bool ReportPSOErrors(const LLGL::PipelineState* pso);
 
     // Load image from file, create texture, upload image into texture, and generate MIP-maps.
     LLGL::Texture* LoadTexture(
-        const std::string&  filename,
+        const string&  filename,
         long                bindFlags   = (LLGL::BindFlags::Sampled | LLGL::BindFlags::ColorAttachment),
         LLGL::Format        format      = LLGL::Format::RGBA8UNorm
     );
 
     // Save texture image to a PNG file.
-    bool SaveTexture(LLGL::Texture& texture, const std::string& filename, std::uint32_t mipLevel = 0);
+    bool SaveTexture(LLGL::Texture& texture, const string& filename, std::uint32_t mipLevel = 0);
 
     // Captures the current framebuffer into a new texture.
     LLGL::Texture* CaptureFramebuffer(LLGL::CommandBuffer& commandBuffer, const LLGL::RenderTarget* resolutionSource = nullptr);
@@ -324,7 +324,7 @@ protected:
 protected:
 
     // Returns the name of the renderer module (e.g. "OpenGL" or "Direct3D11").
-    static const std::string& GetModuleName();
+    static const string& GetModuleName();
 
 protected:
 

--- a/examples/Cpp/ExampleBase/FileUtils.cpp
+++ b/examples/Cpp/ExampleBase/FileUtils.cpp
@@ -26,7 +26,7 @@
  * AssetReader class
  */
 
-AssetReader::AssetReader(std::vector<char>&& content) :
+AssetReader::AssetReader(vector<char>&& content) :
     content_ { std::move(content) }
 {
 }
@@ -54,19 +54,19 @@ AssetReader::operator bool () const
  * Global helper functions
  */
 
-static bool FileExists(const std::string& filename)
+static bool FileExists(const string& filename)
 {
     std::ifstream file{ filename };
     return file.good();
 };
 
-static std::string FindAssetFilename(const std::string& name)
+static string FindAssetFilename(const string& name)
 {
     #if defined LLGL_OS_IOS || defined LLGL_OS_MACOS
 
     // Returns filename for resource from main NSBundle
     const std::size_t subPathStart = name.find_last_of('/');
-    if (subPathStart != std::string::npos)
+    if (subPathStart != string::npos)
         return FindNSResourcePath(name.substr(subPathStart + 1));
     else
         return FindNSResourcePath(name);
@@ -88,11 +88,11 @@ static std::string FindAssetFilename(const std::string& name)
         return name;
 
     // Search file in known asset folders
-    const std::string assetsRoot = "../../Shared/Assets/";
+    const string assetsRoot = "../../Shared/Assets/";
 
     for (const char* folder : { "Textures", "Models", "Fonts"  })
     {
-        const std::string filename = assetsRoot + folder + "/" + name;
+        const string filename = assetsRoot + folder + "/" + name;
         if (FileExists(filename))
             return filename;
     }
@@ -102,10 +102,10 @@ static std::string FindAssetFilename(const std::string& name)
     return name;
 }
 
-std::vector<char> ReadAsset(const std::string& name, std::string* outFullPath)
+vector<char> ReadAsset(const string& name, string* outFullPath)
 {
     // Get full filename for asset
-    const std::string filename = FindAssetFilename(name);
+    const string filename = FindAssetFilename(name);
     if (outFullPath != nullptr)
         *outFullPath = filename;
 
@@ -120,7 +120,7 @@ std::vector<char> ReadAsset(const std::string& name, std::string* outFullPath)
     }
 
     // Read entire content of file into output container
-    std::vector<char> content;
+    vector<char> content;
 
     fseek(file, 0, SEEK_END);
     long fileSize = ftell(file);
@@ -145,7 +145,7 @@ std::vector<char> ReadAsset(const std::string& name, std::string* outFullPath)
     }
 
     // Read entire content of file stream into output container
-    return std::vector<char>
+    return vector<char>
     {
         std::istreambuf_iterator<char>{file},
         std::istreambuf_iterator<char>{}
@@ -159,29 +159,29 @@ static bool IsNewlineChar(char c)
     return (c == '\n' || c == '\r');
 }
 
-std::vector<std::string> ReadTextLines(const std::string& name, std::string* outFullPath)
+vector<string> ReadTextLines(const string& name, string* outFullPath)
 {
-    const std::vector<char> content = ReadAsset(name, outFullPath);
-    std::vector<std::string> lines;
+    const vector<char> content = ReadAsset(name, outFullPath);
+    vector<string> lines;
     if (!content.empty())
     {
-        std::vector<char>::const_iterator itStart = content.begin(), itEnd;
+        vector<char>::const_iterator itStart = content.begin(), itEnd;
         while ((itEnd = std::find_if(itStart, content.end(), IsNewlineChar)) != content.end())
         {
-            lines.push_back(std::string{ itStart, itEnd });
+            lines.push_back(string{ itStart, itEnd });
             if (itEnd != content.end() && *itEnd == '\r' && itEnd + 1 != content.end() && *(itEnd + 1) == '\n')
                 itStart = itEnd + 2;
             else
                 itStart = itEnd + 1;
         }
-        lines.push_back(std::string{ itStart, itEnd });
+        lines.push_back(string{ itStart, itEnd });
     }
     return lines;
 }
 
-std::string WriteFrameProfileToJson(const LLGL::FrameProfile& frameProfile)
+string WriteFrameProfileToJson(const LLGL::FrameProfile& frameProfile)
 {
-    std::string s;
+    string s;
 
     s += "{\n";
     s += "\t\"traceEvents\": [\n";
@@ -224,7 +224,7 @@ bool WriteFrameProfileToJsonFile(const LLGL::FrameProfile& frameProfile, const c
     std::ofstream file{ filename };
     if (file.good())
     {
-        std::string jsonContent = WriteFrameProfileToJson(frameProfile);
+        string jsonContent = WriteFrameProfileToJson(frameProfile);
         file.write(jsonContent.c_str(), jsonContent.size());
         return true;
     }

--- a/examples/Cpp/ExampleBase/FileUtils.h
+++ b/examples/Cpp/ExampleBase/FileUtils.h
@@ -9,8 +9,8 @@
 #define LLGLEXAMPLES_FILE_UTILS_H
 
 
-#include <string>
-#include <vector>
+#include <LLGL/Container/String.h>
+#include <LLGL/Container/Vector.h>
 #include <type_traits>
 #include <LLGL/RenderingDebuggerFlags.h>
 
@@ -31,7 +31,7 @@ class AssetReader
         AssetReader& operator = (AssetReader&&) = default;
 
         // Take ownership of the specified content to read an asset.
-        AssetReader(std::vector<char>&& content);
+        AssetReader(vector<char>&& content);
 
         // Returns true if this asset reader has any content.
         bool IsValid() const;
@@ -54,21 +54,21 @@ class AssetReader
 
     public:
 
-        std::vector<char>   content_;
+        vector<char>   content_;
         std::size_t         readPos_ = 0;
 
 };
 
 // Returns the content of the specified asset.
 // If the file could not be found, an empty container is returned and an error is reported to the log.
-std::vector<char> ReadAsset(const std::string& name, std::string* outFullPath = nullptr);
+vector<char> ReadAsset(const string& name, string* outFullPath = nullptr);
 
 // Reads the specified asset as text file and returns each line in an array.
-std::vector<std::string> ReadTextLines(const std::string& name, std::string* outFullPath = nullptr);
+vector<string> ReadTextLines(const string& name, string* outFullPath = nullptr);
 
 // Writes the specified FrameProfile as a JSON body string.
 // This can be loaded up in Goolge Chrome's Trace Viewer (see https://google.github.io/trace-viewer/).
-std::string WriteFrameProfileToJson(const LLGL::FrameProfile& frameProfile);
+string WriteFrameProfileToJson(const LLGL::FrameProfile& frameProfile);
 
 // Writes the specified FrameProfile to a JSON file.
 bool WriteFrameProfileToJsonFile(const LLGL::FrameProfile& frameProfile, const char* filename);

--- a/examples/Cpp/ExampleBase/GeometryUtils.cpp
+++ b/examples/Cpp/ExampleBase/GeometryUtils.cpp
@@ -19,17 +19,17 @@
 * Global helper functions
 */
 
-std::vector<TexturedVertex> LoadObjModel(const std::string& filename)
+vector<TexturedVertex> LoadObjModel(const string& filename)
 {
-    std::vector<TexturedVertex> vertices;
+    vector<TexturedVertex> vertices;
     LoadObjModel(vertices, filename);
     return vertices;
 }
 
-TriangleMesh LoadObjModel(std::vector<TexturedVertex>& vertices, const std::string& filename, unsigned verticesPerFace)
+TriangleMesh LoadObjModel(vector<TexturedVertex>& vertices, const string& filename, unsigned verticesPerFace)
 {
     // Read obj file
-    std::vector<char> fileContent = ReadAsset(filename);
+    vector<char> fileContent = ReadAsset(filename);
     if (fileContent.empty())
         LLGL_THROW_RUNTIME_ERROR("failed to load model from file: \"%s\"", filename.c_str());
 
@@ -37,22 +37,22 @@ TriangleMesh LoadObjModel(std::vector<TexturedVertex>& vertices, const std::stri
     TriangleMesh mesh;
     mesh.firstVertex = static_cast<std::uint32_t>(vertices.size());
 
-    std::vector<Gs::Vector3f> coords, normals;
-    std::vector<Gs::Vector2f> texCoords;
+    vector<Gs::Vector3f> coords, normals;
+    vector<Gs::Vector2f> texCoords;
 
     // Convert file content into a stream (this code used to read the file via std::ifstream)
     std::stringstream stream;
     std::copy(fileContent.begin(), fileContent.end(), std::ostream_iterator<char>{ stream });
 
     // Read each line
-    std::string line;
+    string line;
     while (std::getline(stream, line))
     {
         std::stringstream s;
         s << line;
 
         // Parse line
-        std::string mode;
+        string mode;
         s >> mode;
 
         if (mode == "v")
@@ -116,7 +116,7 @@ TriangleMesh LoadObjModel(std::vector<TexturedVertex>& vertices, const std::stri
     return mesh;
 }
 
-std::vector<Gs::Vector3f> GenerateCubeVertices()
+vector<Gs::Vector3f> GenerateCubeVertices()
 {
     return
     {
@@ -125,7 +125,7 @@ std::vector<Gs::Vector3f> GenerateCubeVertices()
     };
 }
 
-std::vector<std::uint32_t> GenerateCubeTriangleIndices()
+vector<std::uint32_t> GenerateCubeTriangleIndices()
 {
     return
     {
@@ -138,7 +138,7 @@ std::vector<std::uint32_t> GenerateCubeTriangleIndices()
     };
 }
 
-std::vector<TexturedVertex> GenerateTexturedCubeVertices()
+vector<TexturedVertex> GenerateTexturedCubeVertices()
 {
     return
     {
@@ -181,7 +181,7 @@ std::vector<TexturedVertex> GenerateTexturedCubeVertices()
     };
 }
 
-std::vector<std::uint32_t> GenerateTexturedCubeTriangleIndices()
+vector<std::uint32_t> GenerateTexturedCubeTriangleIndices()
 {
     return
     {
@@ -194,10 +194,10 @@ std::vector<std::uint32_t> GenerateTexturedCubeTriangleIndices()
     };
 }
 
-std::vector<std::uint32_t> GenerateTexturedCubeQuadIndices(std::uint32_t numVertices, std::uint32_t firstVertex)
+vector<std::uint32_t> GenerateTexturedCubeQuadIndices(std::uint32_t numVertices, std::uint32_t firstVertex)
 {
     // Assume the vertices are already laid out as quads. Generate indices 0/1/3/2 for each quad.
-    std::vector<std::uint32_t> indices;
+    vector<std::uint32_t> indices;
     indices.resize(numVertices);
 
     for_range(i, numVertices)
@@ -251,9 +251,9 @@ static void GenerateTangentSpace(TangentSpaceVertex& v0, TangentSpaceVertex& v1,
     NormalizeTangents(v2, tangent0, tangent1);
 }
 
-std::vector<TangentSpaceVertex> GenerateTangentSpaceVertices(const LLGL::ArrayView<TexturedVertex>& vertices)
+vector<TangentSpaceVertex> GenerateTangentSpaceVertices(const LLGL::ArrayView<TexturedVertex>& vertices)
 {
-    std::vector<TangentSpaceVertex> outp;
+    vector<TangentSpaceVertex> outp;
     outp.resize(vertices.size());
 
     for (std::size_t i = 0, n = outp.size(); i + 3 <= n; i += 3)
@@ -290,9 +290,9 @@ static void GenerateTangentSpaceQuad(TangentSpaceVertex& v0, TangentSpaceVertex&
     NormalizeTangents(v3, tangent0, tangent1);
 }
 
-std::vector<TangentSpaceVertex> GenerateTangentSpaceQuadVertices(const LLGL::ArrayView<TexturedVertex>& vertices)
+vector<TangentSpaceVertex> GenerateTangentSpaceQuadVertices(const LLGL::ArrayView<TexturedVertex>& vertices)
 {
-    std::vector<TangentSpaceVertex> outp;
+    vector<TangentSpaceVertex> outp;
     outp.resize(vertices.size());
 
     for (std::size_t i = 0, n = outp.size(); i + 4 <= n; i += 4)

--- a/examples/Cpp/ExampleBase/GeometryUtils.h
+++ b/examples/Cpp/ExampleBase/GeometryUtils.h
@@ -12,7 +12,7 @@
 #include <LLGL/LLGL.h>
 #include <LLGL/Container/ArrayView.h>
 #include <Gauss/Gauss.h>
-#include <vector>
+#include <LLGL/Container/Vector.h>
 
 
 /*
@@ -49,33 +49,33 @@ struct TriangleMesh
  */
 
 // Loads the vertices with position and normal from the specified Wavefront OBJ model file.
-std::vector<TexturedVertex> LoadObjModel(const std::string& filename);
+vector<TexturedVertex> LoadObjModel(const string& filename);
 
 // Loads the vertices with position and normal from the specified Wavefront OBJ model file.
-TriangleMesh LoadObjModel(std::vector<TexturedVertex>& vertices, const std::string& filename, unsigned verticesPerFace = 3);
+TriangleMesh LoadObjModel(vector<TexturedVertex>& vertices, const string& filename, unsigned verticesPerFace = 3);
 
 // Generates eight vertices for a unit cube.
-std::vector<Gs::Vector3f> GenerateCubeVertices();
+vector<Gs::Vector3f> GenerateCubeVertices();
 
 // Generates 36 indices for a unit cube of 8 vertices
 // (36 = 3 indices per triangle * 2 triangles per cube face * 6 faces).
-std::vector<std::uint32_t> GenerateCubeTriangleIndices();
+vector<std::uint32_t> GenerateCubeTriangleIndices();
 
 // Generates 24 vertices for a unit cube with texture coordinates.
-std::vector<TexturedVertex> GenerateTexturedCubeVertices();
+vector<TexturedVertex> GenerateTexturedCubeVertices();
 
 // Generates 36 indices for a unit cube of 24 vertices
-std::vector<std::uint32_t> GenerateTexturedCubeTriangleIndices();
+vector<std::uint32_t> GenerateTexturedCubeTriangleIndices();
 
 // Generates 24 indices for a unit cube of 8 vertices.
 // (24 = 4 indices per quad * 1 quad per cube face * 6 faces)
-std::vector<std::uint32_t> GenerateTexturedCubeQuadIndices(std::uint32_t numVertices, std::uint32_t firstVertex);
+vector<std::uint32_t> GenerateTexturedCubeQuadIndices(std::uint32_t numVertices, std::uint32_t firstVertex);
 
 // Generates tangent-space vertices from the specified list of textured vertices.
-std::vector<TangentSpaceVertex> GenerateTangentSpaceVertices(const LLGL::ArrayView<TexturedVertex>& vertices);
+vector<TangentSpaceVertex> GenerateTangentSpaceVertices(const LLGL::ArrayView<TexturedVertex>& vertices);
 
 // Generates tangent-space vertices (per quad) from the specified list of textured vertices.
-std::vector<TangentSpaceVertex> GenerateTangentSpaceQuadVertices(const LLGL::ArrayView<TexturedVertex>& vertices);
+vector<TangentSpaceVertex> GenerateTangentSpaceQuadVertices(const LLGL::ArrayView<TexturedVertex>& vertices);
 
 // Returns a point on the specified line segment that is the closest to the reference point.
 Gs::Vector3f ClosestPointOnLineSegment(const Gs::Vector3f& linePointA, const Gs::Vector3f& linePointB, const Gs::Vector3f& referencePoint);

--- a/examples/Cpp/ExampleBase/ImageReader.cpp
+++ b/examples/Cpp/ExampleBase/ImageReader.cpp
@@ -12,11 +12,11 @@
 #include <stb/stb_image.h>
 
 
-bool ImageReader::LoadFromFile(const std::string& filename, LLGL::Format format)
+bool ImageReader::LoadFromFile(const string& filename, LLGL::Format format)
 {
     // Read image asset
-    std::string assetPath;
-    std::vector<char> content = ReadAsset(filename, &assetPath);
+    string assetPath;
+    vector<char> content = ReadAsset(filename, &assetPath);
     if (content.empty())
         return false;
 
@@ -35,7 +35,7 @@ bool ImageReader::LoadFromFile(const std::string& filename, LLGL::Format format)
         return false;
     }
 
-    data_ = std::vector<char>
+    data_ = vector<char>
     {
         reinterpret_cast<const char*>(imageData),
         reinterpret_cast<const char*>(imageData + w*h*formatAttribs.components)
@@ -68,7 +68,7 @@ LLGL::ImageView ImageReader::GetImageView() const
     return imageView;
 }
 
-void ImageReader::AppendImageDataTo(std::vector<char>& outBuffer)
+void ImageReader::AppendImageDataTo(vector<char>& outBuffer)
 {
     const std::size_t outBufferOffset = outBuffer.size();
     outBuffer.resize(outBufferOffset + data_.size());

--- a/examples/Cpp/ExampleBase/ImageReader.h
+++ b/examples/Cpp/ExampleBase/ImageReader.h
@@ -11,8 +11,8 @@
 
 #include <LLGL/ImageFlags.h>
 #include <LLGL/TextureFlags.h>
-#include <string>
-#include <vector>
+#include <LLGL/Container/String.h>
+#include <LLGL/Container/Vector.h>
 
 
 // Image reader class to load common image formats (using STB lib).
@@ -22,13 +22,13 @@ class ImageReader
     public:
 
         // Loads the specified image from file.
-        bool LoadFromFile(const std::string& filename, LLGL::Format format = LLGL::Format::RGBA8UNorm);
+        bool LoadFromFile(const string& filename, LLGL::Format format = LLGL::Format::RGBA8UNorm);
 
         // Returns the image view for the first MIP-map that can be passed to RenderSystem::CreateTexture or RenderSystem::WriteTexture.
         LLGL::ImageView GetImageView() const;
 
         // Appends the data of the loaded image to the specified output buffer.
-        void AppendImageDataTo(std::vector<char>& outBuffer);
+        void AppendImageDataTo(vector<char>& outBuffer);
 
         // Returns the texture descriptor.
         inline const LLGL::TextureDescriptor& GetTextureDesc() const
@@ -38,9 +38,9 @@ class ImageReader
 
     private:
 
-        std::string             name_;
+        string                  name_;
         LLGL::TextureDescriptor texDesc_;
-        std::vector<char>       data_;
+        vector<char>            data_;
 
 };
 

--- a/examples/Cpp/ExampleBase/PerlinNoise.cpp
+++ b/examples/Cpp/ExampleBase/PerlinNoise.cpp
@@ -99,7 +99,7 @@ float PerlinNoise::Noise(float x, float y, float z, std::uint32_t frequency, std
 }
 
 void PerlinNoise::GenerateBuffer(
-    std::vector<float>& buffer,
+    vector<float>& buffer,
     std::uint32_t       width,
     std::uint32_t       height,
     std::uint32_t       depth,
@@ -136,7 +136,7 @@ void PerlinNoise::GenerateBuffer(
 }
 
 void PerlinNoise::GenerateBuffer(
-    std::vector<std::uint8_t>&  buffer,
+    vector<std::uint8_t>&  buffer,
     std::uint32_t               width,
     std::uint32_t               height,
     std::uint32_t               depth,

--- a/examples/Cpp/ExampleBase/PerlinNoise.h
+++ b/examples/Cpp/ExampleBase/PerlinNoise.h
@@ -11,7 +11,7 @@
 
 #include <cstddef>
 #include <cstdint>
-#include <vector>
+#include <LLGL/Container/Vector.h>
 #include <Gauss/Vector3.h>
 
 
@@ -32,7 +32,7 @@ class PerlinNoise
 
         // Generates a perlin noise pattern into the output buffer.
         void GenerateBuffer(
-            std::vector<float>& buffer,
+            vector<float>& buffer,
             std::uint32_t       width,
             std::uint32_t       height,
             std::uint32_t       depth,
@@ -43,7 +43,7 @@ class PerlinNoise
 
         // Generates a perlin noise pattern into the output buffer.
         void GenerateBuffer(
-            std::vector<std::uint8_t>&  buffer,
+            vector<std::uint8_t>&  buffer,
             std::uint32_t               width,
             std::uint32_t               height,
             std::uint32_t               depth,

--- a/examples/Cpp/Fonts/Example.cpp
+++ b/examples/Cpp/Fonts/Example.cpp
@@ -10,7 +10,7 @@
 #include <LLGL/Platform/Platform.h>
 #include <chrono>
 #include <sstream>
-#include <map>
+#include <LLGL/Container/Map.h>
 
 
 class Example_Fonts : public ExampleBase
@@ -25,7 +25,7 @@ class Example_Fonts : public ExampleBase
     LLGL::Sampler*              linearSampler       = nullptr;
 
     struct Font;
-    std::vector<Font>           fonts;
+    vector<Font>           fonts;
     std::size_t                 selectedFontProfile = 1; // 0 = small fonts, 1 = large fonts
 
     // Vertex for a font glyph
@@ -80,7 +80,7 @@ class Example_Fonts : public ExampleBase
         DrawShadow          = (1 << 3),
     };
 
-    std::vector<Vertex> vertexBatch;                    // Dynamic array list for glyph batch
+    vector<Vertex> vertexBatch;                    // Dynamic array list for glyph batch
     std::uint32_t       currentBatchSize    = 0;        // Number of glyphs in the current batch
     std::uint32_t       numBatches          = 0;
     LLGL::Texture*      currentAtlasTexture = nullptr;
@@ -173,7 +173,7 @@ private:
     {
         Font font;
 
-        const std::string fontAtlasName = std::string(fontName) + ".atlas-" + std::to_string(fontSize);
+        const string fontAtlasName = string(fontName) + ".atlas-" + std::to_string(fontSize);
 
         // Load glyph texture as alpha-only texture (automatically interprets color input as alpha channel for transparency)
         font.atlasTexture = LoadTexture(
@@ -197,10 +197,10 @@ private:
         fonts.push_back(std::move(font));
     }
 
-    bool BuildGlyphSet(Font& font, const std::string& mapFilename, char firstChar, char lastChar, std::uint32_t atlasWidth, std::uint32_t atlasHeight)
+    bool BuildGlyphSet(Font& font, const string& mapFilename, char firstChar, char lastChar, std::uint32_t atlasWidth, std::uint32_t atlasHeight)
     {
         // Read glyph map from text file
-        std::vector<std::string> lines = ReadTextLines(mapFilename);
+        vector<string> lines = ReadTextLines(mapFilename);
         if (lines.empty())
         {
             LLGL::Log::Errorf("Failed to read font map: %s\n", mapFilename.c_str());
@@ -212,10 +212,10 @@ private:
             int x0, y0, x1, y1, offset[2], spacing;
         };
 
-        std::map<char, GlyphMapping> mappings;
+        map<char, GlyphMapping> mappings;
 
         // Read glyph mapping, i.e. bounding box within texture atlas, offset, and spacing, line by line
-        for (const std::string& ln : lines)
+        for (const string& ln : lines)
         {
             // Ignore empty lines and comments (staging with '#')
             if (ln.empty() || ln.front() == '#')
@@ -396,7 +396,7 @@ private:
         return DrawFontPrimary(font, text, x, y, color);
     }
 
-    int DrawFont(const Font& font, const std::string& text, int x, int y, const LLGL::ColorRGBAub& color, long flags = 0)
+    int DrawFont(const Font& font, const string& text, int x, int y, const LLGL::ColorRGBAub& color, long flags = 0)
     {
         return DrawFont(font, text.c_str(), x, y, color, flags);
     }
@@ -473,7 +473,7 @@ private:
 
         // Draw swap-chain configuration
         DrawFont(
-            fntA, std::string("Vsync (Space bar): ") + (config.vsync ? "Enabled" : "Disabled"),
+            fntA, string("Vsync (Space bar): ") + (config.vsync ? "Enabled" : "Disabled"),
             paragraphMargin, paragraphPosY, colorYellow, fontFlags
         );
         paragraphPosY += fntA.fontHeight + textMargin;
@@ -488,7 +488,7 @@ private:
 
         // Draw rendering configuration
         DrawFont(
-            fntA, std::string("Draw Shadow (S): ") + (config.shadow ? "Enabled" : "Disabled"),
+            fntA, string("Draw Shadow (S): ") + (config.shadow ? "Enabled" : "Disabled"),
             paragraphMargin, paragraphPosY, colorYellow, fontFlags
         );
         paragraphPosY += fntA.fontHeight + textMargin;
@@ -501,7 +501,7 @@ private:
         );
 
         // Draw paragraph word by word
-        static const std::string paragraph =
+        static const string paragraph =
         (
             "This example demonstrates how to efficiently render text onto "
             "the screen using a font atlas and batched draw calls. "
@@ -511,14 +511,14 @@ private:
 
         int paragraphPosX = paragraphMargin;
         paragraphPosY += fntA.fontHeight + paragraphMargin;
-        std::string word;
+        string word;
 
         for (std::size_t start = 0, end = 0; start < paragraph.size(); start = end)
         {
             // Draw next word
             end = paragraph.find(' ', start);
 
-            if (end != std::string::npos)
+            if (end != string::npos)
             {
                 end++;
                 word = paragraph.substr(start, end - start);

--- a/examples/Cpp/HelloGame/HelloGame.cpp
+++ b/examples/Cpp/HelloGame/HelloGame.cpp
@@ -213,12 +213,12 @@ class Example_HelloGame : public ExampleBase
 
     struct TileRow
     {
-        std::vector<Tile> tiles;
+        vector<Tile> tiles;
     };
 
     struct TileGrid
     {
-        std::vector<TileRow>    rows;
+        vector<TileRow>    rows;
         int                     gridSize[2] = {}; // Bounding box in grid coordinates
 
         void Resize(int width, int height)
@@ -302,21 +302,21 @@ class Example_HelloGame : public ExampleBase
 
     struct Level
     {
-        std::string             name;
-        LLGL::ColorRGBub        wallColors[2];
-        TileGrid                floor;
-        TileGrid                walls;
-        std::vector<Decor>      trees;
-        std::vector<Instance>   meshInstances;
-        InstanceRange           meshInstanceDirtyRange;
-        InstanceRange           tileInstanceRange;
-        InstanceRange           treeInstanceRange;
-        int                     gridSize[2]                 = {}; // Bounding box in grid coordinates
-        int                     playerStart[2]              = {};
-        float                   viewDistance                = 0.0f;
-        int                     activatedTiles              = 0;
-        int                     maxTilesToActivate          = 0;
-        float                   lightPhase                  = 0.0f;
+        string             name;
+        LLGL::ColorRGBub   wallColors[2];
+        TileGrid           floor;
+        TileGrid           walls;
+        vector<Decor>      trees;
+        vector<Instance>   meshInstances;
+        InstanceRange      meshInstanceDirtyRange;
+        InstanceRange      tileInstanceRange;
+        InstanceRange      treeInstanceRange;
+        int                gridSize[2]                 = {}; // Bounding box in grid coordinates
+        int                playerStart[2]              = {};
+        float              viewDistance                = 0.0f;
+        int                activatedTiles              = 0;
+        int                maxTilesToActivate          = 0;
+        float              lightPhase                  = 0.0f;
 
         bool IsWall(int x, int y) const
         {
@@ -559,7 +559,7 @@ class Example_HelloGame : public ExampleBase
     {
         static constexpr std::uint32_t  cbufferNumInstances = 64u;      // This must match MAX_NUM_INSTANCES in ESSL shaders
 
-        std::vector<LLGL::Buffer*>      segments;                       // Buffer segments
+        vector<LLGL::Buffer*>      segments;                       // Buffer segments
         std::uint64_t                   sizePerSegment      = 0;        // Size (in bytes) per segment
         std::uint32_t                   capacity            = 0;        // Number of instances the instance buffer can hold
         std::uint64_t                   bufferLimit         = 0;
@@ -598,7 +598,7 @@ class Example_HelloGame : public ExampleBase
                 numInstances = std::max<std::uint32_t>(numInstances, cbufferNumInstances);
 
             // Check if number of instances will exceed limit
-            std::string bufferName;
+            string bufferName;
             const std::uint64_t bufferSize = sizeof(Instance) * numInstances;
 
             sizePerSegment = std::min<std::uint64_t>(bufferLimit, (isCbuffer ? sizeof(Instance) * cbufferNumInstances : bufferSize));
@@ -713,7 +713,7 @@ class Example_HelloGame : public ExampleBase
         }
     };
 
-    std::vector<Level>  levels;
+    vector<Level>  levels;
     int                 currentLevelIndex           = -1;
     Level*              currentLevel                = nullptr;
     Level*              nextLevel                   = nullptr;
@@ -795,7 +795,7 @@ private:
         };
 
         // Load 3D models
-        std::vector<TexturedVertex> vertices;
+        vector<TexturedVertex> vertices;
         mdlPlayer   = LoadObjModel(vertices, "HelloGame_Player.obj");
         mdlBlock    = LoadObjModel(vertices, "HelloGame_Block.obj");
         mdlTree     = LoadObjModel(vertices, "HelloGame_Tree.obj");
@@ -863,7 +863,7 @@ private:
         return vertexFormat;
     }
 
-    static std::string BytesToString(std::uint64_t val)
+    static string BytesToString(std::uint64_t val)
     {
         char buf[128] = { '\0' };
         if (val / 1024 / 1024 / 1024 > 0)
@@ -874,7 +874,7 @@ private:
             ::sprintf(buf, "%.2f KiB", static_cast<double>(val) / 1024.0);
         else
             ::sprintf(buf, "%" PRIu64 " Bytes", val);
-        return std::string(buf);
+        return string(buf);
     }
 
     void CreateShaders(const LLGL::VertexFormat& vertexFormat)
@@ -1115,7 +1115,7 @@ private:
         instance.color[3] = 1.0f;
     }
 
-    void GenerateTileInstances(TileGrid& grid, std::vector<Instance>& meshInstances, std::uint32_t& instanceCounter, float posY, const Gradient* gradient)
+    void GenerateTileInstances(TileGrid& grid, vector<Instance>& meshInstances, std::uint32_t& instanceCounter, float posY, const Gradient* gradient)
     {
         int gridPos[2];
 
@@ -1134,7 +1134,7 @@ private:
         }
     }
 
-    void GenerateDecorInstances(std::vector<Decor>& decors, std::vector<Instance>& meshInstances, std::uint32_t& instanceCounter, const Gradient* gradient)
+    void GenerateDecorInstances(vector<Decor>& decors, vector<Instance>& meshInstances, std::uint32_t& instanceCounter, const Gradient* gradient)
     {
         for (Decor& decor : decors)
         {
@@ -1174,11 +1174,11 @@ private:
     void LoadLevels()
     {
         // Load level files
-        const std::vector<std::string> levelsFileLines = ReadTextLines("HelloGame.levels.txt");
+        const vector<string> levelsFileLines = ReadTextLines("HelloGame.levels.txt");
 
-        std::string name;
-        std::string wallGradient;
-        std::vector<std::string> currentGrid;
+        string name;
+        string wallGradient;
+        vector<string> currentGrid;
         float timeOfDay = 0.0f;
 
         auto HexToInt = [](char c) -> int
@@ -1193,7 +1193,7 @@ private:
                 return -1;
         };
 
-        auto FloatFromString = [](const std::string& s) -> float
+        auto FloatFromString = [](const string& s) -> float
         {
             std::stringstream sstr(s);
             float val = 0.0f;
@@ -1255,9 +1255,9 @@ private:
 
             for_range(i, currentGrid.size())
             {
-                const std::string& row = currentGrid[i];
+                const string& row = currentGrid[i];
                 const std::size_t rowStart = row.find_first_of(".#@");
-                if (rowStart != std::string::npos)
+                if (rowStart != string::npos)
                 {
                     gridOffset[0] = std::min<int>(gridOffset[0], static_cast<int>(rowStart));
                     gridOffset[1] = std::min<int>(gridOffset[1], static_cast<int>(i));
@@ -1274,7 +1274,7 @@ private:
             initialTile.instanceIndex = 0;
 
             int gridPosY = newLevel.gridSize[1] + gridOffset[1];
-            for (const std::string& row : currentGrid)
+            for (const string& row : currentGrid)
             {
                 --gridPosY;
                 int gridPosX = -gridOffset[0];
@@ -1320,7 +1320,7 @@ private:
             name.clear();
         };
 
-        for (const std::string& line : levelsFileLines)
+        for (const string& line : levelsFileLines)
         {
             if (line.empty())
                 FlushLevelConstruct();

--- a/examples/Cpp/HelloTriangle/Example.cpp
+++ b/examples/Cpp/HelloTriangle/Example.cpp
@@ -35,7 +35,7 @@ int main(int argc, char* argv[])
         rendererDesc.moduleName = "OpenGLES3";
         rendererDesc.androidApp = androidApp;
         #else
-        const std::string rendererModule = GetSelectedRendererModule(argc, argv);
+        const string rendererModule = GetSelectedRendererModule(argc, argv);
         rendererDesc.moduleName = rendererModule;
         #endif
 
@@ -204,7 +204,7 @@ int main(int argc, char* argv[])
         #if ENABLE_CACHED_PSO
 
         // Try to read PSO cache from file
-        const std::string cacheFilename = "GraphicsPSO." + rendererModule + ".cache";
+        const string cacheFilename = "GraphicsPSO." + rendererModule + ".cache";
         bool hasInitialCache = false;
 
         LLGL::Blob pipelineCacheBlob = LLGL::Blob::CreateFromFile(cacheFilename);

--- a/examples/Cpp/Instancing/Example.cpp
+++ b/examples/Cpp/Instancing/Example.cpp
@@ -88,7 +88,7 @@ private:
         return a + (b - a) * rnd;
     }
 
-    std::vector<LLGL::VertexFormat> CreateBuffers()
+    vector<LLGL::VertexFormat> CreateBuffers()
     {
         // Initialize per-vertex data (4 vertices for the plane of each plant)
         static const float grassSize    = 100.0f;
@@ -122,7 +122,7 @@ private:
             Gs::Matrix4f    wMatrix;    // World matrix
         };
 
-        std::vector<Instance> instanceData(numPlantInstances + 1);
+        vector<Instance> instanceData(numPlantInstances + 1);
 
         for (std::size_t i = 0; i < numPlantInstances; ++i)
         {
@@ -209,9 +209,9 @@ private:
 
     void CreateTextures()
     {
-        std::string filename;
+        string filename;
 
-        std::vector<char> arrayImageBuffer;
+        vector<char> arrayImageBuffer;
 
         // Load all array images
         std::uint32_t width = 0, height = 0;
@@ -285,7 +285,7 @@ private:
         samplers[0] = renderer->CreateSampler(samplerDesc);
     }
 
-    void CreatePipelines(const std::vector<LLGL::VertexFormat>& vertexFormats)
+    void CreatePipelines(const vector<LLGL::VertexFormat>& vertexFormats)
     {
         // Create shaders
         vertexShader    = LoadStandardVertexShader("VS", vertexFormats);

--- a/examples/Cpp/MultiRenderer/Example.cpp
+++ b/examples/Cpp/MultiRenderer/Example.cpp
@@ -125,10 +125,10 @@ MyRenderer::MyRenderer(
     swapChain->SetVsyncInterval(1);
 }
 
-static std::string GetRendererModuleName(std::string rendererName)
+static string GetRendererModuleName(string rendererName)
 {
     // Remove white spaces from name
-    std::string name = std::regex_replace(rendererName, std::regex("\\s+"), "");
+    string name = std::regex_replace(rendererName, std::regex("\\s+"), "");
     return (name.compare(0, 6, "OpenGL") == 0 ? "OpenGL" : name);
 }
 
@@ -156,7 +156,7 @@ void MyRenderer::CreateResources(const LLGL::ArrayView<TexturedVertex>& vertices
     constantBuffer = renderer->CreateBuffer(LLGL::ConstantBufferDesc(sizeof(Matrices)));
 
     // Create textures
-    const std::string rendererName = GetRendererModuleName(renderer->GetName());
+    const string rendererName = GetRendererModuleName(renderer->GetName());
     texture = LoadTextureWithRenderer(*renderer, "Logo_" + rendererName + ".png");
 
     // Create samplers
@@ -387,7 +387,7 @@ int main(int argc, char* argv[])
         };
 
         // Set window title with all renderer names
-        std::string rendererNames;
+        string rendererNames;
         for (LLGL::RenderSystem* sys : rendererRefs)
         {
             if (!rendererNames.empty())
@@ -395,7 +395,7 @@ int main(int argc, char* argv[])
             rendererNames += sys->GetName();
         }
 
-        mainWindow->SetTitle(std::string(mainWindowDesc.title) + " ( " + rendererNames + " )");
+        mainWindow->SetTitle(string(mainWindowDesc.title) + " ( " + rendererNames + " )");
         mainWindow->Show();
 
         // Create resources

--- a/examples/Cpp/MultiThreading/Example.cpp
+++ b/examples/Cpp/MultiThreading/Example.cpp
@@ -26,7 +26,7 @@ class Measure
     public:
 
         // Interval (in milliseconds) to the next measurement result.
-        Measure(std::uint64_t interval = 1000, const std::string& title = "Average Time") :
+        Measure(std::uint64_t interval = 1000, const string& title = "Average Time") :
             interval_ { interval },
             title_    { title    }
         {
@@ -81,7 +81,7 @@ class Measure
         TimePoint       intervalStartTime_;
         std::uint64_t   samples_            = 0;
         std::uint64_t   elapsed_            = 0;
-        std::string     title_;
+        string          title_;
 
 };
 
@@ -199,7 +199,7 @@ private:
         bundle[1].pipeline = renderer->CreatePipelineState(pipelineDesc);
     }
 
-    static void PrintThreadsafe(std::mutex& mtx, const std::string& text)
+    static void PrintThreadsafe(std::mutex& mtx, const string& text)
     {
         std::lock_guard<std::mutex> guard { mtx };
         printf("%s\n", text.c_str());
@@ -209,7 +209,7 @@ private:
         Bundle&         bundle,
         std::uint32_t   numIndices,
         std::mutex&     mtx,
-        std::string     threadName)
+        string          threadName)
     {
         // Print thread start
         PrintThreadsafe(mtx, "Enter thread: " + threadName);
@@ -229,7 +229,7 @@ private:
         PrintThreadsafe(mtx, "Leave thread: " + threadName);
     }
 
-    void EncodePrimaryCommandBuffer(LLGL::CommandBuffer& cmdBuffer, std::uint32_t swapBufferIndex, const std::string& threadName = "")
+    void EncodePrimaryCommandBuffer(LLGL::CommandBuffer& cmdBuffer, std::uint32_t swapBufferIndex, const string& threadName = "")
     {
         // Print thread start
         if (!threadName.empty())

--- a/examples/Cpp/PBR/Example.cpp
+++ b/examples/Cpp/PBR/Example.cpp
@@ -34,7 +34,7 @@ class Example_PBR : public ExampleBase
     LLGL::ResourceHeap*         resourceHeapMeshes  = nullptr;
     LLGL::ResourceHeap*         resourceHeapSkybox  = nullptr;
 
-    std::vector<TriangleMesh>   meshes;
+    vector<TriangleMesh>   meshes;
 
     struct Settings
     {
@@ -96,7 +96,7 @@ private:
         vertexFormat.AppendAttribute({ "texCoord",  LLGL::Format::RG32Float  });
 
         // Load 3D models
-        std::vector<TexturedVertex> vertices;
+        vector<TexturedVertex> vertices;
         meshes.push_back(LoadObjModel(vertices, "UVSphere.obj"));
         meshes.push_back(LoadObjModel(vertices, "WiredBox.obj"));
 
@@ -203,7 +203,7 @@ private:
         pipelineMeshes = renderer->CreatePipelineState(pipelineDescMeshes);
     }
 
-    bool LoadImageSlice(const std::string& filename, std::uint32_t& texWidth, std::uint32_t& texHeight, std::vector<std::uint8_t>& imageData)
+    bool LoadImageSlice(const string& filename, std::uint32_t& texWidth, std::uint32_t& texHeight, vector<std::uint8_t>& imageData)
     {
         // Print information about current texture
         LLGL::Log::Printf("load image: \"%s\"\n", filename.c_str());
@@ -235,7 +235,7 @@ private:
         return true;
     }
 
-    void FillImageSlice(std::uint32_t& texWidth, std::uint32_t& texHeight, std::vector<std::uint8_t>& imageData)
+    void FillImageSlice(std::uint32_t& texWidth, std::uint32_t& texHeight, vector<std::uint8_t>& imageData)
     {
         // Initialize texture size with default value if necessary
         if (texWidth == 0)
@@ -252,14 +252,14 @@ private:
     }
 
     // Loads multiple images into one texture array or cube-map array
-    LLGL::Texture* LoadTextureArray(const LLGL::TextureType texType, const std::initializer_list<std::string>& texFilenames)
+    LLGL::Texture* LoadTextureArray(const LLGL::TextureType texType, const std::initializer_list<string>& texFilenames)
     {
         // Load image data
         std::uint32_t texWidth = 0, texHeight = 0;
-        std::vector<std::uint8_t> imageData;
+        vector<std::uint8_t> imageData;
         std::uint32_t numImageSlices = 0;
 
-        for (const std::string& filename : texFilenames)
+        for (const string& filename : texFilenames)
         {
             if (filename.empty())
             {
@@ -379,7 +379,7 @@ private:
         resourceHeapSkybox->SetDebugName("resourceHeapSkybox");
 
         // Create resource heap for meshes
-        std::vector<LLGL::ResourceViewDescriptor> resourceViewsMeshes =
+        vector<LLGL::ResourceViewDescriptor> resourceViewsMeshes =
         {
             constantBuffer,
             linearSampler,

--- a/examples/Cpp/RenderTarget/Example.cpp
+++ b/examples/Cpp/RenderTarget/Example.cpp
@@ -62,7 +62,7 @@ class Example_RenderTarget : public ExampleBase
 
     #if ENABLE_CBUFFER_RANGE
     std::uint64_t           cbufferAlignment        = 0;
-    std::vector<char>       cbufferData;
+    vector<char>       cbufferData;
     #endif
 
     #if ENABLE_CUSTOM_MULTISAMPLING

--- a/examples/Cpp/ResourceBinding/Example.cpp
+++ b/examples/Cpp/ResourceBinding/Example.cpp
@@ -46,8 +46,8 @@ class Example_ResourceBinding : public ExampleBase
         std::uint32_t           instance            = 0;
     };
 
-    std::vector<Model>          models;
-    std::vector<TexturedVertex> vertices;
+    vector<Model>          models;
+    vector<TexturedVertex> vertices;
 
 public:
 
@@ -67,7 +67,7 @@ public:
 
 private:
 
-    void LoadModel(const std::string& filename, const Gs::Vector3f& position, int colorMapIndex, const float scale = 1.0f)
+    void LoadModel(const string& filename, const Gs::Vector3f& position, int colorMapIndex, const float scale = 1.0f)
     {
         static std::uint32_t instanceCounter;
         Model mdl;

--- a/examples/Cpp/ShadowMapping/Example.cpp
+++ b/examples/Cpp/ShadowMapping/Example.cpp
@@ -31,7 +31,7 @@ class Example_ShadowMapping : public ExampleBase
     const LLGL::Extent2D        shadowMapResolution     = { 256, 256 };
     LLGL::RenderTarget*         shadowMapRenderTarget   = nullptr;
 
-    std::vector<TriangleMesh>   meshes;
+    vector<TriangleMesh>   meshes;
 
     Gs::Vector3f                boxPosition             = { 0, 0, 0 };
     float                       viewDistanceToBox       = 1.25f;
@@ -84,7 +84,7 @@ private:
         vertexFormat.SetStride(sizeof(TexturedVertex));
 
         // Load 3D models
-        std::vector<TexturedVertex> vertices;
+        vector<TexturedVertex> vertices;
         meshes.push_back(LoadObjModel(vertices, "SimpleRoom.obj"));
         meshes.push_back(LoadObjModel(vertices, "WiredBox.obj"));
 

--- a/examples/Cpp/StencilBuffer/Example.cpp
+++ b/examples/Cpp/StencilBuffer/Example.cpp
@@ -77,7 +77,7 @@ private:
         vertexFormat.SetStride(sizeof(TexturedVertex));
 
         // Load 3D models
-        std::vector<TexturedVertex> vertices;
+        vector<TexturedVertex> vertices;
         meshScene   = LoadObjModel(vertices, "Portal-Scene.obj");
         meshPortal  = LoadObjModel(vertices, "Portal-Stencil.obj");
         meshObject1 = LoadObjModel(vertices, "WiredBox.obj");

--- a/examples/Cpp/Tessellation/Example.cpp
+++ b/examples/Cpp/Tessellation/Example.cpp
@@ -97,7 +97,7 @@ public:
 
         // Load cube model with minor pre-tessellation.
         // A cube with only 8 vertices would only allow a rough tessellation depending on the displacement map.
-        std::vector<TexturedVertex> texuturedVertices;
+        vector<TexturedVertex> texuturedVertices;
         model = LoadObjModel(texuturedVertices, "UVCube2x.obj", 4);
 
         // Create buffers for a simple 3D cube model

--- a/examples/Cpp/Texturing/Example.cpp
+++ b/examples/Cpp/Texturing/Example.cpp
@@ -122,7 +122,7 @@ public:
         pipeline = renderer->CreatePipelineState(pipelineDesc);
     }
 
-    void LoadUncompressedTexture(const std::string& filename)
+    void LoadUncompressedTexture(const string& filename)
     {
         // Load image data from file (using STBI library, see http://nothings.org/stb_image.h)
         ImageReader reader;
@@ -155,7 +155,7 @@ public:
         LLGL::Log::Printf("texture creation time: %f ms\n", texCreationTime * 1000.0);
     }
 
-    void LoadCompressedTexture(const std::string& filename)
+    void LoadCompressedTexture(const string& filename)
     {
         // Load DDS image
         DDSImageReader imageReader;
@@ -243,7 +243,7 @@ private:
                 resourceIndex = (resourceIndex + 1) % 4;
 #endif
 
-            const std::string spaces(30, ' ');
+            const string spaces(30, ' ');
             LLGL::Log::Printf(
                 "texture: %s%s\r",
                 resourceLabels[resourceIndex],

--- a/examples/Cpp/VolumeRendering/Example.cpp
+++ b/examples/Cpp/VolumeRendering/Example.cpp
@@ -88,7 +88,7 @@ private:
         vertexFormat.SetStride(sizeof(TexturedVertex));
 
         // Load 3D models
-        std::vector<TexturedVertex> vertices;
+        vector<TexturedVertex> vertices;
         mesh = LoadObjModel(vertices, "Suzanne.obj");
 
         // Create vertex, index, and constant buffer
@@ -164,7 +164,7 @@ private:
     void CreateTextures()
     {
         // Generate 3D perlin noise texture
-        std::vector<std::uint8_t> imageData;
+        vector<std::uint8_t> imageData;
         {
             perlinNoise.GenerateBuffer(imageData, noiseTextureSize, noiseTextureSize, noiseTextureSize, 4);
         }

--- a/include/LLGL/Blob.h
+++ b/include/LLGL/Blob.h
@@ -11,8 +11,8 @@
 
 #include <LLGL/NonCopyable.h>
 #include <LLGL/Container/DynamicArray.h>
-#include <vector>
-#include <string>
+#include <LLGL/Container/Vector.h>
+#include <LLGL/Container/String.h>
 #include <memory>
 
 
@@ -85,14 +85,14 @@ class LLGL_EXPORT Blob : public NonCopyable
         \param[in] cont Specifies the container whose data is to be moved into this Blob instance.
         \return New instance of Blob that manages the specified container.
         */
-        static Blob CreateStrongRef(std::vector<char>&& cont);
+        static Blob CreateStrongRef(vector<char>&& cont);
 
         /**
         \brief Creates a new Blob instance with a strong reference to the specified string container.
         \param[in] str Specifies the container whose data is to be moved into this Blob instance.
         \return New instance of Blob that manages the specified container.
         */
-        static Blob CreateStrongRef(std::string&& str);
+        static Blob CreateStrongRef(string&& str);
 
         /**
         \brief Creates a new Blob instance with the data read from the specified binary file.
@@ -106,7 +106,7 @@ class LLGL_EXPORT Blob : public NonCopyable
         \param[in] filename Specifies the file that is to be read.
         \return New instance of Blob that manages the memory of a conent copy from the specified file or null if the file could not be read.
         */
-        static Blob CreateFromFile(const std::string& filename);
+        static Blob CreateFromFile(const string& filename);
 
     public:
 

--- a/include/LLGL/Container/DynamicArray.h
+++ b/include/LLGL/Container/DynamicArray.h
@@ -125,7 +125,7 @@ class LLGL_EXPORT DynamicArray
             return size_;
         }
 
-        //! Convenience function to be partially compatible with \c std::vector<T>. Equivalent to \c size().
+        //! Convenience function to be partially compatible with \c vector<T>. Equivalent to \c size().
         size_type capacity() const noexcept
         {
             return size();

--- a/include/LLGL/Container/DynamicVector.h
+++ b/include/LLGL/Container/DynamicVector.h
@@ -18,7 +18,7 @@ namespace LLGL
 
 
 /**
-\brief Template alias to a SmallVector with zero local capacity. This is intended as alternative to \c std::vector in the public interface.
+\brief Template alias to a SmallVector with zero local capacity. This is intended as alternative to \c vector in the public interface.
 \remarks The SmallVector template also allows a local capacity of 0, which effectively disables the local storage and only performs dynamic allocations.
 \see SmallVector
 */

--- a/include/LLGL/Container/Map.h
+++ b/include/LLGL/Container/Map.h
@@ -1,0 +1,25 @@
+/*
+ * Map.h
+ *
+ * Copyright (c) 2015 Lukas Hermanns. All rights reserved.
+ * Licensed under the terms of the BSD 3-Clause license (see LICENSE.txt).
+ */
+
+#ifndef LLGL_MAP_H
+#define LLGL_MAP_H
+
+#ifndef LLGL_REPLACE_STD_MAP
+#include <map>
+#endif
+
+#ifdef LLGL_REPLACE_STD_MAP
+template < typename Key, typename Value, typename Less >
+using map = LLGL_CUSTOM_MAP;
+#else
+template < typename Key, typename Value, typename Less = std::less< Key > >
+using map = std::map< Key, Value, Less >;
+#endif
+
+#endif
+
+// ================================================================================

--- a/include/LLGL/Container/Set.h
+++ b/include/LLGL/Container/Set.h
@@ -1,0 +1,25 @@
+/*
+ * Set.h
+ *
+ * Copyright (c) 2015 Lukas Hermanns. All rights reserved.
+ * Licensed under the terms of the BSD 3-Clause license (see LICENSE.txt).
+ */
+
+#ifndef LLGL_SET_H
+#define LLGL_SET_H
+
+#ifndef LLGL_REPLACE_STD_SET
+#include <set>
+#endif
+
+#ifdef LLGL_REPLACE_STD_SET
+template < typename Type >
+using set = LLGL_CUSTOM_SET;
+#else
+template < typename Type >
+using set = std::set< Type >;
+#endif
+
+#endif
+
+// ================================================================================

--- a/include/LLGL/Container/Stack.h
+++ b/include/LLGL/Container/Stack.h
@@ -1,0 +1,25 @@
+/*
+ * Stack.h
+ *
+ * Copyright (c) 2015 Lukas Hermanns. All rights reserved.
+ * Licensed under the terms of the BSD 3-Clause license (see LICENSE.txt).
+ */
+
+#ifndef LLGL_STACK_H
+#define LLGL_STACK_H
+
+#ifndef LLGL_REPLACE_STD_STACK
+#include <stack>
+#endif
+
+#ifdef LLGL_REPLACE_STD_STACK
+template < typename Type >
+using stack = LLGL_CUSTOM_STACK;
+#else
+template < typename Type >
+using stack = std::stack< Type >;
+#endif
+
+#endif
+
+// ================================================================================

--- a/include/LLGL/Container/String.h
+++ b/include/LLGL/Container/String.h
@@ -1,0 +1,25 @@
+/*
+ * String.h
+ *
+ * Copyright (c) 2015 Lukas Hermanns. All rights reserved.
+ * Licensed under the terms of the BSD 3-Clause license (see LICENSE.txt).
+ */
+
+#ifndef LLGL_STRING_H
+#define LLGL_STRING_H
+
+#ifndef LLGL_REPLACE_STD_STRING
+#include <string>
+#endif
+
+#ifdef LLGL_REPLACE_STD_STRING
+typedef LLGL_CUSTOM_STRING  string;
+typedef LLGL_CUSTOM_WSTRING wstring;
+#else
+typedef std::string  string;
+typedef std::wstring wstring;
+#endif
+
+#endif
+
+// ================================================================================

--- a/include/LLGL/Container/StringLiteral.h
+++ b/include/LLGL/Container/StringLiteral.h
@@ -189,7 +189,7 @@ class LLGL_EXPORT BasicStringLiteral
 
         /**
         \brief Returns the raw pointer of this string literal.
-        \remarks This points to a NUL-terminated string like \c std::string does.
+        \remarks This points to a NUL-terminated string like \c string does.
         */
         const_pointer c_str() const noexcept
         {

--- a/include/LLGL/Container/StringView.h
+++ b/include/LLGL/Container/StringView.h
@@ -10,7 +10,7 @@
 
 
 #include <LLGL/Export.h>
-#include <string>
+#include <LLGL/Container/String.h>
 #include <cstddef>
 #include <iterator>
 #include <algorithm>
@@ -114,7 +114,7 @@ class LLGL_EXPORT BasicStringView
 
         /**
         \brief Returns the raw pointer of this string view.
-        \remarks This does not necessarily point to a NUL-terminated string like \c std::string does.
+        \remarks This does not necessarily point to a NUL-terminated string like \c string does.
         A string view only covers a range from the first to the last character of a string whose memory is managed elsewhere.
         */
         const_pointer data() const noexcept

--- a/include/LLGL/Container/Vector.h
+++ b/include/LLGL/Container/Vector.h
@@ -1,0 +1,25 @@
+/*
+ * Vector.h
+ *
+ * Copyright (c) 2015 Lukas Hermanns. All rights reserved.
+ * Licensed under the terms of the BSD 3-Clause license (see LICENSE.txt).
+ */
+
+#ifndef LLGL_VECTOR_H
+#define LLGL_VECTOR_H
+
+#ifndef LLGL_REPLACE_STD_VECTOR
+#include <vector>
+#endif
+
+#ifdef LLGL_REPLACE_STD_VECTOR
+template < typename Type >
+using vector = LLGL_CUSTOM_VECTOR;
+#else
+template < typename Type >
+using vector = std::vector< Type >;
+#endif
+
+#endif
+
+// ================================================================================

--- a/include/LLGL/Display.h
+++ b/include/LLGL/Display.h
@@ -12,7 +12,7 @@
 #include <LLGL/Interface.h>
 #include <LLGL/DisplayFlags.h>
 #include <LLGL/Container/Strings.h>
-#include <vector>
+#include <LLGL/Container/Vector.h>
 
 
 namespace LLGL
@@ -148,7 +148,7 @@ class LLGL_EXPORT Display : public Interface
         To get only the currently active display mode, use GetDisplayMode.
         \see GetDisplayMode
         */
-        virtual std::vector<DisplayMode> GetSupportedDisplayModes() const = 0;
+        virtual vector<DisplayMode> GetSupportedDisplayModes() const = 0;
 
     protected:
 
@@ -156,7 +156,7 @@ class LLGL_EXPORT Display : public Interface
         \brief Sorts the specified list of display modes as described in the GetSupportedDisplayModes function, and removes duplicate entries.
         \see GetSupportedDisplayModes
         */
-        static void FinalizeDisplayModes(std::vector<DisplayMode>& displayMode);
+        static void FinalizeDisplayModes(vector<DisplayMode>& displayMode);
 
 };
 

--- a/include/LLGL/FragmentAttribute.h
+++ b/include/LLGL/FragmentAttribute.h
@@ -12,7 +12,7 @@
 #include <LLGL/Format.h>
 #include <LLGL/SystemValue.h>
 #include <LLGL/Container/StringLiteral.h>
-#include <string>
+#include <LLGL/Container/String.h>
 #include <cstdint>
 #include <utility>
 

--- a/include/LLGL/PipelineLayoutFlags.h
+++ b/include/LLGL/PipelineLayoutFlags.h
@@ -16,7 +16,7 @@
 #include <LLGL/ShaderFlags.h>
 #include <LLGL/Container/StringView.h>
 #include <LLGL/Container/StringLiteral.h>
-#include <vector>
+#include <LLGL/Container/Vector.h>
 #include <utility>
 
 
@@ -485,7 +485,7 @@ struct PipelineLayoutDescriptor
     \see ResourceViewDescriptor
     \see ResourceHeap::GetNumDescriptorSets
     */
-    std::vector<BindingDescriptor>                  heapBindings;
+    vector<BindingDescriptor>                  heapBindings;
 
     /**
     \brief List of individual layout resource bindings.
@@ -493,13 +493,13 @@ struct PipelineLayoutDescriptor
     \remarks Individual bindings are limited to binding the entire resource as opposed to heap bindigs that can also bind a subresource view.
     \see CommandBuffer::SetResource
     */
-    std::vector<BindingDescriptor>                  bindings;
+    vector<BindingDescriptor>                  bindings;
 
     /**
     \brief List of static sampler states with their binding points.
     \remarks These sampler states are immutable and are automatically bound with each pipeline state.
     */
-    std::vector<StaticSamplerDescriptor>            staticSamplers;
+    vector<StaticSamplerDescriptor>            staticSamplers;
 
     /**
     \brief List of shader uniforms that can be written dynamically.
@@ -516,7 +516,7 @@ struct PipelineLayoutDescriptor
     Only static samplers are not counted towards root parameters.
     \see CommandBuffer::SetUniforms
     */
-    std::vector<UniformDescriptor>                  uniforms;
+    vector<UniformDescriptor>                  uniforms;
 
     /**
     \brief List of combined texture-samplers.
@@ -526,7 +526,7 @@ struct PipelineLayoutDescriptor
     this is required unless each texture binding in the pipeline layout has its own sampler binding at the same binding slot.
     \note Only supported with: OpenGL (Vulkan will be supported next).
     */
-    std::vector<CombinedTextureSamplerDescriptor>   combinedTextureSamplers;
+    vector<CombinedTextureSamplerDescriptor>   combinedTextureSamplers;
 
     /**
     \brief Specifies optional resource barrier flags. By default 0.

--- a/include/LLGL/PipelineStateFlags.h
+++ b/include/LLGL/PipelineStateFlags.h
@@ -14,7 +14,7 @@
 #include <LLGL/Format.h>
 #include <LLGL/ForwardDecls.h>
 #include <LLGL/Constants.h>
-#include <vector>
+#include <LLGL/Container/Vector.h>
 #include <cstdint>
 
 
@@ -839,7 +839,7 @@ struct GraphicsPipelineDescriptor
     \see CommandBuffer::SetViewport
     \see CommandBuffer::SetViewports
     */
-    std::vector<Viewport>   viewports;
+    vector<Viewport>   viewports;
 
     /**
     \brief Specifies an optional list of static scissor rectangles. If empty, the scissors must be set dynamically with the command buffer.
@@ -847,7 +847,7 @@ struct GraphicsPipelineDescriptor
     \see CommandBuffer::SetScissor
     \see CommandBuffer::SetScissors
     */
-    std::vector<Scissor>    scissors;
+    vector<Scissor>    scissors;
 
     //! Specifies the depth state for the depth-stencil stage.
     DepthDescriptor         depth;

--- a/include/LLGL/RenderSystem.h
+++ b/include/LLGL/RenderSystem.h
@@ -44,9 +44,9 @@
 #include <LLGL/Texture.h>
 #include <LLGL/TextureFlags.h>
 
-#include <string>
+#include <LLGL/Container/String.h>
 #include <memory>
-#include <vector>
+#include <LLGL/Container/Vector.h>
 #include <cstdint>
 
 
@@ -138,7 +138,7 @@ class LLGL_EXPORT RenderSystem : public Interface
         \brief Returns the list of all available render system modules for the current platform.
         \remarks For example, on Win32 this might be <code>{ "Direct3D12", "Direct3D11", "OpenGL" }</code>, but on MacOS it might be <code>{ "Metal", "OpenGL" }</code>.
         */
-        static std::vector<std::string> FindModules();
+        static vector<string> FindModules();
 
         /**
         \brief Loads a new render system from the specified module.
@@ -402,7 +402,7 @@ class LLGL_EXPORT RenderSystem : public Interface
         auto myTextureExtent = myTexture->GetMipExtent(0);
 
         // Allocate image buffer with elements in all dimensions
-        std::vector<std::uint8_t> myImage(myTextureExtent.width * myTextureExtent.height * myTextureExtent.depth * 4);
+        vector<std::uint8_t> myImage(myTextureExtent.width * myTextureExtent.height * myTextureExtent.depth * 4);
 
         // Initialize destination image descriptor
         const MutableImageView myImageView {

--- a/include/LLGL/RenderSystemFlags.h
+++ b/include/LLGL/RenderSystemFlags.h
@@ -26,8 +26,8 @@
 
 #include <cstddef>
 #include <cstdint>
-#include <string>
-#include <vector>
+#include <LLGL/Container/String.h>
+#include <LLGL/Container/Vector.h>
 #include <functional>
 
 
@@ -300,7 +300,7 @@ struct RendererInfo
     UTF8String              shadingLanguageName;
 
     //! List of enabled renderer extensions (e.g. "GL_ARB_direct_state_access" or "VK_EXT_conditional_rendering").
-    std::vector<UTF8String> extensionNames;
+    vector<UTF8String> extensionNames;
 
     /**
     \brief Arbitrary string used to identify invalidated pipeline caches.
@@ -310,7 +310,7 @@ struct RendererInfo
     \see RenderSystem::CreatePipelineCache
     \see RenderingFeatures::hasPipelineCaching
     */
-    std::vector<char>       pipelineCacheID;
+    vector<char>       pipelineCacheID;
 };
 
 /**
@@ -324,8 +324,8 @@ struct RenderSystemDescriptor
     RenderSystemDescriptor(const RenderSystemDescriptor&) = default;
     RenderSystemDescriptor& operator = (const RenderSystemDescriptor&) = default;
 
-    //! Constructor to initialize the descriptor with the module name from an std::string.
-    inline RenderSystemDescriptor(const std::string& moduleName) :
+    //! Constructor to initialize the descriptor with the module name from an string.
+    inline RenderSystemDescriptor(const string& moduleName) :
         moduleName { moduleName }
     {
     }
@@ -895,13 +895,13 @@ struct RenderingCapabilities
     \see Shader::Compile
     \see Shader::LoadBinary
     */
-    std::vector<ShadingLanguage>    shadingLanguages;
+    vector<ShadingLanguage>    shadingLanguages;
 
     /**
     \brief Specifies the list of supported hardware texture formats.
     \see Format
     */
-    std::vector<Format>             textureFormats;
+    vector<Format>             textureFormats;
 
     /**
     \brief Specifies all supported hardware features.
@@ -927,7 +927,7 @@ struct RenderingCapabilities
 \see ValidateRenderingCaps
 \ingroup group_callbacks
 */
-using ValidateRenderingCapsFunc = std::function<bool(const std::string& info, const std::string& attrib)>;
+using ValidateRenderingCapsFunc = std::function<bool(const string& info, const string& attrib)>;
 
 /**
 \brief Validates the presence of the specified required rendering capabilities.
@@ -953,7 +953,7 @@ myRequirements.limits.maxComputeShaderWorkGroupSize[2]  = 8;
 LLGL::ValidateRenderingCaps(
     myRenderer->GetRenderingCaps(),
     myRequirements,
-    [](const std::string& info, const std::string& attrib) {
+    [](const string& info, const string& attrib) {
         ::fprintf(stderr, "%s: %s\n", info.c_str(), attrib.c_str());
         return true;
     }

--- a/include/LLGL/RenderingDebugger.h
+++ b/include/LLGL/RenderingDebugger.h
@@ -12,7 +12,7 @@
 #include <LLGL/Export.h>
 #include <LLGL/Container/Strings.h>
 #include <LLGL/RenderingDebuggerFlags.h>
-#include <vector>
+#include <LLGL/Container/Vector.h>
 #include <cstdint>
 #include <cstring>
 

--- a/include/LLGL/Report.h
+++ b/include/LLGL/Report.h
@@ -11,7 +11,7 @@
 
 #include <LLGL/Export.h>
 #include <LLGL/Container/StringView.h>
-#include <string>
+#include <LLGL/Container/String.h>
 
 
 namespace LLGL
@@ -42,7 +42,7 @@ class LLGL_EXPORT Report final
         Report(const StringView& text, bool hasErrors);
 
         //! Constructs the report by taking the ownersip of the specified string.
-        Report(std::string&& text, bool hasErrors);
+        Report(string&& text, bool hasErrors);
 
         //! Copy constructor.
         Report(const Report& rhs);
@@ -83,7 +83,7 @@ class LLGL_EXPORT Report final
         void Reset(const StringView& text, bool hasErrors);
 
         //! Overrides the report by taking the ownership of the specified string.
-        void Reset(std::string&& text, bool hasErrors);
+        void Reset(string&& text, bool hasErrors);
 
         /**
         \brief Appends a formatted message to this report. The previous error flag remains unchanged.

--- a/include/LLGL/ResourceHeapFlags.h
+++ b/include/LLGL/ResourceHeapFlags.h
@@ -15,7 +15,7 @@
 #include <LLGL/Buffer.h>
 #include <LLGL/BufferFlags.h>
 #include <LLGL/Deprecated.h>
-#include <vector>
+#include <LLGL/Container/Vector.h>
 
 
 namespace LLGL

--- a/include/LLGL/ShaderFlags.h
+++ b/include/LLGL/ShaderFlags.h
@@ -15,7 +15,7 @@
 #include <LLGL/FragmentAttribute.h>
 #include <LLGL/Deprecated.h>
 #include <cstddef>
-#include <vector>
+#include <LLGL/Container/Vector.h>
 
 
 namespace LLGL
@@ -239,7 +239,7 @@ struct VertexShaderAttributes
     In other words, a shader must not declare any vertex attributes that are not contained in the currently bound vertex buffer.
     \see BufferDescriptor::vertexAttribs
     */
-    std::vector<VertexAttribute> inputAttribs;
+    vector<VertexAttribute> inputAttribs;
 
     /**
     \brief Vertex (or geometry or tessellation-evaluation) shader stream-output attributes.
@@ -254,7 +254,7 @@ struct VertexShaderAttributes
     \see RenderingFeatures::hasStreamOutputs
     \see CommandBuffer::BeginStreamOutput
     */
-    std::vector<VertexAttribute> outputAttribs;
+    vector<VertexAttribute> outputAttribs;
 };
 
 /**
@@ -265,7 +265,7 @@ struct VertexShaderAttributes
 struct FragmentShaderAttributes
 {
     //! Fragment shader output attributes.
-    std::vector<FragmentAttribute> outputAttribs;
+    vector<FragmentAttribute> outputAttribs;
 };
 
 /**

--- a/include/LLGL/ShaderReflection.h
+++ b/include/LLGL/ShaderReflection.h
@@ -14,8 +14,8 @@
 #include <LLGL/BufferFlags.h>
 #include <LLGL/PipelineLayoutFlags.h>
 #include <LLGL/ShaderFlags.h>
-#include <vector>
-#include <string>
+#include <LLGL/Container/Vector.h>
+#include <LLGL/Container/String.h>
 #include <cstdint>
 
 
@@ -127,14 +127,14 @@ This is not a "descriptor", because it is only used as output from an interface 
 struct ShaderReflection
 {
     //! List of all shader reflection resource views.
-    std::vector<ShaderResourceReflection>   resources;
+    vector<ShaderResourceReflection>   resources;
 
     /**
     \brief List of all uniforms (a.k.a. shader constants).
     \note Only supported with: OpenGL, Vulkan.
     \todo Add support to D3D11 and D3D12 for global constants.
     */
-    std::vector<UniformDescriptor>          uniforms;
+    vector<UniformDescriptor>          uniforms;
 
     /**
     \brief Reflection data that is specifically for the vertex shader.

--- a/include/LLGL/SwapChain.h
+++ b/include/LLGL/SwapChain.h
@@ -22,9 +22,9 @@
 #include <LLGL/Sampler.h>
 #include <LLGL/QueryHeap.h>
 
-#include <string>
+#include <LLGL/Container/String.h>
 #include <memory>
-#include <map>
+#include <LLGL/Container/Map.h>
 
 
 namespace LLGL

--- a/include/LLGL/Tags.h
+++ b/include/LLGL/Tags.h
@@ -21,7 +21,7 @@ namespace LLGL
 LLGL::ColorRGBAf color{ LLGL::UninitializeTag{} };
 
 // Explicitly uninitialized color elements in a container.
-std::vector<LLGL::ColorRGBAf> color;
+vector<LLGL::ColorRGBAf> color;
 color.resize(1024, LLGL::ColorRGBAf{ LLGL::UninitializeTag{} });
 \endcode
 */

--- a/include/LLGL/Utils/VertexFormat.h
+++ b/include/LLGL/Utils/VertexFormat.h
@@ -12,7 +12,7 @@
 #include <LLGL/Export.h>
 #include <LLGL/Constants.h>
 #include <LLGL/VertexAttribute.h>
-#include <vector>
+#include <LLGL/Container/Vector.h>
 #include <cstdint>
 #include <algorithm>
 
@@ -126,7 +126,7 @@ struct VertexFormat
     \brief Specifies the list of vertex attributes.
     \see AppendAttribute
     */
-    std::vector<VertexAttribute> attributes;
+    vector<VertexAttribute> attributes;
 };
 
 

--- a/include/LLGL/VideoAdapter.h
+++ b/include/LLGL/VideoAdapter.h
@@ -12,8 +12,8 @@
 #include <LLGL/Deprecated.h>
 #include <LLGL/Export.h>
 #include <LLGL/DisplayFlags.h>
-#include <vector>
-#include <string>
+#include <LLGL/Container/Vector.h>
+#include <LLGL/Container/String.h>
 #include <cstdint>
 
 
@@ -26,16 +26,16 @@ namespace LLGL
 //! \deprecated Since 0.04b; Write custom structure instead!
 struct LLGL_DEPRECATED("LLGL::VideoOutputDescriptor is deprecated since 0.04b; Write a custom structure instead!") VideoOutputDescriptor
 {
-    std::vector<DisplayMode> displayModes;
+    vector<DisplayMode> displayModes;
 };
 
 //! \deprecated Since 0.04b; Write custom structure instead!
 struct LLGL_DEPRECATED("LLGL::VideoAdapterDescriptor is deprecated since 0.04b; Write a custom structure instead!") VideoAdapterDescriptor
 {
-    std::wstring                        name;
-    std::string                         vendor;
-    std::uint64_t                       videoMemory = 0;
-    std::vector<VideoOutputDescriptor>  outputs;
+    wstring                        name;
+    string                         vendor;
+    std::uint64_t                  videoMemory = 0;
+    vector<VideoOutputDescriptor>  outputs;
 };
 
 

--- a/sources/Core/Blob.cpp
+++ b/sources/Core/Blob.cpp
@@ -27,8 +27,8 @@ struct Blob::Pimpl
 
 struct InternalStringBlob final : Blob::Pimpl
 {
-    InternalStringBlob(std::string&& str) :
-        str { std::forward<std::string>(str) }
+    InternalStringBlob(string&& str) :
+        str { std::forward<string>(str) }
     {
     }
 
@@ -42,7 +42,7 @@ struct InternalStringBlob final : Blob::Pimpl
         return str.size();
     }
 
-    std::string str;
+    string str;
 };
 
 struct InternalVectorBlob final : Blob::Pimpl
@@ -52,8 +52,8 @@ struct InternalVectorBlob final : Blob::Pimpl
     {
     }
 
-    InternalVectorBlob(std::vector<char>&& cont) :
-        container { std::forward<std::vector<char>>(cont) }
+    InternalVectorBlob(vector<char>&& cont) :
+        container { std::forward<vector<char>>(cont) }
     {
     }
 
@@ -67,7 +67,7 @@ struct InternalVectorBlob final : Blob::Pimpl
         return container.size();
     }
 
-    std::vector<char> container;
+    vector<char> container;
 };
 
 struct InternalBufferBlob final : Blob::Pimpl
@@ -125,14 +125,14 @@ static Blob::Pimpl* MakeInternalBlob(DynamicByteArray&& cont)
     return new InternalBufferBlob{ std::forward<DynamicByteArray>(cont) };
 }
 
-static Blob::Pimpl* MakeInternalBlob(std::vector<char>&& cont)
+static Blob::Pimpl* MakeInternalBlob(vector<char>&& cont)
 {
-    return new InternalVectorBlob{ std::forward<std::vector<char>>(cont) };
+    return new InternalVectorBlob{ std::forward<vector<char>>(cont) };
 }
 
-static Blob::Pimpl* MakeInternalBlob(std::string&& str)
+static Blob::Pimpl* MakeInternalBlob(string&& str)
 {
-    return new InternalStringBlob{ std::forward<std::string>(str) };
+    return new InternalStringBlob{ std::forward<string>(str) };
 }
 
 
@@ -194,17 +194,17 @@ Blob Blob::CreateStrongRef(DynamicByteArray&& cont)
     return blob;
 }
 
-Blob Blob::CreateStrongRef(std::vector<char>&& cont)
+Blob Blob::CreateStrongRef(vector<char>&& cont)
 {
     Blob blob;
-    blob.pimpl_ = MakeInternalBlob(std::forward<std::vector<char>>(cont));
+    blob.pimpl_ = MakeInternalBlob(std::forward<vector<char>>(cont));
     return blob;
 }
 
-Blob Blob::CreateStrongRef(std::string&& str)
+Blob Blob::CreateStrongRef(string&& str)
 {
     Blob blob;
-    blob.pimpl_ = MakeInternalBlob(std::forward<std::string>(str));
+    blob.pimpl_ = MakeInternalBlob(std::forward<string>(str));
     return blob;
 }
 
@@ -233,7 +233,7 @@ Blob Blob::CreateFromFile(const char* filename)
     return blob;
 }
 
-Blob Blob::CreateFromFile(const std::string& filename)
+Blob Blob::CreateFromFile(const string& filename)
 {
     return CreateFromFile(filename.c_str());
 }

--- a/sources/Core/Exception.cpp
+++ b/sources/Core/Exception.cpp
@@ -24,7 +24,7 @@ namespace LLGL
 {
 
 
-static void AddOptionalOrigin(std::string& s, const char* origin)
+static void AddOptionalOrigin(string& s, const char* origin)
 {
     if (origin != nullptr && *origin != '\0')
     {
@@ -38,7 +38,7 @@ static void AddOptionalOrigin(std::string& s, const char* origin)
 LLGL_EXPORT void Trap(Exception exception, const char* origin, const char* format, ...)
 {
     /* Build full report string */
-    std::string report;
+    string report;
     AddOptionalOrigin(report, origin);
 
     LLGL_STRING_PRINTF(report, format);
@@ -89,7 +89,7 @@ LLGL_EXPORT void TrapAssertionFailed(const char* origin, const char* expr, const
 {
     if (details != nullptr && *details != '\0')
     {
-        std::string detailsStr;
+        string detailsStr;
         LLGL_STRING_PRINTF(detailsStr, details);
 
         if (!detailsStr.empty())
@@ -161,7 +161,7 @@ LLGL_EXPORT void TrapParamExceededMaximum(const char* origin, const char* paramN
 [[noreturn]]
 LLGL_EXPORT void TrapReport(const char* origin, const Report& report)
 {
-    std::string text = report.GetText();
+    string text = report.GetText();
     for (std::size_t n = text.size(); n > 0 && (text[n - 1] == '\n' || text[n - 1] == '\r'); --n)
         text.pop_back();
     Trap(Exception::RuntimeError, origin, "%s", text.c_str());
@@ -171,7 +171,7 @@ LLGL_EXPORT std::nullptr_t ReportException(Report* report, const char* format, .
 {
     #if LLGL_EXCEPTIONS_SUPPORTED
 
-    std::string errorStr;
+    string errorStr;
     LLGL_STRING_PRINTF(errorStr, format);
     throw std::runtime_error(errorStr);
 
@@ -179,7 +179,7 @@ LLGL_EXPORT std::nullptr_t ReportException(Report* report, const char* format, .
 
     if (report != nullptr)
     {
-        std::string errorStr;
+        string errorStr;
         LLGL_STRING_PRINTF(errorStr, format);
         report->Errorf("%s\n", errorStr.c_str());
     }

--- a/sources/Core/Exception.h
+++ b/sources/Core/Exception.h
@@ -12,7 +12,7 @@
 #include <LLGL/Export.h>
 #include <LLGL/Container/StringView.h>
 #include <LLGL/Trap.h>
-#include <string>
+#include <LLGL/Container/String.h>
 #include <cstddef>
 #include "MacroUtils.h"
 

--- a/sources/Core/Input.cpp
+++ b/sources/Core/Input.cpp
@@ -11,7 +11,7 @@
 #include <LLGL/Canvas.h>
 #include <LLGL/Container/Strings.h>
 #include <string.h>
-#include <vector>
+#include <LLGL/Container/Vector.h>
 #include <algorithm>
 #include <memory>
 #include <math.h>
@@ -107,10 +107,10 @@ struct Input::Pimpl
     unsigned        anyKeyCount             = 0;
     UTF8String      chars;
 
-    std::vector<EventListenerSurfacePair<WindowEventListener>>
+    vector<EventListenerSurfacePair<WindowEventListener>>
                     windowEventListeners;
 
-    std::vector<EventListenerSurfacePair<CanvasEventListener>>
+    vector<EventListenerSurfacePair<CanvasEventListener>>
                     canvasEventListeners;
 
     void Reset()
@@ -361,7 +361,7 @@ Input::~Input()
 
 template <typename T>
 bool HasEventListenerForSurface(
-    std::vector<EventListenerSurfacePair<T>>&   eventListeners,
+    vector<EventListenerSurfacePair<T>>&   eventListeners,
     const Surface*                              surface)
 {
     return

--- a/sources/Core/LinearStringContainer.h
+++ b/sources/Core/LinearStringContainer.h
@@ -11,7 +11,7 @@
 
 #include "StringUtils.h"
 #include <LLGL/Container/StringView.h>
-#include <vector>
+#include <LLGL/Container/Vector.h>
 #include <string.h>
 
 
@@ -115,7 +115,7 @@ class LinearStringContainerBase
 
     private:
 
-        std::vector<T>  data_;
+        vector<T>  data_;
         std::size_t     reserved_   = 0;
         std::size_t     offset_     = 0;
 

--- a/sources/Core/Log.cpp
+++ b/sources/Core/Log.cpp
@@ -13,7 +13,7 @@
 #include "../Renderer/ContainerTypes.h"
 #include <mutex>
 #include <atomic>
-#include <string>
+#include <LLGL/Container/String.h>
 #include <stdio.h>
 #include <stdarg.h>
 
@@ -117,7 +117,7 @@ LLGL_EXPORT void Printf(const char* format, ...)
     if (!g_logRecursionLock)
     {
         std::lock_guard<TrivialLock> guard{ g_logRecursionLock };
-        std::string str;
+        string str;
         LLGL_STRING_PRINTF(str, format);
         PostReport(ReportType::Default, str.c_str());
     }
@@ -128,7 +128,7 @@ LLGL_EXPORT void Printf(const ColorCodes& colors, const char* format, ...)
     if (!g_logRecursionLock)
     {
         std::lock_guard<TrivialLock> guard{ g_logRecursionLock };
-        std::string str;
+        string str;
         LLGL_STRING_PRINTF(str, format);
         PostReport(ReportType::Default, str.c_str(), colors);
     }
@@ -139,7 +139,7 @@ LLGL_EXPORT void Errorf(const char* format, ...)
     if (!g_logRecursionLock)
     {
         std::lock_guard<TrivialLock> guard{ g_logRecursionLock };
-        std::string str;
+        string str;
         LLGL_STRING_PRINTF(str, format);
         PostReport(ReportType::Error, str.c_str());
     }
@@ -150,7 +150,7 @@ LLGL_EXPORT void Errorf(const ColorCodes& colors, const char* format, ...)
     if (!g_logRecursionLock)
     {
         std::lock_guard<TrivialLock> guard{ g_logRecursionLock };
-        std::string str;
+        string str;
         LLGL_STRING_PRINTF(str, format);
         PostReport(ReportType::Error, str.c_str(), colors);
     }

--- a/sources/Core/Parse.cpp
+++ b/sources/Core/Parse.cpp
@@ -9,8 +9,8 @@
 #include <LLGL/Utils/ForRange.h>
 #include <LLGL/Container/Strings.h>
 #include <LLGL/Report.h>
-#include <vector>
-#include <string>
+#include <LLGL/Container/Vector.h>
+#include <LLGL/Container/String.h>
 #include <cstring>
 #include <cmath>
 #include "Exception.h"
@@ -344,7 +344,7 @@ static bool ParseValueFromDictionary(Parser& parser, const Dictionary<T>& dict, 
         }
     }
 
-    std::string tokStr{ tok.begin(), tok.end() };
+    string tokStr{ tok.begin(), tok.end() };
     parser.report.Errorf("unknown %s: %s", valueName, tokStr.c_str());
     return false;
 }
@@ -356,7 +356,7 @@ static bool ReturnWithParseError(Parser& parser, const char* format)
     const StringView prevTok = parser.Token(-1);
     if (!prevTok.empty())
     {
-        std::string prevTokStr{ prevTok.begin(), prevTok.end() };
+        string prevTokStr{ prevTok.begin(), prevTok.end() };
         parser.report.Errorf("%s; last token = '%s'", format, prevTokStr.c_str());
     }
     else
@@ -366,7 +366,7 @@ static bool ReturnWithParseError(Parser& parser, const char* format)
 
 static bool ReturnWithParseError(Parser& parser, const char* format, const StringView& tok)
 {
-    std::string tokStr{ tok.begin(), tok.end() };
+    string tokStr{ tok.begin(), tok.end() };
     parser.report.Errorf(format, tokStr.c_str());
     return false;
 }
@@ -643,7 +643,7 @@ static bool ParseLayoutSignatureResourceBinding(Parser& parser, PipelineLayoutDe
     if (!parser.Accept("("))
         return ReturnWithParseError(parser, "expected open bracket '(' after resource type");
 
-    std::vector<BindingDescriptor> intermediateBindings;
+    vector<BindingDescriptor> intermediateBindings;
 
     while (parser.Feed() && !parser.Match(")"))
     {
@@ -982,7 +982,7 @@ static void RaiseParsingError(const Parser& parser, const char* descName)
     {
         /* Raise token error */
         StringView errorToken = parser.Token();
-        const std::string errorTokenStr{ errorToken.begin(), errorToken.end() };
+        const string errorTokenStr{ errorToken.begin(), errorToken.end() };
         LLGL_TRAP("parsing %s failed at token '%s'", descName, errorTokenStr.c_str());
     }
 }
@@ -1007,7 +1007,7 @@ static bool ParseSamplerDescAddress(Parser& parser, SamplerDescriptor& outDesc)
         {
             if ((axes & axis) != 0)
             {
-                std::string tokStr{ tok.begin(), tok.end() };
+                string tokStr{ tok.begin(), tok.end() };
                 parser.report.Errorf("duplicate sampler address mode %s axis: %s", axisName, tokStr.c_str());
                 return false;
             }
@@ -1628,7 +1628,7 @@ LLGL_EXPORT ParseContext Parse(const char* format, ...)
 {
     if (std::strchr(format, '%') != nullptr)
     {
-        std::string s;
+        string s;
         LLGL_STRING_PRINTF(s, format);
         return ParseContext{ UTF8String{ s.c_str() } };
     }

--- a/sources/Core/Report.cpp
+++ b/sources/Core/Report.cpp
@@ -6,7 +6,7 @@
  */
 
 #include <LLGL/Report.h>
-#include <string>
+#include <LLGL/Container/String.h>
 #include <stdarg.h>
 #include "StringUtils.h"
 
@@ -17,7 +17,7 @@ namespace LLGL
 
 struct Report::Pimpl
 {
-    std::string text;
+    string text;
     bool        hasErrors;
 };
 
@@ -32,11 +32,11 @@ Report::Report(const char* text, bool hasErrors) :
 }
 
 Report::Report(const StringView& text, bool hasErrors) :
-    pimpl_ { new Report::Pimpl{ std::string(text.begin(), text.end()), hasErrors } }
+    pimpl_ { new Report::Pimpl{ string(text.begin(), text.end()), hasErrors } }
 {
 }
 
-Report::Report(std::string&& text, bool hasErrors) :
+Report::Report(string&& text, bool hasErrors) :
     pimpl_ { new Report::Pimpl{ std::move(text), hasErrors } }
 {
 }
@@ -82,14 +82,14 @@ void Report::Reset(const StringView& text, bool hasErrors)
 {
     if (pimpl_ != nullptr)
     {
-        pimpl_->text        = std::string(text.begin(), text.end());
+        pimpl_->text        = string(text.begin(), text.end());
         pimpl_->hasErrors   = hasErrors;
     }
     else
-        pimpl_ = new Report::Pimpl{ std::string(text.begin(), text.end()), hasErrors };
+        pimpl_ = new Report::Pimpl{ string(text.begin(), text.end()), hasErrors };
 }
 
-void Report::Reset(std::string&& text, bool hasErrors)
+void Report::Reset(string&& text, bool hasErrors)
 {
     if (pimpl_ != nullptr)
     {

--- a/sources/Core/ReportUtils.h
+++ b/sources/Core/ReportUtils.h
@@ -25,9 +25,9 @@ inline void EndReportWithNewline(Report& report)
 }
 
 // Resets the specified report and ensures it ends with a newline character.
-inline void ResetReportWithNewline(Report& report, std::string&& text, bool hasErrors)
+inline void ResetReportWithNewline(Report& report, string&& text, bool hasErrors)
 {
-    report.Reset(std::forward<std::string>(text), hasErrors);
+    report.Reset(std::forward<string>(text), hasErrors);
     EndReportWithNewline(report);
 }
 

--- a/sources/Core/StringUtils.cpp
+++ b/sources/Core/StringUtils.cpp
@@ -38,9 +38,9 @@ namespace LLGL
 
 #ifdef LLGL_OS_ANDROID
 
-static std::vector<char> ReadFileBufferPrimary(const char* filename)
+static vector<char> ReadFileBufferPrimary(const char* filename)
 {
-    std::vector<char> content;
+    vector<char> content;
 
     if (filename != nullptr && *filename != '\0')
     {
@@ -68,13 +68,13 @@ static std::vector<char> ReadFileBufferPrimary(const char* filename)
     return content;
 }
 
-LLGL_EXPORT std::string ReadFileString(const char* filename)
+LLGL_EXPORT string ReadFileString(const char* filename)
 {
-    const std::vector<char> content = ReadFileBufferPrimary(filename);
-    return std::string(content.begin(), content.end());
+    const vector<char> content = ReadFileBufferPrimary(filename);
+    return string(content.begin(), content.end());
 }
 
-LLGL_EXPORT std::vector<char> ReadFileBuffer(const char* filename)
+LLGL_EXPORT vector<char> ReadFileBuffer(const char* filename)
 {
     return ReadFileBufferPrimary(filename);
 }
@@ -91,14 +91,14 @@ static UTF8String GetPlatformAppropriateFilename(const char* filename)
     #endif
 }
 
-LLGL_EXPORT std::string ReadFileString(const char* filename)
+LLGL_EXPORT string ReadFileString(const char* filename)
 {
     /* Read file content into string */
     const UTF8String path = GetPlatformAppropriateFilename(filename);
     std::ifstream file{ path.c_str() };
     if (file.good())
     {
-        return std::string
+        return string
         {
             ( std::istreambuf_iterator<char>(file) ),
             ( std::istreambuf_iterator<char>() )
@@ -107,7 +107,7 @@ LLGL_EXPORT std::string ReadFileString(const char* filename)
     return "";
 }
 
-LLGL_EXPORT std::vector<char> ReadFileBuffer(const char* filename)
+LLGL_EXPORT vector<char> ReadFileBuffer(const char* filename)
 {
     /* Read file content into buffer */
     const UTF8String path = GetPlatformAppropriateFilename(filename);
@@ -115,7 +115,7 @@ LLGL_EXPORT std::vector<char> ReadFileBuffer(const char* filename)
     if (file.good())
     {
         const std::size_t fileSize = static_cast<std::size_t>(file.tellg());
-        std::vector<char> buffer(fileSize);
+        vector<char> buffer(fileSize);
 
         file.seekg(0);
         file.read(buffer.data(), fileSize);
@@ -127,33 +127,33 @@ LLGL_EXPORT std::vector<char> ReadFileBuffer(const char* filename)
 
 #endif // /LLGL_OS_ANDROID
 
-static std::wstring ToWideStringPrimary(const char* str, std::size_t len)
+static wstring ToWideStringPrimary(const char* str, std::size_t len)
 {
-    std::wstring wstr;
+    wstring wstr;
     wstr.resize(len);
     for_range(i, len)
         wstr[i] = static_cast<wchar_t>(str[i]);
     return wstr;
 }
 
-LLGL_EXPORT std::wstring ToWideString(const std::string& str)
+LLGL_EXPORT wstring ToWideString(const string& str)
 {
     return ToWideStringPrimary(str.c_str(), str.size());
 }
 
-LLGL_EXPORT std::wstring ToWideString(const char* str)
+LLGL_EXPORT wstring ToWideString(const char* str)
 {
     return ToWideStringPrimary(str, std::strlen(str));
 }
 
-void StringPrintf(std::string& str, const char* format, va_list args1, va_list args2)
+void StringPrintf(string& str, const char* format, va_list args1, va_list args2)
 {
     const int len = ::vsnprintf(nullptr, 0, format, args1);
     if (len > 0)
     {
         /*
         Since C++11 we can override the last character with '\0' ourselves,
-        so it's safe to let ::vsnprintf override std::string from [0, size()] inclusive.
+        so it's safe to let ::vsnprintf override string from [0, size()] inclusive.
         */
         const std::size_t formatLen = static_cast<std::size_t>(len);
         const std::size_t appendOff = str.size();

--- a/sources/Core/StringUtils.h
+++ b/sources/Core/StringUtils.h
@@ -13,8 +13,8 @@
 #include <LLGL/Container/ArrayView.h>
 #include <LLGL/Container/UTF8String.h>
 #include "Exception.h"
-#include <string>
-#include <vector>
+#include <LLGL/Container/String.h>
+#include <LLGL/Container/Vector.h>
 #include <stdarg.h>
 
 
@@ -113,17 +113,17 @@ inline std::size_t StrLength(const T* s)
 /* ----- Functions ----- */
 
 // Reads the specified text file into a string.
-LLGL_EXPORT std::string ReadFileString(const char* filename);
+LLGL_EXPORT string ReadFileString(const char* filename);
 
 // Reads the specified binary file into a buffer.
-LLGL_EXPORT std::vector<char> ReadFileBuffer(const char* filename);
+LLGL_EXPORT vector<char> ReadFileBuffer(const char* filename);
 
 // Converts the UTF8 input string to UTF16 string.
-LLGL_EXPORT std::wstring ToWideString(const std::string& str);
-LLGL_EXPORT std::wstring ToWideString(const char* str);
+LLGL_EXPORT wstring ToWideString(const string& str);
+LLGL_EXPORT wstring ToWideString(const char* str);
 
 // Writes a formatted string into an STL string.
-LLGL_EXPORT void StringPrintf(std::string& str, const char* format, va_list args1, va_list args2);
+LLGL_EXPORT void StringPrintf(string& str, const char* format, va_list args1, va_list args2);
 
 struct FormattedTableColumn
 {

--- a/sources/Core/Threading.cpp
+++ b/sources/Core/Threading.cpp
@@ -8,7 +8,7 @@
 #include "Threading.h"
 #include <LLGL/Utils/ForRange.h>
 #include <thread>
-#include <vector>
+#include <LLGL/Container/Vector.h>
 #include <algorithm>
 
 
@@ -99,7 +99,7 @@ LLGL_EXPORT void DoConcurrentRange(
     else if (threadCount > 1)
     {
         /* Launch worker threads in dynamic array */
-        std::vector<std::thread> workers(threadCount);
+        vector<std::thread> workers(threadCount);
         DoConcurrentRangeInWorkerContainer(task, count, threadCount, workers.data());
     }
 }

--- a/sources/Core/Version.cpp
+++ b/sources/Core/Version.cpp
@@ -7,7 +7,7 @@
 
 #include <LLGL/Version.h>
 #include "VersionMacros.h"
-#include <string>
+#include <LLGL/Container/String.h>
 
 
 namespace LLGL
@@ -42,9 +42,9 @@ LLGL_EXPORT unsigned GetID()
     return LLGL_VERSION_ID;
 }
 
-static std::string BuildVersionString()
+static string BuildVersionString()
 {
-    std::string s;
+    string s;
 
     s += std::to_string(GetMajor());
     s += '.';
@@ -70,7 +70,7 @@ static std::string BuildVersionString()
 
 LLGL_EXPORT const char* GetString()
 {
-    static std::string s = BuildVersionString();
+    static string s = BuildVersionString();
     return s.c_str();
 }
 

--- a/sources/Platform/Canvas.cpp
+++ b/sources/Platform/Canvas.cpp
@@ -7,7 +7,7 @@
 
 #include <LLGL/Canvas.h>
 #include "../Core/CoreUtils.h"
-#include <vector>
+#include <LLGL/Container/Vector.h>
 
 
 namespace LLGL
@@ -16,7 +16,7 @@ namespace LLGL
 
 struct Canvas::Pimpl
 {
-    std::vector<std::shared_ptr<EventListener>> eventListeners;
+    vector<std::shared_ptr<EventListener>> eventListeners;
     void*                                       userData        = nullptr;
 };
 

--- a/sources/Platform/Debug.cpp
+++ b/sources/Platform/Debug.cpp
@@ -18,7 +18,7 @@ namespace LLGL
 
 LLGL_EXPORT void DebugPrintf(const char* format, ...)
 {
-    std::string str;
+    string str;
     LLGL_STRING_PRINTF(str, format);
     DebugPuts(str.c_str());
 }

--- a/sources/Platform/Display.cpp
+++ b/sources/Platform/Display.cpp
@@ -17,7 +17,7 @@ namespace LLGL
  * ======= Protected: =======
  */
 
-void Display::FinalizeDisplayModes(std::vector<DisplayMode>& displayMode)
+void Display::FinalizeDisplayModes(vector<DisplayMode>& displayMode)
 {
     /* Sort display mode descriptors in ascending order (with, height, frequency) */
     std::sort(displayMode.begin(), displayMode.end(), CompareSWO);

--- a/sources/Platform/Module.h
+++ b/sources/Platform/Module.h
@@ -13,7 +13,7 @@
 #include <LLGL/NonCopyable.h>
 #include <LLGL/Report.h>
 #include <memory>
-#include <string>
+#include <LLGL/Container/String.h>
 
 
 namespace LLGL
@@ -34,7 +34,7 @@ class LLGL_EXPORT Module : public NonCopyable
     public:
 
         // Converts the module name into a specific filename (e.g. "OpenGL" to "LLGL_OpenGL.dll" on Windows).
-        static std::string GetModuleFilename(const char* moduleName);
+        static string GetModuleFilename(const char* moduleName);
 
         // Returns true if the specified module is available.
         static bool IsAvailable(const char* moduleFilename);

--- a/sources/Platform/Path.cpp
+++ b/sources/Platform/Path.cpp
@@ -24,10 +24,10 @@ static bool IsCharAnySeparator(char c)
 
 LLGL_EXPORT UTF8String Sanitize(const UTF8String& path)
 {
-    std::string s(path.begin(), path.end());
+    string s(path.begin(), path.end());
 
     /* Sanitize separators and remove redundant upper-level directory entries */
-    auto JoinSubPaths = [](std::string& s, std::size_t off) -> std::size_t
+    auto JoinSubPaths = [](string& s, std::size_t off) -> std::size_t
     {
         /* Find start of previous path */
         for (std::size_t i = off; i-- > 0;)

--- a/sources/Platform/Path.h
+++ b/sources/Platform/Path.h
@@ -11,7 +11,7 @@
 
 #include <LLGL/Export.h>
 #include <LLGL/Container/UTF8String.h>
-#include <string>
+#include <LLGL/Container/String.h>
 
 
 namespace LLGL

--- a/sources/Platform/Win32/Win32Debug.cpp
+++ b/sources/Platform/Win32/Win32Debug.cpp
@@ -10,7 +10,7 @@
 #include "Win32Module.h"
 #include <stdio.h>
 #include <limits.h>
-#include <vector>
+#include <LLGL/Container/Vector.h>
 #include <algorithm>
 #include <LLGL/Utils/ForRange.h>
 
@@ -203,9 +203,9 @@ LLGL_EXPORT void DebugPuts(const char* text)
     }
 }
 
-static std::vector<void*> CaptureStackTraceAddresses(DWORD framesToSkip, DWORD framesToCapture)
+static vector<void*> CaptureStackTraceAddresses(DWORD framesToSkip, DWORD framesToCapture)
 {
-    std::vector<void*> backTrace;
+    vector<void*> backTrace;
     backTrace.resize(framesToCapture);
 
     const WORD capturedFrames = CaptureStackBackTrace(framesToSkip, framesToCapture, backTrace.data(), nullptr);
@@ -223,10 +223,10 @@ LLGL_EXPORT UTF8String DebugStackTrace(unsigned firstStackFrame, unsigned maxNum
     const       DWORD framesToCapture       = (std::max<DWORD>)(maxNumStackFrames, USHRT_MAX);
     const       DWORD framesToSkip          = (std::max<DWORD>)(0, firstStackFrame) + framesToAlwaysSkip;
 
-    std::vector<void*> framePointers = CaptureStackTraceAddresses(framesToSkip, framesToCapture);
+    vector<void*> framePointers = CaptureStackTraceAddresses(framesToSkip, framesToCapture);
 
     /* Build chart with columns for stack frames and source information */
-    std::vector<UTF8String> columns[2];
+    vector<UTF8String> columns[2];
     UTF8String cells[2];
     std::size_t columnWidths[2] = { 0, 0 };
 

--- a/sources/Platform/Win32/Win32Display.cpp
+++ b/sources/Platform/Win32/Win32Display.cpp
@@ -34,8 +34,8 @@ struct Win32DisplayContainer
     int                             cacheIndex = 0;
 };
 
-static std::vector<Win32DisplayContainer>   g_displayList;
-static std::vector<Display*>                g_displayRefList;
+static vector<Win32DisplayContainer>   g_displayList;
+static vector<Display*>                g_displayRefList;
 static Win32Display*                        g_primaryDisplay;
 static int                                  g_displayCacheIndex;
 
@@ -317,9 +317,9 @@ DisplayMode Win32Display::GetDisplayMode() const
     return {};
 }
 
-std::vector<DisplayMode> Win32Display::GetSupportedDisplayModes() const
+vector<DisplayMode> Win32Display::GetSupportedDisplayModes() const
 {
-    std::vector<DisplayMode> displayModes;
+    vector<DisplayMode> displayModes;
 
     /* Get display device name */
     MONITORINFOEX infoEx;

--- a/sources/Platform/Win32/Win32Display.h
+++ b/sources/Platform/Win32/Win32Display.h
@@ -36,7 +36,7 @@ class Win32Display final : public Display
         bool SetDisplayMode(const DisplayMode& displayMode) override;
         DisplayMode GetDisplayMode() const override;
 
-        std::vector<DisplayMode> GetSupportedDisplayModes() const override;
+        vector<DisplayMode> GetSupportedDisplayModes() const override;
 
     public:
 

--- a/sources/Platform/Win32/Win32Module.cpp
+++ b/sources/Platform/Win32/Win32Module.cpp
@@ -14,13 +14,13 @@ namespace LLGL
 {
 
 
-std::string Module::GetModuleFilename(const char* moduleName)
+string Module::GetModuleFilename(const char* moduleName)
 {
     /* Extend module name to Win32 dynamic link library name (DLL) */
     #ifdef __MINGW32__
-    std::string s = "libLLGL_";
+    string s = "libLLGL_";
     #else
-    std::string s = "LLGL_";
+    string s = "LLGL_";
     #endif
     s += moduleName;
     #ifdef LLGL_DEBUG

--- a/sources/Platform/Win32/Win32Path.cpp
+++ b/sources/Platform/Win32/Win32Path.cpp
@@ -28,9 +28,9 @@ LLGL_EXPORT UTF8String GetWorkingDir()
     {
         /* Override content of string including the NUL-terminator, which is allowed since C++11 */
         #ifdef UNICODE
-        std::wstring path;
+        wstring path;
         #else
-        std::string path;
+        string path;
         #endif
         path.resize(static_cast<std::size_t>(pathLen - 1));
         ::GetCurrentDirectory(pathLen, &path[0]);

--- a/sources/Platform/Win32/Win32RawInputRegistry.h
+++ b/sources/Platform/Win32/Win32RawInputRegistry.h
@@ -10,7 +10,7 @@
 
 
 #include <Windows.h>
-#include <vector>
+#include <LLGL/Container/Vector.h>
 
 
 namespace LLGL
@@ -41,7 +41,7 @@ class Win32RawInputRegistry
 
     private:
 
-        std::vector<HWND>   wndHandles_;
+        vector<HWND>   wndHandles_;
         HWND                activeWndForInputDevices_   = nullptr;
 
 };

--- a/sources/Platform/Window.cpp
+++ b/sources/Platform/Window.cpp
@@ -90,7 +90,7 @@ void Window::EventListener::OnLostFocus(Window& sender)
 
 struct Window::Pimpl
 {
-    std::vector<std::shared_ptr<EventListener>> eventListeners;
+    vector<std::shared_ptr<EventListener>> eventListeners;
     bool                                        quit            = false;
     bool                                        focus           = false;
     void*                                       userData        = nullptr;

--- a/sources/Renderer/ContainerTypes.h
+++ b/sources/Renderer/ContainerTypes.h
@@ -13,7 +13,7 @@
 #include "../Core/Assertion.h"
 #include "CheckedCast.h"
 #include <memory>
-#include <vector>
+#include <LLGL/Container/Vector.h>
 #include <utility>
 #include <type_traits>
 #include <unordered_set>
@@ -52,7 +52,7 @@ SubType* TakeOwnership(std::unordered_set<std::unique_ptr<BaseType>>& objectSet,
 }
 
 template <typename BaseType, typename SubType>
-SubType* TakeOwnership(std::vector<std::unique_ptr<BaseType>>& objectSet, std::unique_ptr<SubType>&& object)
+SubType* TakeOwnership(vector<std::unique_ptr<BaseType>>& objectSet, std::unique_ptr<SubType>&& object)
 {
     auto ref = object.get();
     objectSet.emplace_back(std::forward<std::unique_ptr<SubType>>(object));
@@ -215,7 +215,7 @@ class UnorderedUniquePtrVector
 
     public:
 
-        using container_type    = std::vector<IndexedUniquePtr<T>>;
+        using container_type    = vector<IndexedUniquePtr<T>>;
         using iterator          = typename container_type::iterator;
         using const_iterator    = typename container_type::const_iterator;
 

--- a/sources/Renderer/DXCommon/DXCore.cpp
+++ b/sources/Renderer/DXCommon/DXCore.cpp
@@ -143,7 +143,7 @@ void DXThrowIfCastFailed(HRESULT hr, const char* interfaceName, const char* cont
 {
     if (FAILED(hr))
     {
-        std::string s;
+        string s;
         {
             s = "failed to interpret object as instance of <";
             s += interfaceName;
@@ -162,7 +162,7 @@ void DXThrowIfCreateFailed(HRESULT hr, const char* interfaceName, const char* co
 {
     if (FAILED(hr))
     {
-        std::string s;
+        string s;
         {
             s = "failed to create instance of <";
             s += interfaceName;
@@ -181,7 +181,7 @@ void DXThrowIfInvocationFailed(HRESULT hr, const char* funcName, const char* con
 {
     if (FAILED(hr))
     {
-        std::string s;
+        string s;
         {
             s = "invocation of <";
             s += funcName;
@@ -215,18 +215,18 @@ Cont GetBlobDataTmpl(ID3DBlob* blob)
     return container;
 }
 
-std::string DXGetBlobString(ID3DBlob* blob)
+string DXGetBlobString(ID3DBlob* blob)
 {
     if (blob != nullptr)
-        return GetBlobDataTmpl<std::string>(blob);
+        return GetBlobDataTmpl<string>(blob);
     else
         return {};
 }
 
-std::vector<char> DXGetBlobData(ID3DBlob* blob)
+vector<char> DXGetBlobData(ID3DBlob* blob)
 {
     if (blob != nullptr)
-        return GetBlobDataTmpl<std::vector<char>>(blob);
+        return GetBlobDataTmpl<vector<char>>(blob);
     else
         return {};
 }
@@ -242,7 +242,7 @@ ComPtr<ID3DBlob> DXCreateBlob(const void* data, std::size_t size)
     return blob;
 }
 
-ComPtr<ID3DBlob> DXCreateBlob(const std::vector<char>& data)
+ComPtr<ID3DBlob> DXCreateBlob(const vector<char>& data)
 {
     return DXCreateBlob(data.data(), data.size());
 }
@@ -327,11 +327,11 @@ UINT DXGetFxcCompilerFlags(int flags)
     return dxFlags;
 }
 
-static std::vector<VideoAdapterOutputInfo> GetDXGIAdapterOutputInfos(IDXGIAdapter* adapter)
+static vector<VideoAdapterOutputInfo> GetDXGIAdapterOutputInfos(IDXGIAdapter* adapter)
 {
     LLGL_ASSERT_PTR(adapter);
 
-    std::vector<VideoAdapterOutputInfo> outputInfos;
+    vector<VideoAdapterOutputInfo> outputInfos;
 
     /* Enumerate over all adapter outputs */
     ComPtr<IDXGIOutput> output;
@@ -346,7 +346,7 @@ static std::vector<VideoAdapterOutputInfo> GetDXGIAdapterOutputInfos(IDXGIAdapte
         output->GetDisplayModeList(DXGI_FORMAT_R8G8B8A8_UNORM, DXGI_ENUM_MODES_INTERLACED, &numModes, nullptr);
 
         /* Query display modes */
-        std::vector<DXGI_MODE_DESC> modeDesc(numModes);
+        vector<DXGI_MODE_DESC> modeDesc(numModes);
 
         HRESULT hr = output->GetDisplayModeList(DXGI_FORMAT_R8G8B8A8_UNORM, DXGI_ENUM_MODES_INTERLACED, &numModes, modeDesc.data());
         DXThrowIfFailed(hr, "failed to get display mode list with format DXGI_FORMAT_R8G8B8A8_UNORM");

--- a/sources/Renderer/DXCommon/DXCore.h
+++ b/sources/Renderer/DXCommon/DXCore.h
@@ -15,8 +15,8 @@
 #include <LLGL/ImageFlags.h>
 #include "ComPtr.h"
 #include <dxgi.h>
-#include <string>
-#include <vector>
+#include <LLGL/Container/String.h>
+#include <LLGL/Container/Vector.h>
 #include <Windows.h>
 #include <d3dcommon.h>
 
@@ -49,16 +49,16 @@ void DXThrowIfInvocationFailed(HRESULT hr, const char* funcName, const char* con
 BOOL DXBoolean(bool value);
 
 // Returns the blob data as string.
-std::string DXGetBlobString(ID3DBlob* blob);
+string DXGetBlobString(ID3DBlob* blob);
 
 // Returns the blob data as char vector.
-std::vector<char> DXGetBlobData(ID3DBlob* blob);
+vector<char> DXGetBlobData(ID3DBlob* blob);
 
 // Returns a blob and copies the specified data into the blob.
 ComPtr<ID3DBlob> DXCreateBlob(const void* data, std::size_t size);
 
 // Returns a blob and copies the specified data into the blob.
-ComPtr<ID3DBlob> DXCreateBlob(const std::vector<char>& data);
+ComPtr<ID3DBlob> DXCreateBlob(const vector<char>& data);
 
 // Returns a blob that was created from a resource (*.rc files).
 ComPtr<ID3DBlob> DXCreateBlobFromResource(int resourceID);

--- a/sources/Renderer/DXCommon/DXManagedComPtrArray.h
+++ b/sources/Renderer/DXCommon/DXManagedComPtrArray.h
@@ -12,9 +12,9 @@
 #include "ComPtr.h"
 #include "../../Core/Assertion.h"
 #include <LLGL/Utils/ForRange.h>
-#include <vector>
+#include <LLGL/Container/Vector.h>
 #include <algorithm>
-#include <string>
+#include <LLGL/Container/String.h>
 
 
 namespace LLGL
@@ -28,8 +28,8 @@ class DXManagedComPtrArray
 
     public:
 
-        using iterator          = typename std::vector<ComPtr<T>>::iterator;
-        using const_iterator    = typename std::vector<ComPtr<T>>::const_iterator;
+        using iterator          = typename vector<ComPtr<T>>::iterator;
+        using const_iterator    = typename vector<ComPtr<T>>::const_iterator;
 
     public:
 
@@ -127,7 +127,7 @@ class DXManagedComPtrArray
 
     private:
 
-        std::vector<ComPtr<T>>  container_;
+        vector<ComPtr<T>>  container_;
         std::size_t             lowerFreeBound_ = 0;
 
 };

--- a/sources/Renderer/DXCommon/DXShaderReflection.cpp
+++ b/sources/Renderer/DXCommon/DXShaderReflection.cpp
@@ -34,7 +34,7 @@ ShaderResourceReflection* FetchOrInsertResource(
     outReflection.resources.resize(outReflection.resources.size() + 1);
     ShaderResourceReflection* ref = &(outReflection.resources.back());
     {
-        ref->binding.name = std::string(name);
+        ref->binding.name = string(name);
         ref->binding.type = type;
         ref->binding.slot = slot;
     }

--- a/sources/Renderer/DXCommon/DXShaderReflection.h
+++ b/sources/Renderer/DXCommon/DXShaderReflection.h
@@ -11,7 +11,7 @@
 
 #include <LLGL/ShaderReflection.h>
 #include <LLGL/Utils/ForRange.h>
-#include <string.h>
+#include <LLGL/Container/String.h>
 #include "DXCore.h"
 #include "DXTypes.h"
 
@@ -31,7 +31,7 @@ ShaderResourceReflection* FetchOrInsertResource(
 template <typename TSignatureParameterDesc>
 static void DXConvertD3DParamDescToVertexAttrib(VertexAttribute& dst, const TSignatureParameterDesc& src)
 {
-    dst.name            = std::string(src.SemanticName);
+    dst.name            = string(src.SemanticName);
     dst.format          = DXGetSignatureParameterType(src.ComponentType, src.Mask);
     dst.semanticIndex   = src.SemanticIndex;
     dst.systemValue     = DXTypes::Unmap(src.SystemValueType);
@@ -83,7 +83,7 @@ HRESULT DXReflectShaderVertexAttributes(
 template <typename TSignatureParameterDesc>
 static void DXConvertD3DParamDescToFragmentAttrib(FragmentAttribute& dst, const TSignatureParameterDesc& src)
 {
-    dst.name        = std::string(src.SemanticName);
+    dst.name        = string(src.SemanticName);
     dst.format      = DXGetSignatureParameterType(src.ComponentType, src.Mask);
     dst.location    = src.SemanticIndex;
     dst.systemValue = DXTypes::Unmap(src.SystemValueType);
@@ -222,7 +222,7 @@ HRESULT DXReflectShaderConstantBuffer(
                 /* Add new uniform descriptor to reflection output */
                 UniformDescriptor uniformDesc;
                 {
-                    uniformDesc.name        = std::string(varDesc.Name); // Make copy of string, since reflection object will be released
+                    uniformDesc.name        = string(varDesc.Name); // Make copy of string, since reflection object will be released
                     uniformDesc.type        = DXMapD3DShaderTypeToUniformType(typeDesc);
                     uniformDesc.arraySize   = typeDesc.Elements;
                 }

--- a/sources/Renderer/DXCommon/DXTypes.cpp
+++ b/sources/Renderer/DXCommon/DXTypes.cpp
@@ -7,7 +7,7 @@
 
 #include "DXTypes.h"
 #include <stdexcept>
-#include <string>
+#include <LLGL/Container/String.h>
 
 
 namespace LLGL

--- a/sources/Renderer/DebugLayer/Buffer/DbgBuffer.h
+++ b/sources/Renderer/DebugLayer/Buffer/DbgBuffer.h
@@ -11,7 +11,7 @@
 
 #include <LLGL/Buffer.h>
 #include <LLGL/Container/SmallVector.h>
-#include <string>
+#include <LLGL/Container/String.h>
 
 
 namespace LLGL
@@ -45,7 +45,7 @@ class DbgBuffer final : public Buffer
 
         Buffer&                 instance;
         const BufferDescriptor  desc;
-        std::string             label;
+        string             label;
         std::uint64_t           elements    = 0;
         bool                    initialized = false;
 

--- a/sources/Renderer/DebugLayer/Buffer/DbgBufferArray.cpp
+++ b/sources/Renderer/DebugLayer/Buffer/DbgBufferArray.cpp
@@ -12,7 +12,7 @@ namespace LLGL
 {
 
 
-DbgBufferArray::DbgBufferArray(BufferArray& instance, long bindFlags, std::vector<DbgBuffer*>&& buffers) :
+DbgBufferArray::DbgBufferArray(BufferArray& instance, long bindFlags, vector<DbgBuffer*>&& buffers) :
     BufferArray { bindFlags          },
     instance    { instance           },
     buffers     { std::move(buffers) }

--- a/sources/Renderer/DebugLayer/Buffer/DbgBufferArray.h
+++ b/sources/Renderer/DebugLayer/Buffer/DbgBufferArray.h
@@ -23,12 +23,12 @@ class DbgBufferArray final : public BufferArray
 
     public:
 
-        DbgBufferArray(BufferArray& instance, long bindFlags, std::vector<DbgBuffer*>&& buffers);
+        DbgBufferArray(BufferArray& instance, long bindFlags, vector<DbgBuffer*>&& buffers);
 
     public:
 
         BufferArray&                    instance;
-        const std::vector<DbgBuffer*>   buffers;
+        const vector<DbgBuffer*>   buffers;
 
 };
 

--- a/sources/Renderer/DebugLayer/DbgCommandBuffer.cpp
+++ b/sources/Renderer/DebugLayer/DbgCommandBuffer.cpp
@@ -84,7 +84,7 @@ namespace LLGL
 #define LLGL_DBG_ASSERT_REF(OBJ) \
     LLGL_ASSERT(&OBJ != nullptr, #OBJ " reference must not be null")
 
-static const char* GetLabelOrDefault(const std::string& label, const char* defaultLabel)
+static const char* GetLabelOrDefault(const string& label, const char* defaultLabel)
 {
     return (!label.empty() ? label.c_str() : defaultLabel);
 }
@@ -1590,7 +1590,7 @@ void DbgCommandBuffer::ValidateSubmit()
     {
         if (pair.swapChain->GetCurrentSwapIndex() != pair.frame)
         {
-            const std::string labelStr = (pair.swapChain->label.empty() ? "" : " ['" + pair.swapChain->label + "']");
+            const string labelStr = (pair.swapChain->label.empty() ? "" : " ['" + pair.swapChain->label + "']");
             LLGL_DBG_ERROR(
                 ErrorType::InvalidState,
                 "command buffer submitted with swap-chain%s back-buffer [%" PRIu64 "] while swap-chain has current back buffer [%u]",
@@ -1861,7 +1861,7 @@ void DbgCommandBuffer::ValidateNumVertices(std::uint32_t numVertices)
                 auto numPatchVertices = static_cast<std::uint32_t>(topology_) - static_cast<std::uint32_t>(PrimitiveTopology::Patches1) + 1;
                 if (numVertices % numPatchVertices != 0)
                 {
-                    const std::string topologyLabel = "patches" + std::to_string(numPatchVertices);
+                    const string topologyLabel = "patches" + std::to_string(numPatchVertices);
                     WarnImproperVertices(topologyLabel.c_str(), (numVertices % numPatchVertices));
                 }
             }
@@ -2041,7 +2041,7 @@ void DbgCommandBuffer::ValidateDescriptorSetIndex(std::uint32_t setIndex, std::u
 {
     if (setIndex >= setUpperBound)
     {
-        std::string resHeapLabel;
+        string resHeapLabel;
         if (resourceHeapName != nullptr && *resourceHeapName != '\0')
         {
             resHeapLabel += " for resource heap \"";
@@ -2077,9 +2077,9 @@ static const char* BindFlagToString(long bindFlag)
     }
 }
 
-static std::string BindFlagsToStringList(long bindFlags)
+static string BindFlagsToStringList(long bindFlags)
 {
-    std::string s;
+    string s;
 
     for (long i = 0; i < sizeof(bindFlags)*8; ++i)
     {
@@ -2114,7 +2114,7 @@ void DbgCommandBuffer::ValidateBindFlags(long resourceFlags, long bindFlags, lon
 
     if (invalidFlags != 0)
     {
-        const std::string invalidFlagsLabel = BindFlagsToStringList(invalidFlags);
+        const string invalidFlagsLabel = BindFlagsToStringList(invalidFlags);
         LLGL_DBG_ERROR(
             ErrorType::InvalidArgument,
             "cannot bind %s with the following bind flags: %s",
@@ -2124,7 +2124,7 @@ void DbgCommandBuffer::ValidateBindFlags(long resourceFlags, long bindFlags, lon
 
     if (missingFlags != 0)
     {
-        const std::string missingFlagsLabel = BindFlagsToStringList(missingFlags);
+        const string missingFlagsLabel = BindFlagsToStringList(missingFlags);
         LLGL_DBG_ERROR(
             ErrorType::InvalidArgument,
             "%s was not created with the the following bind flags: %s",
@@ -2333,11 +2333,11 @@ void DbgCommandBuffer::ValidateTextureBufferCopyStrides(DbgTexture& textureDbg, 
     }
 }
 
-void DbgCommandBuffer::ValidateMemoryBarrierResourceFlags(ResourceType resourceType, long bindFlags, const std::string& label, std::uint32_t resourceIndex)
+void DbgCommandBuffer::ValidateMemoryBarrierResourceFlags(ResourceType resourceType, long bindFlags, const string& label, std::uint32_t resourceIndex)
 {
     if ((bindFlags & BindFlags::Storage) == 0)
     {
-        const std::string labelStr = (label.empty() ? "" : " '" + label + '\'');
+        const string labelStr = (label.empty() ? "" : " '" + label + '\'');
         LLGL_DBG_ERROR(
             ErrorType::InvalidArgument,
             "memory barrier for buffer resource [%u]%s without binding flag LLGL::BindFlags::Storage",
@@ -2358,7 +2358,7 @@ void DbgCommandBuffer::ValidateBufferRange(DbgBuffer& bufferDbg, std::uint64_t o
 {
     if (offset + size > bufferDbg.desc.size)
     {
-        const std::string bufferLabel = (bufferDbg.label.empty() ? "" : " for \"" + bufferDbg.label + "\"");
+        const string bufferLabel = (bufferDbg.label.empty() ? "" : " for \"" + bufferDbg.label + "\"");
         LLGL_DBG_ERROR(
             ErrorType::InvalidArgument,
             "%s out of bounds%s: %" PRIu64 " specified but limit is %" PRIu64,
@@ -2617,15 +2617,15 @@ void DbgCommandBuffer::ValidateBindingTable()
 {
     auto ValidateBindingTableWithLayout = [this](const DbgPipelineState& pso, const BindingTable& table, const PipelineLayoutDescriptor& layoutDesc)
     {
-        const std::string psoLabel = (!pso.label.empty() ? " \'" + pso.label + '\'' : "");
+        const string psoLabel = (!pso.label.empty() ? " \'" + pso.label + '\'' : "");
         LLGL_ASSERT(table.resources.size() == layoutDesc.bindings.size());
         for_range(i, table.resources.size())
         {
             if (table.resources[i] == nullptr)
             {
                 const BindingDescriptor& binding = layoutDesc.bindings[i];
-                const std::string bindingSetLabel = (binding.slot.set != 0 ? ", set " + std::to_string(binding.slot.set) : "");
-                const std::string bindingNameLabel = (!binding.name.empty() ? ", name '" + std::string(binding.name.c_str()) + '\'' : "");
+                const string bindingSetLabel = (binding.slot.set != 0 ? ", set " + std::to_string(binding.slot.set) : "");
+                const string bindingNameLabel = (!binding.name.empty() ? ", name '" + string(binding.name.c_str()) + '\'' : "");
                 LLGL_DBG_ERROR(
                     ErrorType::InvalidState,
                     "missing descriptor [%zu] in pipeline state%s for binding (slot %u%s%s)",
@@ -2652,7 +2652,7 @@ void DbgCommandBuffer::ValidateBlendStates()
             /* If fragment discard is disabled and there is any fragment shader output, this configuration might have been unintentional */
             if (!pso->graphicsDesc.rasterizer.discardEnabled && bindings_.anyFragmentOutput)
             {
-                const std::string psoLabel = (!pso->label.empty() ? " \'" + pso->label + '\'' : "");
+                const string psoLabel = (!pso->label.empty() ? " \'" + pso->label + '\'' : "");
                 LLGL_DBG_WARN(
                     WarningType::PointlessOperation,
                     "drawing to output merger with pipeline state%s [blend.sampleMask=0] might be unintentional",

--- a/sources/Renderer/DebugLayer/DbgCommandBuffer.h
+++ b/sources/Renderer/DebugLayer/DbgCommandBuffer.h
@@ -16,8 +16,8 @@
 #include "RenderState/DbgQueryHeap.h"
 #include "DbgQueryTimerPool.h"
 #include <cstdint>
-#include <string>
-#include <stack>
+#include <LLGL/Container/String.h>
+#include <LLGL/Container/Stack.h>
 
 
 namespace LLGL
@@ -65,15 +65,15 @@ class DbgCommandBuffer final : public CommandBuffer
 
         CommandBuffer&                  instance;
         const CommandBufferDescriptor   desc;
-        std::string                     label;
+        string                     label;
 
     private:
 
         struct BindingTable
         {
             ResourceHeap*           resourceHeap = nullptr;
-            std::vector<Resource*>  resources;
-            std::vector<char>       uniforms;
+            vector<Resource*>  resources;
+            vector<char>       uniforms;
         };
 
         struct Bindings
@@ -121,7 +121,7 @@ class DbgCommandBuffer final : public CommandBuffer
 
         struct Records
         {
-            std::vector<SwapChainFramePair> swapChainFrames;
+            vector<SwapChainFramePair> swapChainFrames;
         };
 
     private:
@@ -158,7 +158,7 @@ class DbgCommandBuffer final : public CommandBuffer
         void ValidateTextureRegionForFramebuffer(const TextureRegion& region, const Offset2D& offset);
         void ValidateIndexType(const Format format);
         void ValidateTextureBufferCopyStrides(DbgTexture& textureDbg, std::uint32_t rowStride, std::uint32_t layerStride, const Extent3D& extent);
-        void ValidateMemoryBarrierResourceFlags(ResourceType resourceType, long bindFlags, const std::string& label, std::uint32_t resourceIndex);
+        void ValidateMemoryBarrierResourceFlags(ResourceType resourceType, long bindFlags, const string& label, std::uint32_t resourceIndex);
 
         void ValidateStageFlags(long stageFlags, long validFlags);
         void ValidateBufferRange(DbgBuffer& bufferDbg, std::uint64_t offset, std::uint64_t size, const char* rangeName = nullptr);
@@ -226,7 +226,7 @@ class DbgCommandBuffer final : public CommandBuffer
         const RenderingFeatures&    features_;
         const RenderingLimits&      limits_;
 
-        std::stack<std::string>     debugGroups_;
+        stack<string>               debugGroups_;
 
         DbgQueryTimerPool           queryTimerPool_;
         bool                        perfProfilerEnabled_    = false;

--- a/sources/Renderer/DebugLayer/DbgCore.h
+++ b/sources/Renderer/DebugLayer/DbgCore.h
@@ -46,7 +46,7 @@ namespace LLGL
     LLGL_DBG_ERROR(ErrorType::UnsupportedFeature, UTF8String(FEATURE) + " not supported")
 
 #define LLGL_DBG_LABEL(DESC) \
-    ((DESC).debugName != nullptr ? std::string{ (DESC).debugName } : std::string{})
+    ((DESC).debugName != nullptr ? string{ (DESC).debugName } : string{})
 
 #define LLGL_DBG_CAST(TYPE, OBJ)                                                                \
     (                                                                                           \

--- a/sources/Renderer/DebugLayer/DbgQueryTimerPool.h
+++ b/sources/Renderer/DebugLayer/DbgQueryTimerPool.h
@@ -11,8 +11,8 @@
 
 #include <LLGL/ForwardDecls.h>
 #include <LLGL/RenderingDebugger.h>
-#include <vector>
-#include <stack>
+#include <LLGL/Container/Vector.h>
+#include <LLGL/Container/Stack.h>
 
 
 namespace LLGL
@@ -53,8 +53,8 @@ class DbgQueryTimerPool
         CommandQueue&                       commandQueue_;
         CommandBuffer&                      commandBuffer_;
 
-        std::vector<QueryHeap*>             queryHeaps_;
-        std::stack<std::size_t>             pendingRecordStack_;
+        vector<QueryHeap*>                  queryHeaps_;
+        stack<std::size_t>                  pendingRecordStack_;
         std::uint32_t                       currentQuery_       = 0;
         std::uint32_t                       currentQueryHeap_   = 0;
 

--- a/sources/Renderer/DebugLayer/DbgRenderSystem.cpp
+++ b/sources/Renderer/DebugLayer/DbgRenderSystem.cpp
@@ -131,8 +131,8 @@ BufferArray* DbgRenderSystem::CreateBufferArray(std::uint32_t numBuffers, Buffer
     RenderSystem::AssertCreateBufferArray(numBuffers, bufferArray);
 
     /* Create temporary buffer array with buffer instances */
-    std::vector<Buffer*>    bufferInstanceArray(numBuffers);
-    std::vector<DbgBuffer*> bufferDbgArray(numBuffers);
+    vector<Buffer*>    bufferInstanceArray(numBuffers);
+    vector<DbgBuffer*> bufferDbgArray(numBuffers);
 
     for (std::uint32_t i = 0; i < numBuffers; ++i)
     {
@@ -312,9 +312,9 @@ void DbgRenderSystem::Release(Sampler& sampler)
 /* ----- Resource Views ----- */
 
 // private
-std::vector<ResourceViewDescriptor> DbgRenderSystem::GetResourceViewInstanceCopy(const ArrayView<ResourceViewDescriptor>& resourceViews)
+vector<ResourceViewDescriptor> DbgRenderSystem::GetResourceViewInstanceCopy(const ArrayView<ResourceViewDescriptor>& resourceViews)
 {
-    std::vector<ResourceViewDescriptor> instanceResourceViews;
+    vector<ResourceViewDescriptor> instanceResourceViews;
     instanceResourceViews.reserve(resourceViews.size());
 
     for_range(i, resourceViews.size())
@@ -700,7 +700,7 @@ void DbgRenderSystem::ValidateCPUAccessFlags(long flags, long validFlags, const 
 {
     if ((flags & (~validFlags)) != 0)
     {
-        const std::string contextLabel = (contextDesc != nullptr ? " for " + std::string(contextDesc) : "");
+        const string contextLabel = (contextDesc != nullptr ? " for " + string(contextDesc) : "");
         LLGL_DBG_WARN(WarningType::ImproperArgument, "unknown CPU access flags specified%s", contextLabel.c_str());
     }
 }
@@ -709,7 +709,7 @@ void DbgRenderSystem::ValidateMiscFlags(long flags, long validFlags, const char*
 {
     if ((flags & (~validFlags)) != 0)
     {
-        const std::string contextLabel = (contextDesc != nullptr ? " for " + std::string(contextDesc) : "");
+        const string contextLabel = (contextDesc != nullptr ? " for " + string(contextDesc) : "");
         LLGL_DBG_WARN(WarningType::ImproperArgument, "unknown miscellaneous flags specified%s", contextLabel.c_str());
     }
 }
@@ -926,7 +926,7 @@ void DbgRenderSystem::ValidateBufferView(DbgBuffer& bufferDbg, const BufferViewD
     const std::uint64_t minAlignment = GetMinAlignmentForBufferBinding(bindingDesc, limits);
     if (minAlignment > 0 && (viewDesc.offset % minAlignment != 0 || viewDesc.size % minAlignment != 0))
     {
-        const std::string bindingSetLabel = (bindingDesc.slot.set != 0 ? "(set " + std::to_string(bindingDesc.slot.set) + ')' : "");
+        const string bindingSetLabel = (bindingDesc.slot.set != 0 ? "(set " + std::to_string(bindingDesc.slot.set) + ')' : "");
         LLGL_DBG_ERROR(
             ErrorType::InvalidArgument,
             "buffer view '%s' at slot %u%s does not satisfy minimum alignment of %" PRIu64 " %s",
@@ -1526,9 +1526,9 @@ void DbgRenderSystem::ValidateAttachmentDesc(const AttachmentDescriptor& attachm
     }
 }
 
-static std::string GetBindingSlotLabel(const BindingSlot& slot)
+static string GetBindingSlotLabel(const BindingSlot& slot)
 {
-    std::string label = "slot ";
+    string label = "slot ";
     label += std::to_string(slot.index);
     if (slot.set > 0)
     {
@@ -1539,9 +1539,9 @@ static std::string GetBindingSlotLabel(const BindingSlot& slot)
     return label;
 }
 
-static std::string GetBindingDescLabel(const BindingDescriptor& bindingDesc)
+static string GetBindingDescLabel(const BindingDescriptor& bindingDesc)
 {
-    std::string label;
+    string label;
     if (!bindingDesc.name.empty())
     {
         label += '\"';
@@ -1570,7 +1570,7 @@ static bool IsStreamOutputCompatibleFormat(const Format format)
 void DbgRenderSystem::ValidateShaderDesc(const ShaderDescriptor& shaderDesc)
 {
     /* Validate shader output-stream attributes */
-    std::unordered_map<std::string, std::size_t> attribNameToIndexMap;
+    std::unordered_map<string, std::size_t> attribNameToIndexMap;
     std::unordered_map<SystemValue, std::size_t, EnumHasher<SystemValue>> attribSVToIndexMap;
 
     struct BufferStrideRef
@@ -1580,13 +1580,13 @@ void DbgRenderSystem::ValidateShaderDesc(const ShaderDescriptor& shaderDesc)
     };
     BufferStrideRef bufferStridesRefs[LLGL_MAX_NUM_SO_BUFFERS];
 
-    const std::string shaderLabelPrefix =
+    const string shaderLabelPrefix =
     (
         shaderDesc.debugName != nullptr && *shaderDesc.debugName != '\0'
-            ? "shader '" + std::string(shaderDesc.debugName) + "': "
+            ? "shader '" + string(shaderDesc.debugName) + "': "
             : ""
     );
-    std::string attribLabel;
+    string attribLabel;
 
     for_range(i, shaderDesc.vertex.outputAttribs.size())
     {
@@ -1595,7 +1595,7 @@ void DbgRenderSystem::ValidateShaderDesc(const ShaderDescriptor& shaderDesc)
         /* Construct label for each attribute */;
         attribLabel = shaderLabelPrefix + "stream-output attribute [" + std::to_string(i) + "]";
         if (attrib.systemValue == SystemValue::Undefined && !attrib.name.empty())
-            attribLabel += " '" + std::string(attrib.name.c_str()) + "'";
+            attribLabel += " '" + string(attrib.name.c_str()) + "'";
 
         /* Validate attribute format */
         if (const char* formatIdent = ToString(attrib.format))
@@ -1704,7 +1704,7 @@ void DbgRenderSystem::ValidatePipelineLayoutDesc(const PipelineLayoutDescriptor&
     {
         if (binding.arraySize > 1)
         {
-            const std::string bindingLabel = GetBindingDescLabel(binding);
+            const string bindingLabel = GetBindingDescLabel(binding);
             LLGL_DBG_ERROR(
                 ErrorType::InvalidArgument,
                 "individual binding %s has array size of %u, but only heap-bindings can have an array size other than 0 or 1",
@@ -1837,7 +1837,7 @@ void DbgRenderSystem::ValidateBufferForBinding(const DbgBuffer& bufferDbg, const
 {
     if ((bufferDbg.desc.bindFlags & bindingDesc.bindFlags) != bindingDesc.bindFlags)
     {
-        const std::string bindingSetLabel = (bindingDesc.slot.set != 0 ? " (set " + std::to_string(bindingDesc.slot.set) + ')' : "");
+        const string bindingSetLabel = (bindingDesc.slot.set != 0 ? " (set " + std::to_string(bindingDesc.slot.set) + ')' : "");
         LLGL_DBG_ERROR(
             ErrorType::InvalidArgument,
             "binding flags mismatch between buffer resource at %u%s and binding descriptor",
@@ -1850,7 +1850,7 @@ void DbgRenderSystem::ValidateTextureForBinding(const DbgTexture& textureDbg, co
 {
     if ((textureDbg.desc.bindFlags & bindingDesc.bindFlags) != bindingDesc.bindFlags)
     {
-        const std::string bindingSetLabel = (bindingDesc.slot.set != 0 ? " (set " + std::to_string(bindingDesc.slot.set) + ')' : "");
+        const string bindingSetLabel = (bindingDesc.slot.set != 0 ? " (set " + std::to_string(bindingDesc.slot.set) + ')' : "");
         LLGL_DBG_ERROR(
             ErrorType::InvalidArgument,
             "binding flags mismatch between texture resource at %u%s and binding descriptor",
@@ -1860,9 +1860,9 @@ void DbgRenderSystem::ValidateTextureForBinding(const DbgTexture& textureDbg, co
 }
 
 // Converts the specified color mask into a string representation (e.g. "RGBA" or "R_G_").
-static std::string ColorMaskToString(std::uint8_t colorMask)
+static string ColorMaskToString(std::uint8_t colorMask)
 {
-    std::string s;
+    string s;
     s.reserve(4);
 
     s += ((colorMask & ColorMaskFlags::R) != 0 ? 'R' : '_');
@@ -1893,7 +1893,7 @@ void DbgRenderSystem::ValidateBlendTargetDescriptor(const BlendTargetDescriptor&
 {
     if (blendTargetDesc.colorMask != 0)
     {
-        const std::string colorMaskLabel = ColorMaskToString(blendTargetDesc.colorMask);
+        const string colorMaskLabel = ColorMaskToString(blendTargetDesc.colorMask);
         LLGL_DBG_ERROR(
             ErrorType::InvalidArgument,
             "cannot use color mask {%s} of blend target [%zu] without a fragment shader",
@@ -2112,7 +2112,7 @@ void DbgRenderSystem::ValidateGraphicsPipelineDesc(const GraphicsPipelineDescrip
                 !pipelineLayoutDbg->desc.heapBindings.empty())
             {
                 const char* psoDebugName = pipelineStateDesc.debugName;
-                const std::string psoLabel = (psoDebugName != nullptr && *psoDebugName != '\0' ? " '" + std::string(psoDebugName) + '\'' : "");
+                const string psoLabel = (psoDebugName != nullptr && *psoDebugName != '\0' ? " '" + string(psoDebugName) + '\'' : "");
                 LLGL_DBG_ERROR(
                     ErrorType::UndefinedBehavior,
                     "failed to reflect shader code in PSO%s with mix of heap- and individual bindings; "
@@ -2314,7 +2314,7 @@ void DbgRenderSystem::ValidatePipelineStateUniforms(const DbgPipelineLayout& pip
     if (pipelineLayout.desc.uniforms.empty())
         return;
 
-    std::vector<ShaderReflection> reflections;
+    vector<ShaderReflection> reflections;
 
     auto FindResourceInPreviousReflectionsByName = [&reflections](const LLGL::StringLiteral& name) -> const ShaderResourceReflection*
     {
@@ -2332,8 +2332,8 @@ void DbgRenderSystem::ValidatePipelineStateUniforms(const DbgPipelineLayout& pip
         return nullptr;
     };
 
-    std::set<std::string> reflectedUniformNames;
-    const std::string psoLabel = (psoDebugName != nullptr && *psoDebugName != '\0' ? " '" + std::string(psoDebugName) + '\'' : "");
+    set<string> reflectedUniformNames;
+    const string psoLabel = (psoDebugName != nullptr && *psoDebugName != '\0' ? " '" + string(psoDebugName) + '\'' : "");
 
     for (DbgShader* shader : shaders)
     {
@@ -2378,8 +2378,8 @@ void DbgRenderSystem::ValidatePipelineStateUniforms(const DbgPipelineLayout& pip
                     }
                     else if (otherResource->binding.slot != resource.binding.slot)
                     {
-                        const std::string lhsSlotLabel = GetBindingSlotLabel(resource.binding.slot);
-                        const std::string rhsSlotLabel = GetBindingSlotLabel(otherResource->binding.slot);
+                        const string lhsSlotLabel = GetBindingSlotLabel(resource.binding.slot);
+                        const string rhsSlotLabel = GetBindingSlotLabel(otherResource->binding.slot);
                         LLGL_DBG_ERROR(
                             ErrorType::InvalidArgument,
                             "slot mismatch for resource binding \"%s\" in %s shader (%s) and %s shader (%s)",

--- a/sources/Renderer/DebugLayer/DbgRenderSystem.h
+++ b/sources/Renderer/DebugLayer/DbgRenderSystem.h
@@ -120,7 +120,7 @@ class DbgRenderSystem final : public RenderSystem
         template <typename T, typename TBase>
         void ReleaseDbg(HWObjectContainer<T>& cont, TBase& entry);
 
-        std::vector<ResourceViewDescriptor> GetResourceViewInstanceCopy(const ArrayView<ResourceViewDescriptor>& resourceViews);
+        vector<ResourceViewDescriptor> GetResourceViewInstanceCopy(const ArrayView<ResourceViewDescriptor>& resourceViews);
 
     private:
 

--- a/sources/Renderer/DebugLayer/DbgSwapChain.cpp
+++ b/sources/Renderer/DebugLayer/DbgSwapChain.cpp
@@ -112,7 +112,7 @@ void DbgSwapChain::NotifyNextRenderPass(RenderingDebugger* debugger, const Rende
         auto* renderPassDbg = LLGL_CAST(const DbgRenderPass*, renderPass);
         if (!(renderPassDbg != nullptr && renderPassDbg->AnySwapChainAttachmentsLoaded(*this)))
         {
-            const std::string swapChainLabel = (!label.empty() ? "swap-chain \"" + label + "\"" : "swap-chain");
+            const string swapChainLabel = (!label.empty() ? "swap-chain \"" + label + "\"" : "swap-chain");
             debugger->Warningf(
                 WarningType::PointlessOperation,
                 "%s has not been read or presented since last render pass, but new render pass does not load its previous content",

--- a/sources/Renderer/DebugLayer/DbgSwapChain.h
+++ b/sources/Renderer/DebugLayer/DbgSwapChain.h
@@ -11,7 +11,7 @@
 
 #include <LLGL/SwapChain.h>
 #include "RenderState/DbgRenderPass.h"
-#include <string>
+#include <LLGL/Container/String.h>
 #include <memory>
 #include <functional>
 
@@ -52,7 +52,7 @@ class DbgSwapChain final : public SwapChain
 
         SwapChain&                  instance;
         const SwapChainDescriptor   desc;
-        std::string                 label;
+        string                      label;
 
     private:
 

--- a/sources/Renderer/DebugLayer/RenderState/DbgPipelineLayout.h
+++ b/sources/Renderer/DebugLayer/RenderState/DbgPipelineLayout.h
@@ -11,7 +11,7 @@
 
 #include <LLGL/PipelineLayout.h>
 #include <LLGL/PipelineLayoutFlags.h>
-#include <string>
+#include <LLGL/Container/String.h>
 
 
 namespace LLGL
@@ -37,7 +37,7 @@ class DbgPipelineLayout final : public PipelineLayout
 
         PipelineLayout&                 instance;
         const PipelineLayoutDescriptor  desc;
-        std::string                     label;
+        string                          label;
 
 };
 

--- a/sources/Renderer/DebugLayer/RenderState/DbgPipelineState.h
+++ b/sources/Renderer/DebugLayer/RenderState/DbgPipelineState.h
@@ -11,7 +11,7 @@
 
 #include <LLGL/PipelineState.h>
 #include <LLGL/PipelineStateFlags.h>
-#include <string>
+#include <LLGL/Container/String.h>
 
 
 namespace LLGL
@@ -43,7 +43,7 @@ class DbgPipelineState final : public PipelineState
     public:
 
         PipelineState&                  instance;
-        std::string                     label;
+        string                          label;
         const DbgPipelineLayout* const  pipelineLayout  = nullptr;
         const bool                      isGraphicsPSO   = false;
 

--- a/sources/Renderer/DebugLayer/RenderState/DbgQueryHeap.h
+++ b/sources/Renderer/DebugLayer/RenderState/DbgQueryHeap.h
@@ -10,8 +10,8 @@
 
 
 #include <LLGL/QueryHeap.h>
-#include <vector>
-#include <string>
+#include <LLGL/Container/Vector.h>
+#include <LLGL/Container/String.h>
 
 
 namespace LLGL
@@ -42,8 +42,8 @@ class DbgQueryHeap final : public QueryHeap
 
         QueryHeap&                  instance;
         const QueryHeapDescriptor   desc;
-        std::string                 label;
-        std::vector<State>          states;
+        string                      label;
+        vector<State>               states;
 
 };
 

--- a/sources/Renderer/DebugLayer/RenderState/DbgRenderPass.h
+++ b/sources/Renderer/DebugLayer/RenderState/DbgRenderPass.h
@@ -11,7 +11,7 @@
 
 #include <LLGL/RenderPass.h>
 #include <LLGL/RenderPassFlags.h>
-#include <string>
+#include <LLGL/Container/String.h>
 
 
 namespace LLGL
@@ -42,7 +42,7 @@ class DbgRenderPass final : public RenderPass
         const RenderPass&           instance;
         RenderPass* const           mutableInstance;
         const RenderPassDescriptor  desc;
-        std::string                 label;
+        string                      label;
 
 };
 

--- a/sources/Renderer/DebugLayer/RenderState/DbgResourceHeap.h
+++ b/sources/Renderer/DebugLayer/RenderState/DbgResourceHeap.h
@@ -11,7 +11,7 @@
 
 #include <LLGL/ResourceHeap.h>
 #include <LLGL/ResourceHeapFlags.h>
-#include <string>
+#include <LLGL/Container/String.h>
 
 
 namespace LLGL
@@ -38,7 +38,7 @@ class DbgResourceHeap final : public ResourceHeap
 
         ResourceHeap&                   instance;
         const ResourceHeapDescriptor    desc;
-        std::string                     label;
+        string                          label;
         const std::uint32_t             numBindings = 1;
 
 };

--- a/sources/Renderer/DebugLayer/Shader/DbgShader.h
+++ b/sources/Renderer/DebugLayer/Shader/DbgShader.h
@@ -11,7 +11,7 @@
 
 #include <LLGL/Shader.h>
 #include <LLGL/RenderingDebugger.h>
-#include <string>
+#include <LLGL/Container/String.h>
 
 
 namespace LLGL
@@ -58,7 +58,7 @@ class DbgShader final : public Shader
 
         Shader&                 instance;
         const ShaderDescriptor  desc;
-        std::string             label;
+        string             label;
 
     private:
 
@@ -67,10 +67,10 @@ class DbgShader final : public Shader
 
     private:
 
-        std::string             vertexID_;
-        std::string             instanceID_;
-        bool                    hasAnyOutputAttribs_    = false;
-        bool                    hasReflectionFailed_    = false;
+        string             vertexID_;
+        string             instanceID_;
+        bool               hasAnyOutputAttribs_    = false;
+        bool               hasReflectionFailed_    = false;
 
 };
 

--- a/sources/Renderer/DebugLayer/Texture/DbgRenderTarget.h
+++ b/sources/Renderer/DebugLayer/Texture/DbgRenderTarget.h
@@ -11,7 +11,7 @@
 
 #include <LLGL/RenderTarget.h>
 #include "../RenderState/DbgRenderPass.h"
-#include <string>
+#include <LLGL/Container/String.h>
 #include <memory>
 
 
@@ -40,7 +40,7 @@ class DbgRenderTarget final : public RenderTarget
 
         RenderTarget&                   instance;
         const RenderTargetDescriptor    desc;
-        std::string                     label;
+        string                          label;
 
     private:
 

--- a/sources/Renderer/DebugLayer/Texture/DbgTexture.h
+++ b/sources/Renderer/DebugLayer/Texture/DbgTexture.h
@@ -10,8 +10,8 @@
 
 
 #include <LLGL/Texture.h>
-#include <string>
-#include <set>
+#include <LLGL/Container/String.h>
+#include <LLGL/Container/Set.h>
 
 
 namespace LLGL
@@ -41,13 +41,13 @@ class DbgTexture final : public Texture
         const TextureDescriptor desc;
         TextureViewDescriptor   viewDesc;
         std::uint32_t           mipLevels           = 1;        // Actual number of MIP-map levels.
-        std::string             label;
+        string                  label;
         const bool              isTextureView       = false;
 
     private:
 
         //DbgTexture*             sharedTexture_      = nullptr;  // Reference to the shared texture (only for texture-views)
-        //std::set<DbgTexture*>   sharedTextureViews_;             // List of texture views that share the image data with this texture
+        //set<DbgTexture*>   sharedTextureViews_;             // List of texture views that share the image data with this texture
 
 };
 

--- a/sources/Renderer/Direct3D11/Buffer/D3D11BufferArray.h
+++ b/sources/Renderer/Direct3D11/Buffer/D3D11BufferArray.h
@@ -10,7 +10,7 @@
 
 
 #include <LLGL/BufferArray.h>
-#include <vector>
+#include <LLGL/Container/Vector.h>
 #include <d3d11.h>
 
 
@@ -60,8 +60,8 @@ class D3D11BufferArray final : public BufferArray
 
     private:
 
-        std::vector<void*>  buffersAndBindingLocators_;
-        std::vector<UINT>   stridesAndOffsets_;
+        vector<void*>  buffersAndBindingLocators_;
+        vector<UINT>   stridesAndOffsets_;
 
 };
 

--- a/sources/Renderer/Direct3D11/Buffer/D3D11StagingBufferPool.h
+++ b/sources/Renderer/Direct3D11/Buffer/D3D11StagingBufferPool.h
@@ -11,7 +11,7 @@
 
 #include "D3D11StagingBuffer.h"
 #include <d3d12.h>
-#include <vector>
+#include <LLGL/Container/Vector.h>
 
 
 namespace LLGL
@@ -67,7 +67,7 @@ class D3D11StagingBufferPool
         ID3D11Device*                   device_             = nullptr;
         ID3D11DeviceContext*            context_            = nullptr;
 
-        std::vector<D3D11StagingBuffer> chunks_;
+        vector<D3D11StagingBuffer> chunks_;
         std::size_t                     chunkIdx_           = 0;
         UINT                            chunkSize_          = 0;
         D3D11_USAGE                     usage_              = D3D11_USAGE_STAGING;

--- a/sources/Renderer/Direct3D11/Command/D3D11CommandBuffer.h
+++ b/sources/Renderer/Direct3D11/Command/D3D11CommandBuffer.h
@@ -14,7 +14,7 @@
 #include "../../DXCommon/DXCore.h"
 #include "../Direct3D11.h"
 #include <dxgi.h>
-#include <vector>
+#include <LLGL/Container/Vector.h>
 #include <cstddef>
 
 

--- a/sources/Renderer/Direct3D11/Command/D3D11PrimaryCommandBuffer.cpp
+++ b/sources/Renderer/Direct3D11/Command/D3D11PrimaryCommandBuffer.cpp
@@ -1050,7 +1050,7 @@ void D3D11PrimaryCommandBuffer::PushDebugGroup(const char* name)
     #if LLGL_D3D11_ENABLE_FEATURELEVEL >= 1
     if (annotation_)
     {
-        const std::wstring nameWStr = ToWideString(name);
+        const wstring nameWStr = ToWideString(name);
         annotation_->BeginEvent(nameWStr.c_str());
     }
     #endif

--- a/sources/Renderer/Direct3D11/D3D11ObjectUtils.cpp
+++ b/sources/Renderer/Direct3D11/D3D11ObjectUtils.cpp
@@ -7,7 +7,7 @@
 
 #include "D3D11ObjectUtils.h"
 #include "../DXCommon/DXCore.h"
-#include <string>
+#include <LLGL/Container/String.h>
 #include <cstring>
 
 
@@ -35,7 +35,7 @@ void D3D11SetObjectNameSubscript(ID3D11DeviceChild* obj, const char* name, const
     {
         if (name != nullptr)
         {
-            std::string nameWithSubscript = name;
+            string nameWithSubscript = name;
             nameWithSubscript += subscript;
             const std::size_t nameLen = nameWithSubscript.size();
             obj->SetPrivateData(DXGetD3DDebugObjectNameGUID(), static_cast<UINT>(nameLen), nameWithSubscript.c_str());
@@ -50,20 +50,20 @@ void D3D11SetObjectNameIndexed(ID3D11DeviceChild* obj, const char* name, std::ui
     if (name != nullptr)
     {
         /* Append subscript to label */
-        const std::string subscript = std::to_string(index);
+        const string subscript = std::to_string(index);
         D3D11SetObjectNameSubscript(obj, name, subscript.c_str());
     }
     else
         D3D11SetObjectName(obj, nullptr);
 }
 
-std::string D3D11GetObjectName(ID3D11DeviceChild* obj)
+string D3D11GetObjectName(ID3D11DeviceChild* obj)
 {
     if (obj != nullptr)
     {
         UINT nameLen = 0;
         obj->GetPrivateData(DXGetD3DDebugObjectNameGUID(), &nameLen, nullptr);
-        std::string name;
+        string name;
         name.resize(nameLen);
         obj->GetPrivateData(DXGetD3DDebugObjectNameGUID(), &nameLen, &name[0]);
         return name;
@@ -77,7 +77,7 @@ void D3D11ThrowIfFailed(HRESULT hr, const char* info, ID3D11DeviceChild* obj)
     {
         if (obj != nullptr)
         {
-            const std::string infoExt = std::string(info) + " \"" + D3D11GetObjectName(obj) + "\"";
+            const string infoExt = string(info) + " \"" + D3D11GetObjectName(obj) + "\"";
             DXThrowIfFailed(hr, infoExt.c_str());
         }
         else

--- a/sources/Renderer/Direct3D11/D3D11ObjectUtils.h
+++ b/sources/Renderer/Direct3D11/D3D11ObjectUtils.h
@@ -15,7 +15,7 @@
 #include <LLGL/Utils/TypeNames.h>
 #include <d3d11.h>
 #include <cstdint>
-#include <string>
+#include <LLGL/Container/String.h>
 
 
 namespace LLGL
@@ -32,7 +32,7 @@ void D3D11SetObjectNameSubscript(ID3D11DeviceChild* obj, const char* name, const
 void D3D11SetObjectNameIndexed(ID3D11DeviceChild* obj, const char* name, std::uint32_t index);
 
 // Returns the debug name of the specified D3D device child.
-std::string D3D11GetObjectName(ID3D11DeviceChild* obj);
+string D3D11GetObjectName(ID3D11DeviceChild* obj);
 
 // Traps the runtime if 'hr' is not S_OK.
 void D3D11ThrowIfFailed(HRESULT hr, const char* info, ID3D11DeviceChild* obj = nullptr);

--- a/sources/Renderer/Direct3D11/D3D11RenderSystem.cpp
+++ b/sources/Renderer/Direct3D11/D3D11RenderSystem.cpp
@@ -832,7 +832,7 @@ void D3D11RenderSystem::QueryRendererInfo(RendererInfo& info)
     }
 
     /* Initialize HLSL version string */
-    info.shadingLanguageName = "HLSL " + std::string(DXFeatureLevelToShaderModel(GetFeatureLevel()));
+    info.shadingLanguageName = "HLSL " + string(DXFeatureLevelToShaderModel(GetFeatureLevel()));
 
     /* Initialize video adapter strings */
     info.deviceName = videoAdatperInfo_.name.c_str();
@@ -840,9 +840,9 @@ void D3D11RenderSystem::QueryRendererInfo(RendererInfo& info)
 }
 
 // Returns the HLSL version for the specified Direct3D feature level.
-static std::vector<ShadingLanguage> DXGetHLSLVersions(D3D_FEATURE_LEVEL featureLevel)
+static vector<ShadingLanguage> DXGetHLSLVersions(D3D_FEATURE_LEVEL featureLevel)
 {
-    std::vector<ShadingLanguage> languages;
+    vector<ShadingLanguage> languages;
 
     languages.push_back(ShadingLanguage::HLSL);
     languages.push_back(ShadingLanguage::HLSL_2_0);
@@ -858,9 +858,9 @@ static std::vector<ShadingLanguage> DXGetHLSLVersions(D3D_FEATURE_LEVEL featureL
     return languages;
 }
 
-static std::vector<Format> GetDefaultSupportedDXTextureFormats(D3D_FEATURE_LEVEL featureLevel)
+static vector<Format> GetDefaultSupportedDXTextureFormats(D3D_FEATURE_LEVEL featureLevel)
 {
-    std::vector<Format> formats;
+    vector<Format> formats;
 
     std::size_t numFormats = 0;
     DXGetDefaultSupportedTextureFormats(nullptr, &numFormats);

--- a/sources/Renderer/Direct3D11/D3D11RenderSystem.h
+++ b/sources/Renderer/Direct3D11/D3D11RenderSystem.h
@@ -190,7 +190,7 @@ class D3D11RenderSystem final : public RenderSystem
         bool                                    tearingSupported_       = false;
 
         std::shared_ptr<D3D11StateManager>      stateMngr_;
-        std::vector<D3D11StateManager*>         deferredStateMngrRefs_;
+        vector<D3D11StateManager*>         deferredStateMngrRefs_;
 
         /* ----- Hardware object containers ----- */
 

--- a/sources/Renderer/Direct3D11/D3D11SwapChain.cpp
+++ b/sources/Renderer/Direct3D11/D3D11SwapChain.cpp
@@ -270,7 +270,7 @@ void D3D11SwapChain::ResolveSubresources(ID3D11DeviceContext* context)
 bool D3D11SwapChain::ResizeBuffersPrimary(const Extent2D& resolution)
 {
     /* Store current debug names */
-    std::string debugNames[5];
+    string debugNames[5];
     if (hasDebugName_)
         StoreDebugNames(debugNames);
 
@@ -505,7 +505,7 @@ void D3D11SwapChain::CreateResolutionDependentResources()
     }
 }
 
-void D3D11SwapChain::StoreDebugNames(std::string (&debugNames)[5])
+void D3D11SwapChain::StoreDebugNames(string (&debugNames)[5])
 {
     debugNames[0] = D3D11GetObjectName(colorBuffer_.Get());
     debugNames[1] = D3D11GetObjectName(colorBufferMS_.Get());
@@ -517,7 +517,7 @@ void D3D11SwapChain::StoreDebugNames(std::string (&debugNames)[5])
     }
 }
 
-void D3D11SwapChain::RestoreDebugNames(const std::string (&debugNames)[5])
+void D3D11SwapChain::RestoreDebugNames(const string (&debugNames)[5])
 {
     D3D11SetObjectName(colorBuffer_.Get(), debugNames[0].c_str());
     D3D11SetObjectName(colorBufferMS_.Get(), debugNames[1].c_str());

--- a/sources/Renderer/Direct3D11/D3D11SwapChain.h
+++ b/sources/Renderer/Direct3D11/D3D11SwapChain.h
@@ -83,8 +83,8 @@ class D3D11SwapChain final : public SwapChain
 
         void CreateResolutionDependentResources();
 
-        void StoreDebugNames(std::string (&debugNames)[5]);
-        void RestoreDebugNames(const std::string (&debugNames)[5]);
+        void StoreDebugNames(string (&debugNames)[5]);
+        void RestoreDebugNames(const string (&debugNames)[5]);
 
     private:
 

--- a/sources/Renderer/Direct3D11/D3D11Types.cpp
+++ b/sources/Renderer/Direct3D11/D3D11Types.cpp
@@ -8,7 +8,7 @@
 #include "D3D11Types.h"
 #include "../DXCommon/DXCore.h"
 #include <stdexcept>
-#include <string>
+#include <LLGL/Container/String.h>
 
 
 namespace LLGL

--- a/sources/Renderer/Direct3D11/RenderState/D3D11ConstantsCache.cpp
+++ b/sources/Renderer/Direct3D11/RenderState/D3D11ConstantsCache.cpp
@@ -27,7 +27,7 @@ D3D11ConstantsCache::D3D11ConstantsCache(
     const ArrayView<UniformDescriptor>& uniforms)
 {
     /* Reflect all constant buffers from all shaders */
-    std::vector<const D3D11ConstantBufferReflection*> cbufferReflections;
+    vector<const D3D11ConstantBufferReflection*> cbufferReflections;
 
     auto FindCbufferField = [&cbufferReflections](const LLGL::StringView& name) -> std::pair<const D3D11ConstantBufferReflection*, const D3D11ConstantReflection*>
     {
@@ -52,7 +52,7 @@ D3D11ConstantsCache::D3D11ConstantsCache(
         LLGL_ASSERT_PTR(shader);
 
         /* Get cached cbuffer reflection from shader */
-        const std::vector<D3D11ConstantBufferReflection>* currentCbufferReflections = nullptr;
+        const vector<D3D11ConstantBufferReflection>* currentCbufferReflections = nullptr;
         HRESULT hr = shader->ReflectAndCacheConstantBuffers(&currentCbufferReflections);
         DXThrowIfFailed(hr, "failed to reflect constant buffers in D3D11 shader");
         LLGL_ASSERT_PTR(currentCbufferReflections);

--- a/sources/Renderer/Direct3D11/RenderState/D3D11ConstantsCache.h
+++ b/sources/Renderer/Direct3D11/RenderState/D3D11ConstantsCache.h
@@ -15,7 +15,7 @@
 #include <LLGL/Container/SmallVector.h>
 #include "../Shader/D3D11Shader.h"
 #include <cstdint>
-#include <vector>
+#include <LLGL/Container/Vector.h>
 #include <d3d11.h>
 #include <memory>
 
@@ -69,7 +69,7 @@ class D3D11ConstantsCache
         {
             UINT                            shaderRegister; // Constant buffer binding slot
             long                            stageFlags;
-            std::vector<ConstantRegister>   constants;
+            vector<ConstantRegister>   constants;
         };
 
     private:

--- a/sources/Renderer/Direct3D11/RenderState/D3D11PipelineLayout.cpp
+++ b/sources/Renderer/Direct3D11/RenderState/D3D11PipelineLayout.cpp
@@ -93,7 +93,7 @@ static D3DResourceType ToD3DResourceType(const BindingDescriptor& desc)
     return D3DResourceType_Invalid;
 }
 
-void D3D11PipelineLayout::BuildDynamicResourceBindings(const std::vector<BindingDescriptor>& bindingDescs)
+void D3D11PipelineLayout::BuildDynamicResourceBindings(const vector<BindingDescriptor>& bindingDescs)
 {
     bindings_.reserve(bindingDescs.size());
     for (const BindingDescriptor& desc : bindingDescs)
@@ -108,7 +108,7 @@ static ComPtr<ID3D11SamplerState> DXCreateSamplerState(ID3D11Device* device, con
     return nativeSamplerState;
 }
 
-void D3D11PipelineLayout::BuildStaticSamplers(ID3D11Device* device, const std::vector<StaticSamplerDescriptor>& staticSamplerDescs)
+void D3D11PipelineLayout::BuildStaticSamplers(ID3D11Device* device, const vector<StaticSamplerDescriptor>& staticSamplerDescs)
 {
     D3D11_SAMPLER_DESC nativeDesc;
     staticSamplers_.reserve(staticSamplerDescs.size());

--- a/sources/Renderer/Direct3D11/RenderState/D3D11PipelineLayout.h
+++ b/sources/Renderer/Direct3D11/RenderState/D3D11PipelineLayout.h
@@ -54,28 +54,28 @@ class D3D11PipelineLayout final : public PipelineLayout
         }
 
         // Returns the list of dynamic D3D resource bindings.
-        inline const std::vector<D3D11PipelineResourceBinding>& GetBindings() const
+        inline const vector<D3D11PipelineResourceBinding>& GetBindings() const
         {
             return bindings_;
         }
 
         // Returns the list of uniform descritpors this pipeline layout was created with.
-        inline const std::vector<UniformDescriptor>& GetUniforms() const
+        inline const vector<UniformDescriptor>& GetUniforms() const
         {
             return uniforms_;
         }
 
     private:
 
-        void BuildDynamicResourceBindings(const std::vector<BindingDescriptor>& bindingDescs);
-        void BuildStaticSamplers(ID3D11Device* device, const std::vector<StaticSamplerDescriptor>& staticSamplerDescs);
+        void BuildDynamicResourceBindings(const vector<BindingDescriptor>& bindingDescs);
+        void BuildStaticSamplers(ID3D11Device* device, const vector<StaticSamplerDescriptor>& staticSamplerDescs);
 
     private:
 
         DynamicVector<BindingDescriptor>            heapBindings_;
-        std::vector<D3D11PipelineResourceBinding>   bindings_;
-        std::vector<D3D11StaticSampler>             staticSamplers_;
-        std::vector<UniformDescriptor>              uniforms_;
+        vector<D3D11PipelineResourceBinding>   bindings_;
+        vector<D3D11StaticSampler>             staticSamplers_;
+        vector<UniformDescriptor>              uniforms_;
 
 };
 

--- a/sources/Renderer/Direct3D11/RenderState/D3D11PipelineState.cpp
+++ b/sources/Renderer/Direct3D11/RenderState/D3D11PipelineState.cpp
@@ -50,9 +50,9 @@ const Report* D3D11PipelineState::GetReport() const
     return (*report_.GetText() != '\0' || report_.HasErrors() ? &report_ : nullptr);
 }
 
-void D3D11PipelineState::ResetReport(std::string&& text, bool hasErrors)
+void D3D11PipelineState::ResetReport(string&& text, bool hasErrors)
 {
-    ResetReportWithNewline(report_, std::forward<std::string&&>(text), hasErrors);
+    ResetReportWithNewline(report_, std::forward<string&&>(text), hasErrors);
 }
 
 

--- a/sources/Renderer/Direct3D11/RenderState/D3D11PipelineState.h
+++ b/sources/Renderer/Direct3D11/RenderState/D3D11PipelineState.h
@@ -61,7 +61,7 @@ class D3D11PipelineState : public PipelineState
         );
 
         // Writes the report with the specified message and error bit.
-        void ResetReport(std::string&& text, bool hasErrors = false);
+        void ResetReport(string&& text, bool hasErrors = false);
 
         // Returns the mutable report object.
         inline Report& GetMutableReport()

--- a/sources/Renderer/Direct3D11/RenderState/D3D11QueryHeap.h
+++ b/sources/Renderer/Direct3D11/RenderState/D3D11QueryHeap.h
@@ -12,7 +12,7 @@
 #include <LLGL/QueryHeap.h>
 #include "../../DXCommon/ComPtr.h"
 #include <d3d11.h>
-#include <vector>
+#include <LLGL/Container/Vector.h>
 #include <cstdint>
 
 
@@ -85,7 +85,7 @@ class D3D11QueryHeap final : public QueryHeap
 
         D3D11_QUERY                     nativeType_     = D3D11_QUERY_EVENT;
         std::uint32_t                   groupSize_      = 1;
-        std::vector<D3D11NativeQuery>   nativeQueries_;
+        vector<D3D11NativeQuery>   nativeQueries_;
 
 };
 

--- a/sources/Renderer/Direct3D11/RenderState/D3D11ResourceHeap.cpp
+++ b/sources/Renderer/Direct3D11/RenderState/D3D11ResourceHeap.cpp
@@ -319,14 +319,14 @@ void D3D11ResourceHeap::BindForComputePipeline1(ID3D11DeviceContext1* context1, 
         __VA_ARGS__                                             \
     )
 
-std::vector<D3D11ResourceHeap::D3DResourceBinding> D3D11ResourceHeap::FilterAndSortD3DBindingSlots(
+vector<D3D11ResourceHeap::D3DResourceBinding> D3D11ResourceHeap::FilterAndSortD3DBindingSlots(
     BindingDescriptorIterator&                  bindingIter,
     const std::initializer_list<ResourceType>&  resourceTypes,
     long                                        resourceBindFlags,
     long                                        affectedStage)
 {
     /* Collect all binding points of the specified resource types */
-    std::vector<D3DResourceBinding> resourceBindings;
+    vector<D3DResourceBinding> resourceBindings;
     resourceBindings.reserve(bindingIter.GetCount());
 
     for (ResourceType type : resourceTypes)

--- a/sources/Renderer/Direct3D11/RenderState/D3D11ResourceHeap.h
+++ b/sources/Renderer/Direct3D11/RenderState/D3D11ResourceHeap.h
@@ -17,7 +17,7 @@
 #include "../../BindingIterator.h"
 #include "../../SegmentedBuffer.h"
 #include "../../DXCommon/DXManagedComPtrArray.h"
-#include <vector>
+#include <LLGL/Container/Vector.h>
 #include <functional>
 #include <initializer_list>
 #include "../Direct3D11.h"
@@ -271,7 +271,7 @@ class D3D11ResourceHeap final : public ResourceHeap
 
     private:
 
-        static std::vector<D3DResourceBinding> FilterAndSortD3DBindingSlots(
+        static vector<D3DResourceBinding> FilterAndSortD3DBindingSlots(
             BindingDescriptorIterator&                  bindingIter,
             const std::initializer_list<ResourceType>&  resourceTypes,
             long                                        resourceBindFlags,

--- a/sources/Renderer/Direct3D11/RenderState/D3D11StateManager.h
+++ b/sources/Renderer/Direct3D11/RenderState/D3D11StateManager.h
@@ -15,7 +15,7 @@
 #include "../Buffer/D3D11StagingBufferPool.h"
 #include "../../DXCommon/ComPtr.h"
 #include <LLGL/PipelineStateFlags.h>
-#include <vector>
+#include <LLGL/Container/Vector.h>
 #include <cstdint>
 
 

--- a/sources/Renderer/Direct3D11/Shader/D3D11Shader.cpp
+++ b/sources/Renderer/Direct3D11/Shader/D3D11Shader.cpp
@@ -47,7 +47,7 @@ bool D3D11Shader::Reflect(ShaderReflection& reflection) const
         return false;
 }
 
-HRESULT D3D11Shader::ReflectAndCacheConstantBuffers(const std::vector<D3D11ConstantBufferReflection>** outConstantBuffers)
+HRESULT D3D11Shader::ReflectAndCacheConstantBuffers(const vector<D3D11ConstantBufferReflection>** outConstantBuffers)
 {
     if (cbufferReflectionResult_ == S_FALSE)
     {
@@ -122,7 +122,7 @@ static void ConvertSODeclEntry(D3D11_SO_DECLARATION_ENTRY& dst, const VertexAttr
 bool D3D11Shader::CompileSource(ID3D11Device* device, const ShaderDescriptor& shaderDesc)
 {
     /* Get source code */
-    std::string fileContent;
+    string      fileContent;
     const char* sourceCode      = nullptr;
     SIZE_T      sourceLength    = 0;
     const char* sourceName      = nullptr;
@@ -248,7 +248,7 @@ ComPtr<ID3D11DeviceChild> D3D11Shader::CreateNativeShaderFromBlob(
             if (streamOutputAttribs != nullptr && numStreamOutputAttribs > 0)
             {
                 /* Initialize output elements for geometry shader with stream-output */
-                std::vector<D3D11_SO_DECLARATION_ENTRY> outputElements;
+                vector<D3D11_SO_DECLARATION_ENTRY> outputElements;
                 outputElements.resize(numStreamOutputAttribs);
 
                 UINT bufferStrides[D3D11_SO_BUFFER_SLOT_COUNT];
@@ -381,7 +381,7 @@ HRESULT D3D11Shader::ReflectShaderByteCode(ShaderReflection& reflection) const
     #endif // /__GNUC__
 }
 
-HRESULT D3D11Shader::ReflectConstantBuffers(std::vector<D3D11ConstantBufferReflection>& outConstantBuffers) const
+HRESULT D3D11Shader::ReflectConstantBuffers(vector<D3D11ConstantBufferReflection>& outConstantBuffers) const
 {
     // D3D11 shader reflection is currently not supported for MinGW,
     // due to missing reference to '_GUID const& __mingw_uuidof<ID3D11ShaderReflection>()'.
@@ -424,7 +424,7 @@ HRESULT D3D11Shader::ReflectConstantBuffers(std::vector<D3D11ConstantBufferRefle
             if (FAILED(hr))
                 return hr;
 
-            std::vector<D3D11ConstantReflection> fieldsInfo;
+            vector<D3D11ConstantReflection> fieldsInfo;
 
             for_range(fieldIndex, shaderBufferDesc.Variables)
             {

--- a/sources/Renderer/Direct3D11/Shader/D3D11Shader.h
+++ b/sources/Renderer/Direct3D11/Shader/D3D11Shader.h
@@ -15,8 +15,8 @@
 #include <LLGL/BufferFlags.h>
 #include <LLGL/Report.h>
 #include "../../DXCommon/ComPtr.h"
-#include <vector>
-#include <string>
+#include <LLGL/Container/Vector.h>
+#include <LLGL/Container/String.h>
 #include <d3d11.h>
 
 
@@ -26,16 +26,16 @@ namespace LLGL
 
 struct D3D11ConstantReflection
 {
-    std::string name;   // Name of the constant buffer field.
-    UINT        offset; // Offset (in bytes) within the constant buffer.
-    UINT        size;   // Size (in bytes) of this uniform.
+    string  name;   // Name of the constant buffer field.
+    UINT    offset; // Offset (in bytes) within the constant buffer.
+    UINT    size;   // Size (in bytes) of this uniform.
 };
 
 struct D3D11ConstantBufferReflection
 {
     UINT                                    slot;
     UINT                                    size;
-    std::vector<D3D11ConstantReflection>    fields;
+    vector<D3D11ConstantReflection>    fields;
 };
 
 class D3D11Shader : public Shader
@@ -54,7 +54,7 @@ class D3D11Shader : public Shader
         D3D11Shader(const ShaderType type);
 
         // Returns a list of all reflected constant buffers including their fields.
-        HRESULT ReflectAndCacheConstantBuffers(const std::vector<D3D11ConstantBufferReflection>** outConstantBuffers);
+        HRESULT ReflectAndCacheConstantBuffers(const vector<D3D11ConstantBufferReflection>** outConstantBuffers);
 
         // Returns the native D3D shader object.
         inline const ComPtr<ID3D11DeviceChild>& GetNative() const
@@ -99,7 +99,7 @@ class D3D11Shader : public Shader
 
         HRESULT ReflectShaderByteCode(ShaderReflection& reflection) const;
 
-        HRESULT ReflectConstantBuffers(std::vector<D3D11ConstantBufferReflection>& outConstantBuffers) const;
+        HRESULT ReflectConstantBuffers(vector<D3D11ConstantBufferReflection>& outConstantBuffers) const;
 
     private:
 
@@ -109,7 +109,7 @@ class D3D11Shader : public Shader
         Report                                      report_;
 
         HRESULT                                     cbufferReflectionResult_    = S_FALSE;
-        std::vector<D3D11ConstantBufferReflection>  cbufferReflections_;
+        vector<D3D11ConstantBufferReflection>  cbufferReflections_;
 
 };
 

--- a/sources/Renderer/Direct3D11/Shader/D3D11VertexShader.cpp
+++ b/sources/Renderer/Direct3D11/Shader/D3D11VertexShader.cpp
@@ -58,7 +58,7 @@ void D3D11VertexShader::BuildInputLayout(ID3D11Device* device, UINT numVertexAtt
     LLGL_ASSERT(GetType() == ShaderType::Vertex, "cannot build input layout for non-vertex-shader");
 
     /* Setup input element descriptors */
-    std::vector<D3D11_INPUT_ELEMENT_DESC> inputElements;
+    vector<D3D11_INPUT_ELEMENT_DESC> inputElements;
     inputElements.resize(numVertexAttribs);
 
     for_range(i, numVertexAttribs)

--- a/sources/Renderer/Direct3D11/Texture/D3D11RenderTarget.cpp
+++ b/sources/Renderer/Direct3D11/Texture/D3D11RenderTarget.cpp
@@ -82,7 +82,7 @@ void D3D11RenderTarget::SetDebugName(const char* name)
         /* Set label for each RTV */
         for_range(i, renderTargetHandles_.GetNumRenderTargetViews())
         {
-            const std::string subscript = ".RTV[" + std::to_string(i) + "]";
+            const string subscript = ".RTV[" + std::to_string(i) + "]";
             D3D11SetObjectNameSubscript(renderTargetHandles_.GetRenderTargetViews()[i], name, subscript.c_str());
         }
 
@@ -93,7 +93,7 @@ void D3D11RenderTarget::SetDebugName(const char* name)
         /* Set lable for each internal texture */
         for_range(i, internalTextures_.size())
         {
-            const std::string subscript = ".Tex2D[" + std::to_string(i) + "]";
+            const string subscript = ".Tex2D[" + std::to_string(i) + "]";
             D3D11SetObjectNameSubscript(internalTextures_[i].Get(), name, subscript.c_str());
         }
     }

--- a/sources/Renderer/Direct3D11/Texture/D3D11RenderTarget.h
+++ b/sources/Renderer/Direct3D11/Texture/D3D11RenderTarget.h
@@ -13,7 +13,7 @@
 #include "D3D11RenderTargetHandles.h"
 #include "../../DXCommon/ComPtr.h"
 #include "../../../Core/CompilerExtensions.h"
-#include <vector>
+#include <LLGL/Container/Vector.h>
 #include <functional>
 #include <d3d11.h>
 
@@ -129,12 +129,12 @@ class D3D11RenderTarget final : public RenderTarget
 
         Extent2D                                resolution_;
 
-        std::vector<ComPtr<ID3D11Texture2D>>    internalTextures_;  // Depth-stencil texture or multi-sampled color targets
+        vector<ComPtr<ID3D11Texture2D>>    internalTextures_;  // Depth-stencil texture or multi-sampled color targets
         DXGI_FORMAT                             depthStencilFormat_     = DXGI_FORMAT_UNKNOWN;
         D3D11RenderTargetHandles                renderTargetHandles_;
 
         DXGI_SAMPLE_DESC                        sampleDesc_             = { 1u, 0u };
-        std::vector<ResolveTarget>              resolveTargets_;
+        vector<ResolveTarget>              resolveTargets_;
 
         const D3D11RenderPass*                  renderPass_             = nullptr;
 

--- a/sources/Renderer/Direct3D11/Texture/D3D11RenderTargetHandles.h
+++ b/sources/Renderer/Direct3D11/Texture/D3D11RenderTargetHandles.h
@@ -13,7 +13,7 @@
 #include <LLGL/Container/DynamicArray.h>
 #include "../RenderState/D3D11BindingLocator.h"
 #include "../../DXCommon/ComPtr.h"
-#include <vector>
+#include <LLGL/Container/Vector.h>
 #include <d3d11.h>
 
 

--- a/sources/Renderer/Direct3D12/Buffer/D3D12BufferConstantsPool.cpp
+++ b/sources/Renderer/Direct3D12/Buffer/D3D12BufferConstantsPool.cpp
@@ -13,7 +13,7 @@
 #include "../../DXCommon/DXCore.h"
 #include "../../../Core/CoreUtils.h"
 #include "../../../Core/Assertion.h"
-#include <string.h>
+#include <LLGL/Container/String.h>
 
 
 namespace LLGL

--- a/sources/Renderer/Direct3D12/Buffer/D3D12BufferConstantsPool.h
+++ b/sources/Renderer/Direct3D12/Buffer/D3D12BufferConstantsPool.h
@@ -13,7 +13,7 @@
 #include <d3d12.h>
 #include <LLGL/Container/ArrayView.h>
 #include <LLGL/Container/SmallVector.h>
-#include <vector>
+#include <LLGL/Container/Vector.h>
 
 
 namespace LLGL
@@ -98,7 +98,7 @@ class D3D12BufferConstantsPool
     private:
 
         D3D12Resource               resource_;
-        std::vector<ConstantRange>  constants_;
+        vector<ConstantRange>  constants_;
 
 };
 

--- a/sources/Renderer/Direct3D12/Buffer/D3D12IntermediateBufferPool.h
+++ b/sources/Renderer/Direct3D12/Buffer/D3D12IntermediateBufferPool.h
@@ -11,7 +11,7 @@
 
 #include "D3D12StagingBuffer.h"
 #include <d3d12.h>
-#include <vector>
+#include <LLGL/Container/Vector.h>
 
 
 namespace LLGL
@@ -46,7 +46,7 @@ class D3D12IntermediateBufferPool
 
         ID3D12Device*                   device_     = nullptr;
         D3D12_HEAP_TYPE                 heapType_   = D3D12_HEAP_TYPE_DEFAULT;
-        std::vector<D3D12StagingBuffer> chunks_; // Chunks are always growing in size, i.e. chunk[N] must always be smaller than chunk[N+1]
+        vector<D3D12StagingBuffer> chunks_; // Chunks are always growing in size, i.e. chunk[N] must always be smaller than chunk[N+1]
 
 };
 

--- a/sources/Renderer/Direct3D12/Buffer/D3D12StagingBuffer.cpp
+++ b/sources/Renderer/Direct3D12/Buffer/D3D12StagingBuffer.cpp
@@ -9,7 +9,7 @@
 #include "../../DXCommon/DXCore.h"
 #include "../../../Core/CoreUtils.h"
 #include "../D3DX12/d3dx12.h"
-#include <string.h>
+#include <LLGL/Container/String.h>
 
 
 namespace LLGL

--- a/sources/Renderer/Direct3D12/Buffer/D3D12StagingBufferPool.h
+++ b/sources/Renderer/Direct3D12/Buffer/D3D12StagingBufferPool.h
@@ -12,7 +12,7 @@
 #include "D3D12StagingBuffer.h"
 #include "D3D12CPUAccessBuffer.h"
 #include <LLGL/RenderSystemFlags.h>
-#include <vector>
+#include <LLGL/Container/Vector.h>
 
 
 namespace LLGL
@@ -116,11 +116,11 @@ class D3D12StagingBufferPool
 
         ID3D12Device*                       device_                     = nullptr;
 
-        std::vector<D3D12StagingBuffer>     chunks_;
+        vector<D3D12StagingBuffer>     chunks_;
         std::size_t                         chunkIdx_                   = 0;
         UINT64                              chunkSize_                  = 0;
 
-        std::vector<D3D12CPUAccessBuffer>   cpuAccessBuffers_;
+        vector<D3D12CPUAccessBuffer>   cpuAccessBuffers_;
         std::size_t                         numReadMappedCPUBuffers_    = 0;
         std::size_t                         numWriteMappedCPUBuffers_   = 0;
 

--- a/sources/Renderer/Direct3D12/Command/D3D12CommandBuffer.cpp
+++ b/sources/Renderer/Direct3D12/Command/D3D12CommandBuffer.cpp
@@ -818,7 +818,7 @@ void D3D12CommandBuffer::SetUniforms(std::uint32_t first, const void* data, std:
 
     const std::uint32_t                             dataSizeInWords = dataSize / 4;
     const std::uint32_t                             maxNumUniforms  = boundPipelineLayout_->GetNumUniforms();
-    const std::vector<D3D12RootConstantLocation>&   rootConstantMap = boundPipelineState_->GetRootConstantMap();
+    const vector<D3D12RootConstantLocation>&   rootConstantMap = boundPipelineState_->GetRootConstantMap();
 
     for (auto words = reinterpret_cast<const UINT*>(data), wordsEnd = words + dataSizeInWords; words != wordsEnd; ++first)
     {

--- a/sources/Renderer/Direct3D12/Command/D3D12CommandBuffer.h
+++ b/sources/Renderer/Direct3D12/Command/D3D12CommandBuffer.h
@@ -154,7 +154,7 @@ class D3D12CommandBuffer final : public CommandBuffer
         D3D12Resource                           soDrawArgBuffer_;
         D3D12_RESOURCE_STATES                   soBufferStates_[LLGL_MAX_NUM_SO_BUFFERS]    = {};
 
-        std::vector<D3D12ResourceTransition>    bundleResourceTransitions_;
+        vector<D3D12ResourceTransition>    bundleResourceTransitions_;
 
 };
 

--- a/sources/Renderer/Direct3D12/Command/D3D12CommandContext.h
+++ b/sources/Renderer/Direct3D12/Command/D3D12CommandContext.h
@@ -315,11 +315,11 @@ class D3D12CommandContext
         D3D12_RESOURCE_BARRIER                  resourceBarriers_[maxNumResourceBarrieres];
         UINT                                    numResourceBarriers_                        = 0;
 
-        std::vector<D3D12_RESOURCE_BARRIER>     uavBarriers_;
+        vector<D3D12_RESOURCE_BARRIER>     uavBarriers_;
         UINT                                    numUAVBarriers_                             = 0;
 
         bool                                    doCacheResourceStates_                      = false;
-        std::vector<D3D12ResourceTransitionExt> cachedResourceStates_; // Last recorded resource states for multi-submit command buffers
+        vector<D3D12ResourceTransitionExt> cachedResourceStates_; // Last recorded resource states for multi-submit command buffers
 
         D3D12StagingDescriptorHeapPool          stagingDescriptorPools_[maxNumAllocators][maxNumDescriptorHeaps];
         D3D12DescriptorHeapSetLayout            stagingDescriptorSetLayout_;

--- a/sources/Renderer/Direct3D12/D3D12ObjectUtils.cpp
+++ b/sources/Renderer/Direct3D12/D3D12ObjectUtils.cpp
@@ -7,7 +7,7 @@
 
 #include "D3D12ObjectUtils.h"
 #include "../DXCommon/DXCore.h"
-#include <string>
+#include <LLGL/Container/String.h>
 #include <cstring>
 
 
@@ -35,7 +35,7 @@ void D3D12SetObjectNameSubscript(ID3D12Object* obj, const char* name, const char
     {
         if (name != nullptr)
         {
-            std::string nameWithSubscript = name;
+            string nameWithSubscript = name;
             nameWithSubscript += subscript;
             const std::size_t nameLen = nameWithSubscript.size();
             obj->SetPrivateData(DXGetD3DDebugObjectNameGUID(), static_cast<UINT>(nameLen), nameWithSubscript.c_str());
@@ -50,20 +50,20 @@ void D3D12SetObjectNameIndexed(ID3D12Object* obj, const char* name, std::uint32_
     if (name != nullptr)
     {
         /* Append subscript to label */
-        const std::string subscript = std::to_string(index);
+        const string subscript = std::to_string(index);
         D3D12SetObjectNameSubscript(obj, name, subscript.c_str());
     }
     else
         D3D12SetObjectName(obj, nullptr);
 }
 
-std::string D3D12GetObjectName(ID3D12Object* obj)
+string D3D12GetObjectName(ID3D12Object* obj)
 {
     if (obj != nullptr)
     {
         UINT nameLen = 0;
         obj->GetPrivateData(DXGetD3DDebugObjectNameGUID(), &nameLen, nullptr);
-        std::string name;
+        string name;
         name.resize(nameLen);
         obj->GetPrivateData(DXGetD3DDebugObjectNameGUID(), &nameLen, &name[0]);
         return name;

--- a/sources/Renderer/Direct3D12/D3D12ObjectUtils.h
+++ b/sources/Renderer/Direct3D12/D3D12ObjectUtils.h
@@ -11,7 +11,7 @@
 
 #include <d3d12.h>
 #include <cstdint>
-#include <string>
+#include <LLGL/Container/String.h>
 
 
 namespace LLGL
@@ -28,7 +28,7 @@ void D3D12SetObjectNameSubscript(ID3D12Object* obj, const char* name, const char
 void D3D12SetObjectNameIndexed(ID3D12Object* obj, const char* name, std::uint32_t index);
 
 // Returns the debug name of the specified D3D device child.
-std::string D3D12GetObjectName(ID3D12Object* obj);
+string D3D12GetObjectName(ID3D12Object* obj);
 
 
 } // /namespace LLGL

--- a/sources/Renderer/Direct3D12/D3D12RenderSystem.cpp
+++ b/sources/Renderer/Direct3D12/D3D12RenderSystem.cpp
@@ -660,7 +660,7 @@ int D3D12RenderSystem::GetMinorVersion() const
 void D3D12RenderSystem::QueryRendererInfo(RendererInfo& info)
 {
     /* Get D3D version */
-    info.rendererName = "Direct3D " + std::string(DXFeatureLevelToVersion(GetFeatureLevel()));
+    info.rendererName = "Direct3D " + string(DXFeatureLevelToVersion(GetFeatureLevel()));
 
     /* Get shading language support */
     info.shadingLanguageName = "HLSL ";
@@ -674,9 +674,9 @@ void D3D12RenderSystem::QueryRendererInfo(RendererInfo& info)
 }
 
 // Returns the HLSL version for the specified Direct3D feature level.
-static std::vector<ShadingLanguage> DXGetHLSLVersions(D3D_FEATURE_LEVEL featureLevel)
+static vector<ShadingLanguage> DXGetHLSLVersions(D3D_FEATURE_LEVEL featureLevel)
 {
-    std::vector<ShadingLanguage> languages;
+    vector<ShadingLanguage> languages;
 
     languages.push_back(ShadingLanguage::HLSL);
     languages.push_back(ShadingLanguage::HLSL_2_0);
@@ -692,9 +692,9 @@ static std::vector<ShadingLanguage> DXGetHLSLVersions(D3D_FEATURE_LEVEL featureL
     return languages;
 }
 
-static std::vector<Format> GetDefaultSupportedDXTextureFormats()
+static vector<Format> GetDefaultSupportedDXTextureFormats()
 {
-    std::vector<Format> formats;
+    vector<Format> formats;
 
     std::size_t numFormats = 0;
     DXGetDefaultSupportedTextureFormats(nullptr, &numFormats);

--- a/sources/Renderer/Direct3D12/D3D12SwapChain.cpp
+++ b/sources/Renderer/Direct3D12/D3D12SwapChain.cpp
@@ -77,7 +77,7 @@ void D3D12SwapChain::SetDebugName(const char* name)
         D3D12SetObjectNameSubscript(rtvDescHeap_.Get(), name, ".RTV");
         D3D12SetObjectNameSubscript(dsvDescHeap_.Get(), name, ".DSV");
 
-        std::string subscript;
+        string subscript;
         for_range(i, D3D12SwapChain::maxNumColorBuffers)
         {
             subscript = (".BackBuffer" + std::to_string(i));
@@ -417,7 +417,7 @@ HRESULT D3D12SwapChain::CreateResolutionDependentResources(const Extent2D& resol
     renderSystem_.SyncGPU();
 
     /* Store current debug names */
-    std::string debugNames[D3D12SwapChain::numDebugNames];
+    string debugNames[D3D12SwapChain::numDebugNames];
     if (hasDebugName_)
         StoreDebugNames(debugNames);
 
@@ -599,7 +599,7 @@ void D3D12SwapChain::MoveToNextFrame()
     frameFenceValues_[currentColorBuffer_] = currentFenceValue + 1;
 }
 
-void D3D12SwapChain::StoreDebugNames(std::string (&debugNames)[D3D12SwapChain::numDebugNames])
+void D3D12SwapChain::StoreDebugNames(string (&debugNames)[D3D12SwapChain::numDebugNames])
 {
     for_range(i, D3D12SwapChain::maxNumColorBuffers)
     {
@@ -609,7 +609,7 @@ void D3D12SwapChain::StoreDebugNames(std::string (&debugNames)[D3D12SwapChain::n
     debugNames[D3D12SwapChain::maxNumColorBuffers*2] = D3D12GetObjectName(depthStencil_.Get());
 }
 
-void D3D12SwapChain::RestoreDebugNames(const std::string (&debugNames)[D3D12SwapChain::numDebugNames])
+void D3D12SwapChain::RestoreDebugNames(const string (&debugNames)[D3D12SwapChain::numDebugNames])
 {
     for_range(i, D3D12SwapChain::maxNumColorBuffers)
     {

--- a/sources/Renderer/Direct3D12/D3D12SwapChain.h
+++ b/sources/Renderer/Direct3D12/D3D12SwapChain.h
@@ -95,8 +95,8 @@ class D3D12SwapChain final : public SwapChain
 
         void MoveToNextFrame();
 
-        void StoreDebugNames(std::string (&debugNames)[D3D12SwapChain::numDebugNames]);
-        void RestoreDebugNames(const std::string (&debugNames)[D3D12SwapChain::numDebugNames]);
+        void StoreDebugNames(string (&debugNames)[D3D12SwapChain::numDebugNames]);
+        void RestoreDebugNames(const string (&debugNames)[D3D12SwapChain::numDebugNames]);
 
     private:
 

--- a/sources/Renderer/Direct3D12/D3D12Types.cpp
+++ b/sources/Renderer/Direct3D12/D3D12Types.cpp
@@ -7,7 +7,7 @@
 
 #include "D3D12Types.h"
 #include <stdexcept>
-#include <string>
+#include <LLGL/Container/String.h>
 
 
 namespace LLGL

--- a/sources/Renderer/Direct3D12/RenderState/D3D12DescriptorHeap.cpp
+++ b/sources/Renderer/Direct3D12/RenderState/D3D12DescriptorHeap.cpp
@@ -36,7 +36,7 @@ ComPtr<ID3D12DescriptorHeap> D3D12DescriptorHeap::CreateNativeOrThrow(ID3D12Devi
     HRESULT hr = device->CreateDescriptorHeap(&desc, IID_PPV_ARGS(descHeap.ReleaseAndGetAddressOf()));
     if (FAILED(hr))
     {
-        std::string contextInfo;
+        string contextInfo;
         if (const char* s = ToString(desc.Type))
         {
             contextInfo += "for heap type ";

--- a/sources/Renderer/Direct3D12/RenderState/D3D12PipelineLayout.cpp
+++ b/sources/Renderer/Direct3D12/RenderState/D3D12PipelineLayout.cpp
@@ -15,7 +15,7 @@
 #include "../../../Core/Assertion.h"
 #include "../../../Core/CoreUtils.h"
 #include <LLGL/Utils/ForRange.h>
-#include <string>
+#include <LLGL/Container/String.h>
 #include <algorithm>
 
 
@@ -134,14 +134,14 @@ void D3D12PipelineLayout::ReleaseRootSignature()
 
 ComPtr<ID3D12RootSignature> D3D12PipelineLayout::CreateRootSignatureWith32BitConstants(
     const ArrayView<D3D12Shader*>&          shaders,
-    std::vector<D3D12RootConstantLocation>& outRootConstantMap) const
+    vector<D3D12RootConstantLocation>& outRootConstantMap) const
 {
     if (!rootSignature_)
         return nullptr;
 
     /* Reflect all constant buffers from all shaders */
     long cbufferStageFlags = 0;
-    std::vector<const D3D12ConstantBufferReflection*> cbufferReflections;
+    vector<const D3D12ConstantBufferReflection*> cbufferReflections;
 
     struct D3D12CbufferField
     {
@@ -176,7 +176,7 @@ ComPtr<ID3D12RootSignature> D3D12PipelineLayout::CreateRootSignatureWith32BitCon
         LLGL_ASSERT_PTR(shader);
 
         /* Get cached cbuffer reflection from shader */
-        const std::vector<D3D12ConstantBufferReflection>* currentCbufferReflections = nullptr;
+        const vector<D3D12ConstantBufferReflection>* currentCbufferReflections = nullptr;
         HRESULT hr = shader->ReflectAndCacheConstantBuffers(&currentCbufferReflections);
         DXThrowIfFailed(hr, "failed to reflect constant buffers in D3D12 shader");
         LLGL_ASSERT_PTR(currentCbufferReflections);

--- a/sources/Renderer/Direct3D12/RenderState/D3D12PipelineLayout.h
+++ b/sources/Renderer/Direct3D12/RenderState/D3D12PipelineLayout.h
@@ -17,7 +17,7 @@
 #include "../../DXCommon/ComPtr.h"
 #include <d3d12.h>
 #include <memory>
-#include <map>
+#include <LLGL/Container/Map.h>
 
 
 namespace LLGL
@@ -134,7 +134,7 @@ class D3D12PipelineLayout final : public PipelineLayout
         */
         ComPtr<ID3D12RootSignature> CreateRootSignatureWith32BitConstants(
             const ArrayView<D3D12Shader*>&          shaders,
-            std::vector<D3D12RootConstantLocation>& outRootConstantMap
+            vector<D3D12RootConstantLocation>& outRootConstantMap
         ) const;
 
         // Returns the layout of the set of descriptor heaps.
@@ -292,7 +292,7 @@ class D3D12PipelineLayout final : public PipelineLayout
         D3D12RootParameterIndices                   rootParameterIndices_;
         long                                        convolutedStageFlags_   = 0;
 
-        std::vector<UniformDescriptor>              uniforms_;
+        vector<UniformDescriptor>              uniforms_;
 
         long                                        barrierFlags_           = 0;
         UINT                                        numUAVBarriers_         = 0;

--- a/sources/Renderer/Direct3D12/RenderState/D3D12PipelineState.cpp
+++ b/sources/Renderer/Direct3D12/RenderState/D3D12PipelineState.cpp
@@ -71,9 +71,9 @@ void D3D12PipelineState::SetNativeAndUpdateCache(ComPtr<ID3D12PipelineState>&& n
     }
 }
 
-void D3D12PipelineState::ResetReport(std::string&& text, bool hasErrors)
+void D3D12PipelineState::ResetReport(string&& text, bool hasErrors)
 {
-    ResetReportWithNewline(report_, std::forward<std::string&&>(text), hasErrors);
+    ResetReportWithNewline(report_, std::forward<string&&>(text), hasErrors);
 }
 
 

--- a/sources/Renderer/Direct3D12/RenderState/D3D12PipelineState.h
+++ b/sources/Renderer/Direct3D12/RenderState/D3D12PipelineState.h
@@ -52,7 +52,7 @@ class D3D12PipelineState : public PipelineState
         }
 
         // Returns the uniform to root constant map. Index for 'uniforms' -> location of root constant 32-bit value.
-        inline const std::vector<D3D12RootConstantLocation>& GetRootConstantMap() const
+        inline const vector<D3D12RootConstantLocation>& GetRootConstantMap() const
         {
             return rootConstantMap_;
         }
@@ -70,7 +70,7 @@ class D3D12PipelineState : public PipelineState
         void SetNativeAndUpdateCache(ComPtr<ID3D12PipelineState>&& native, D3D12PipelineCache* pipelineCache);
 
         // Writes the report with the specified message and error bit.
-        void ResetReport(std::string&& text, bool hasErrors = false);
+        void ResetReport(string&& text, bool hasErrors = false);
 
         // Returns the native PSO object.
         inline ID3D12PipelineState* GetNative() const
@@ -96,7 +96,7 @@ class D3D12PipelineState : public PipelineState
         ComPtr<ID3D12PipelineState>             native_;
         ComPtr<ID3D12RootSignature>             rootSignature_;
         const D3D12PipelineLayout*              pipelineLayout_ = nullptr;
-        std::vector<D3D12RootConstantLocation>  rootConstantMap_;
+        vector<D3D12RootConstantLocation>  rootConstantMap_;
         Report                                  report_;
 
 };

--- a/sources/Renderer/Direct3D12/RenderState/D3D12ResourceHeap.h
+++ b/sources/Renderer/Direct3D12/RenderState/D3D12ResourceHeap.h
@@ -15,7 +15,7 @@
 #include "D3D12PipelineLayout.h"
 #include "../../DXCommon/ComPtr.h"
 #include <d3d12.h>
-#include <vector>
+#include <LLGL/Container/Vector.h>
 #include <cstddef>
 
 
@@ -114,9 +114,9 @@ class D3D12ResourceHeap final : public ResourceHeap
         UINT                                        numDescriptorSets_          = 0;
 
         SmallVector<D3D12DescriptorHeapLocation>    descriptorMap_;
-        std::vector<D3D12Resource*>                 resources_;
+        vector<D3D12Resource*>                 resources_;
 
-        std::vector<ID3D12Resource*>                uavResourceHeap_;                   // Heap of UAV resources that require a barrier
+        vector<ID3D12Resource*>                uavResourceHeap_;                   // Heap of UAV resources that require a barrier
         UINT                                        uavResourceSetStride_       = 0;    // Number of (potential) UAV resources per descriptor set
         UINT                                        uavResourceIndexOffset_     = 0;    // Subtracted offset for 'D3D12DescriptorHeapLocation::index'
 

--- a/sources/Renderer/Direct3D12/RenderState/D3D12StagingDescriptorHeapPool.h
+++ b/sources/Renderer/Direct3D12/RenderState/D3D12StagingDescriptorHeapPool.h
@@ -11,7 +11,7 @@
 
 #include "D3D12StagingDescriptorHeap.h"
 #include <d3d12.h>
-#include <vector>
+#include <LLGL/Container/Vector.h>
 
 
 namespace LLGL
@@ -68,7 +68,7 @@ class D3D12StagingDescriptorHeapPool
         ID3D12Device*                           device_         = nullptr;
         D3D12_DESCRIPTOR_HEAP_TYPE              type_           = D3D12_DESCRIPTOR_HEAP_TYPE_NUM_TYPES;
 
-        std::vector<D3D12StagingDescriptorHeap> chunks_;
+        vector<D3D12StagingDescriptorHeap> chunks_;
         std::size_t                             chunkIdx_       = 0;
         UINT                                    chunkSize_      = 0;
 

--- a/sources/Renderer/Direct3D12/Shader/D3D12RootParameter.h
+++ b/sources/Renderer/Direct3D12/Shader/D3D12RootParameter.h
@@ -10,7 +10,7 @@
 
 
 #include <LLGL/Container/SmallVector.h>
-#include <string>
+#include <LLGL/Container/String.h>
 #include <d3d12.h>
 
 

--- a/sources/Renderer/Direct3D12/Shader/D3D12RootSignature.cpp
+++ b/sources/Renderer/Direct3D12/Shader/D3D12RootSignature.cpp
@@ -128,7 +128,7 @@ static ComPtr<ID3DBlob> DXSerializeRootSignature(
     {
         if (error)
         {
-            std::string errorStr = DXGetBlobString(error.Get());
+            string errorStr = DXGetBlobString(error.Get());
             LLGL_TRAP("failed to serialize D3D12 root signature: %s", errorStr.c_str());
         }
         else

--- a/sources/Renderer/Direct3D12/Shader/D3D12Shader.cpp
+++ b/sources/Renderer/Direct3D12/Shader/D3D12Shader.cpp
@@ -96,7 +96,7 @@ bool D3D12Shader::GetStreamOutputDesc(D3D12_STREAM_OUTPUT_DESC& layoutDesc) cons
     return false;
 }
 
-HRESULT D3D12Shader::ReflectAndCacheConstantBuffers(const std::vector<D3D12ConstantBufferReflection>** outConstantBuffers)
+HRESULT D3D12Shader::ReflectAndCacheConstantBuffers(const vector<D3D12ConstantBufferReflection>** outConstantBuffers)
 {
     if (cbufferReflectionResult_ == S_FALSE)
     {
@@ -258,7 +258,7 @@ static bool IsProfileDxcAppropriate(const char* target)
 bool D3D12Shader::CompileSource(const ShaderDescriptor& shaderDesc)
 {
     /* Get source code */
-    std::string fileContent;
+    string      fileContent;
     const char* sourceCode      = nullptr;
     SIZE_T      sourceLength    = 0;
     const char* sourceName      = nullptr;
@@ -302,23 +302,23 @@ bool D3D12Shader::CompileSource(const ShaderDescriptor& shaderDesc)
         }
 
         /* Get DXC compiler arguments */
-        std::vector<LPCWSTR> compilerArgs = DXGetDxcCompilerArgs(flags);
+        vector<LPCWSTR> compilerArgs = DXGetDxcCompilerArgs(flags);
 
         compilerArgs.push_back(L"-E");
-        const std::wstring entryWide = ToWideString(entry);
+        const wstring entryWide = ToWideString(entry);
         compilerArgs.push_back(entryWide.c_str());
 
         compilerArgs.push_back(L"-T");
-        const std::wstring targetWide = ToWideString(target);
+        const wstring targetWide = ToWideString(target);
         compilerArgs.push_back(targetWide.c_str());
 
-        std::vector<std::wstring> definesWide;
+        vector<wstring> definesWide;
         if (defines != nullptr)
         {
             /* Append macro definitions as compiler arguments "-D<NAME>" or "-D<NAME>=<VALUE>" */
             for (; defines->Name != nullptr; ++defines)
             {
-                std::wstring defineWide = std::wstring(L"-D") + ToWideString(defines->Name);
+                wstring defineWide = wstring(L"-D") + ToWideString(defines->Name);
                 if (defines->Definition != nullptr && defines->Definition[0] != '\0')
                 {
                     defineWide += L'=';
@@ -328,7 +328,7 @@ bool D3D12Shader::CompileSource(const ShaderDescriptor& shaderDesc)
             }
 
             compilerArgs.reserve(compilerArgs.size() + definesWide.size());
-            for (const std::wstring& s : definesWide)
+            for (const wstring& s : definesWide)
                 compilerArgs.push_back(s.c_str());
         }
 
@@ -456,7 +456,7 @@ HRESULT D3D12Shader::ReflectShaderByteCode(ShaderReflection& reflection) const
     return S_OK;
 }
 
-HRESULT D3D12Shader::ReflectConstantBuffers(std::vector<D3D12ConstantBufferReflection>& outConstantBuffers) const
+HRESULT D3D12Shader::ReflectConstantBuffers(vector<D3D12ConstantBufferReflection>& outConstantBuffers) const
 {
     HRESULT hr = S_OK;
 
@@ -495,7 +495,7 @@ HRESULT D3D12Shader::ReflectConstantBuffers(std::vector<D3D12ConstantBufferRefle
             if (FAILED(hr))
                 return hr;
 
-            std::vector<D3D12ConstantReflection> fieldsInfo;
+            vector<D3D12ConstantReflection> fieldsInfo;
 
             for_range(fieldIndex, shaderBufferDesc.Variables)
             {

--- a/sources/Renderer/Direct3D12/Shader/D3D12Shader.h
+++ b/sources/Renderer/Direct3D12/Shader/D3D12Shader.h
@@ -16,7 +16,7 @@
 #include <LLGL/Report.h>
 #include "../../DXCommon/ComPtr.h"
 #include "../../../Core/LinearStringContainer.h"
-#include <vector>
+#include <LLGL/Container/Vector.h>
 #include <d3d12.h>
 
 
@@ -26,7 +26,7 @@ namespace LLGL
 
 struct D3D12ConstantReflection
 {
-    std::string name;   // Name of the constant buffer field.
+    string      name;   // Name of the constant buffer field.
     UINT        offset; // Offset (in bytes) within the constant buffer the uniform's root parameter occupies.
     UINT        size;   // Size (in bytes) of this uniform.
 };
@@ -35,7 +35,7 @@ struct D3D12ConstantBufferReflection
 {
     long                                    stageFlags;
     D3D12_ROOT_CONSTANTS                    rootConstants;
-    std::vector<D3D12ConstantReflection>    fields;
+    vector<D3D12ConstantReflection>    fields;
 };
 
 class D3D12RenderSystem;
@@ -59,7 +59,7 @@ class D3D12Shader final : public Shader
         bool GetStreamOutputDesc(D3D12_STREAM_OUTPUT_DESC& layoutDesc) const;
 
         // Returns a list of all reflected constant buffers including their fields.
-        HRESULT ReflectAndCacheConstantBuffers(const std::vector<D3D12ConstantBufferReflection>** outConstantBuffers);
+        HRESULT ReflectAndCacheConstantBuffers(const vector<D3D12ConstantBufferReflection>** outConstantBuffers);
 
     private:
 
@@ -73,22 +73,22 @@ class D3D12Shader final : public Shader
 
         HRESULT ReflectShaderByteCode(ShaderReflection& reflection) const;
 
-        HRESULT ReflectConstantBuffers(std::vector<D3D12ConstantBufferReflection>& outConstantBuffers) const;
+        HRESULT ReflectConstantBuffers(vector<D3D12ConstantBufferReflection>& outConstantBuffers) const;
 
     private:
 
-		D3D12RenderSystem&    						renderSystem_;
+        D3D12RenderSystem&                          renderSystem_;
 
         ComPtr<ID3DBlob>                            byteCode_;
         Report                                      report_;
 
-        std::vector<D3D12_INPUT_ELEMENT_DESC>       inputElements_;
-        std::vector<D3D12_SO_DECLARATION_ENTRY>     soDeclEntries_;
-        std::vector<UINT>                           soBufferStrides_;
+        vector<D3D12_INPUT_ELEMENT_DESC>            inputElements_;
+        vector<D3D12_SO_DECLARATION_ENTRY>          soDeclEntries_;
+        vector<UINT>                                soBufferStrides_;
         LinearStringContainer                       vertexAttribNames_; // custom string container to hold valid string pointers.
 
         HRESULT                                     cbufferReflectionResult_    = S_FALSE;
-        std::vector<D3D12ConstantBufferReflection>  cbufferReflections_;
+        vector<D3D12ConstantBufferReflection>       cbufferReflections_;
 
 };
 

--- a/sources/Renderer/Direct3D12/Texture/D3D12RenderTarget.cpp
+++ b/sources/Renderer/Direct3D12/Texture/D3D12RenderTarget.cpp
@@ -189,7 +189,7 @@ UINT D3D12RenderTarget::GatherAttachmentFormats(D3D12Device& device, const Rende
         depthStencilFormat_ = DXTypes::ToDXGIFormatDSV(formatDXGI);
     }
 
-    /* Pre-allocate containers to avoid dangling pointers after std::vector::push_back() */
+    /* Pre-allocate containers to avoid dangling pointers after vector::push_back() */
     colorBuffers_.reserve(outColorFormats.size());
     internalTextures_.reserve(NumInternalTexturesForAttachments(desc));
 

--- a/sources/Renderer/Direct3D12/Texture/D3D12RenderTarget.h
+++ b/sources/Renderer/Direct3D12/Texture/D3D12RenderTarget.h
@@ -138,9 +138,9 @@ class D3D12RenderTarget final : public RenderTarget
         D3D12RenderPass                 defaultRenderPass_;
 
         // Containers and references:
-        std::vector<D3D12Resource>      internalTextures_;
-        std::vector<D3D12Resource*>     colorBuffers_;
-        std::vector<ResolveTarget>      resolveTargets_;
+        vector<D3D12Resource>      internalTextures_;
+        vector<D3D12Resource*>     colorBuffers_;
+        vector<ResolveTarget>      resolveTargets_;
         D3D12Resource*                  depthStencil_       = nullptr;
 
 };

--- a/sources/Renderer/Direct3D12/Texture/D3D12Texture.h
+++ b/sources/Renderer/Direct3D12/Texture/D3D12Texture.h
@@ -11,7 +11,7 @@
 
 #include <LLGL/Texture.h>
 #include "../D3D12Resource.h"
-#include <vector>
+#include <LLGL/Container/Vector.h>
 
 
 namespace LLGL

--- a/sources/Renderer/Null/Buffer/NullBuffer.h
+++ b/sources/Renderer/Null/Buffer/NullBuffer.h
@@ -10,8 +10,8 @@
 
 
 #include <LLGL/Buffer.h>
-#include <vector>
-#include <string>
+#include <LLGL/Container/Vector.h>
+#include <LLGL/Container/String.h>
 
 
 namespace LLGL
@@ -85,12 +85,12 @@ class NullBuffer final : public Buffer
 
     private:
 
-        std::string             label_;
-        std::vector<WordType>   data_;
-        std::vector<WordType>   mappedData_;
-        std::size_t             mapOffset_  = 0;
-        std::size_t             mapLength_  = 0;
-        CPUAccess               mapAccess_  = CPUAccess::ReadOnly;
+        string             label_;
+        vector<WordType>   data_;
+        vector<WordType>   mappedData_;
+        std::size_t        mapOffset_  = 0;
+        std::size_t        mapLength_  = 0;
+        CPUAccess          mapAccess_  = CPUAccess::ReadOnly;
 
 };
 

--- a/sources/Renderer/Null/Buffer/NullBufferArray.cpp
+++ b/sources/Renderer/Null/Buffer/NullBufferArray.cpp
@@ -16,9 +16,9 @@ namespace LLGL
 {
 
 
-static std::vector<NullBuffer*> GetNullBuffers(std::uint32_t numBuffers, Buffer* const * bufferArray)
+static vector<NullBuffer*> GetNullBuffers(std::uint32_t numBuffers, Buffer* const * bufferArray)
 {
-    std::vector<NullBuffer*> buffers;
+    vector<NullBuffer*> buffers;
     buffers.reserve(numBuffers);
     for_range(i, numBuffers)
         buffers.push_back(LLGL_CAST(NullBuffer*, bufferArray[i]));

--- a/sources/Renderer/Null/Buffer/NullBufferArray.h
+++ b/sources/Renderer/Null/Buffer/NullBufferArray.h
@@ -10,7 +10,7 @@
 
 
 #include <LLGL/BufferArray.h>
-#include <vector>
+#include <LLGL/Container/Vector.h>
 
 
 namespace LLGL
@@ -29,7 +29,7 @@ class NullBufferArray final : public BufferArray
 
     public:
 
-        const std::vector<NullBuffer*> buffers;
+        const vector<NullBuffer*> buffers;
 
 };
 

--- a/sources/Renderer/Null/NullRenderSystem.cpp
+++ b/sources/Renderer/Null/NullRenderSystem.cpp
@@ -15,7 +15,7 @@ namespace LLGL
 {
 
 
-static void InitNullRendererShadingLanguages(std::vector<ShadingLanguage>& shadingLanguages)
+static void InitNullRendererShadingLanguages(vector<ShadingLanguage>& shadingLanguages)
 {
     shadingLanguages =
     {
@@ -27,7 +27,7 @@ static void InitNullRendererShadingLanguages(std::vector<ShadingLanguage>& shadi
     };
 }
 
-static void InitNullRendererTextureFormats(std::vector<Format>& textureFormats)
+static void InitNullRendererTextureFormats(vector<Format>& textureFormats)
 {
     constexpr int firstFormatIndex  = static_cast<int>(Format::A8UNorm);
     constexpr int lastFormatIndex   = static_cast<int>(Format::BC5SNorm);

--- a/sources/Renderer/Null/NullSwapChain.h
+++ b/sources/Renderer/Null/NullSwapChain.h
@@ -10,7 +10,7 @@
 
 
 #include <LLGL/SwapChain.h>
-#include <string>
+#include <LLGL/Container/String.h>
 
 
 namespace LLGL
@@ -42,7 +42,7 @@ class NullSwapChain final : public SwapChain
 
     private:
 
-        std::string         label_;
+        string              label_;
         std::uint32_t       samples_            = 1;
         Format              colorFormat_        = Format::Undefined;
         Format              depthStencilFormat_ = Format::Undefined;

--- a/sources/Renderer/Null/RenderState/NullFence.h
+++ b/sources/Renderer/Null/RenderState/NullFence.h
@@ -10,7 +10,7 @@
 
 
 #include <LLGL/Fence.h>
-#include <string>
+#include <LLGL/Container/String.h>
 #include <atomic>
 #include <cstdint>
 
@@ -36,8 +36,8 @@ class NullFence final : public Fence
 
     private:
 
-        std::string             label_;
-        std::atomic_uint64_t    signal_;
+        string                label_;
+        std::atomic_uint64_t  signal_;
 
 };
 

--- a/sources/Renderer/Null/RenderState/NullPipelineLayout.h
+++ b/sources/Renderer/Null/RenderState/NullPipelineLayout.h
@@ -11,7 +11,7 @@
 
 #include <LLGL/PipelineLayout.h>
 #include <LLGL/PipelineLayoutFlags.h>
-#include <string>
+#include <LLGL/Container/String.h>
 
 
 namespace LLGL
@@ -39,7 +39,7 @@ class NullPipelineLayout final : public PipelineLayout
 
     private:
 
-        std::string label_;
+        string label_;
 
 };
 

--- a/sources/Renderer/Null/RenderState/NullPipelineState.h
+++ b/sources/Renderer/Null/RenderState/NullPipelineState.h
@@ -11,7 +11,7 @@
 
 #include <LLGL/PipelineState.h>
 #include <LLGL/PipelineStateFlags.h>
-#include <string>
+#include <LLGL/Container/String.h>
 
 
 namespace LLGL
@@ -39,7 +39,7 @@ class NullPipelineState final : public PipelineState
 
     private:
 
-        std::string label_;
+        string label_;
 };
 
 

--- a/sources/Renderer/Null/RenderState/NullQueryHeap.h
+++ b/sources/Renderer/Null/RenderState/NullQueryHeap.h
@@ -10,8 +10,8 @@
 
 
 #include <LLGL/QueryHeap.h>
-#include <vector>
-#include <string>
+#include <LLGL/Container/Vector.h>
+#include <LLGL/Container/String.h>
 
 
 namespace LLGL
@@ -35,7 +35,7 @@ class NullQueryHeap final : public QueryHeap
 
     private:
 
-        std::string label_;
+        string label_;
 
 };
 

--- a/sources/Renderer/Null/RenderState/NullRenderPass.h
+++ b/sources/Renderer/Null/RenderState/NullRenderPass.h
@@ -11,7 +11,7 @@
 
 #include <LLGL/RenderPass.h>
 #include <LLGL/RenderPassFlags.h>
-#include <string>
+#include <LLGL/Container/String.h>
 
 
 namespace LLGL
@@ -35,7 +35,7 @@ class NullRenderPass final : public RenderPass
 
     private:
 
-        std::string label_;
+        string label_;
 
 };
 

--- a/sources/Renderer/Null/RenderState/NullResourceHeap.h
+++ b/sources/Renderer/Null/RenderState/NullResourceHeap.h
@@ -12,8 +12,8 @@
 #include <LLGL/ResourceHeap.h>
 #include <LLGL/ResourceHeapFlags.h>
 #include <LLGL/Container/ArrayView.h>
-#include <string>
-#include <vector>
+#include <LLGL/Container/String.h>
+#include <LLGL/Container/Vector.h>
 
 
 namespace LLGL
@@ -37,9 +37,9 @@ class NullResourceHeap final : public ResourceHeap
 
     private:
 
-        std::string                         label_;
-        const std::uint32_t                 numBindings_    = 1;
-        std::vector<ResourceViewDescriptor> resourceViews_;
+        string                         label_;
+        const std::uint32_t            numBindings_    = 1;
+        vector<ResourceViewDescriptor> resourceViews_;
 
 };
 

--- a/sources/Renderer/Null/Shader/NullShader.h
+++ b/sources/Renderer/Null/Shader/NullShader.h
@@ -10,7 +10,7 @@
 
 
 #include <LLGL/Shader.h>
-#include <string>
+#include <LLGL/Container/String.h>
 
 
 namespace LLGL
@@ -38,7 +38,7 @@ class NullShader final : public Shader
 
     public:
 
-        std::string label_;
+        string label_;
 
 };
 

--- a/sources/Renderer/Null/Texture/NullRenderTarget.h
+++ b/sources/Renderer/Null/Texture/NullRenderTarget.h
@@ -11,8 +11,8 @@
 
 #include <LLGL/RenderTarget.h>
 #include "NullTexture.h"
-#include <string>
-#include <vector>
+#include <LLGL/Container/String.h>
+#include <LLGL/Container/Vector.h>
 
 
 namespace LLGL
@@ -46,12 +46,12 @@ class NullRenderTarget final : public RenderTarget
 
     private:
 
-        std::string                                 label_;
-        std::vector<NullTexture*>                   colorAttachments_;
-        std::vector<NullTexture*>                   resolveAttachments_;
-        NullTexture*                                depthStencilAttachment_     = nullptr;
-        Format                                      depthStencilFormat_         = Format::Undefined;
-        std::vector<std::unique_ptr<NullTexture>>   intermediateAttachments_;
+        string                                 label_;
+        vector<NullTexture*>                   colorAttachments_;
+        vector<NullTexture*>                   resolveAttachments_;
+        NullTexture*                           depthStencilAttachment_     = nullptr;
+        Format                                 depthStencilFormat_         = Format::Undefined;
+        vector<std::unique_ptr<NullTexture>>   intermediateAttachments_;
 
 };
 

--- a/sources/Renderer/Null/Texture/NullSampler.h
+++ b/sources/Renderer/Null/Texture/NullSampler.h
@@ -10,7 +10,7 @@
 
 
 #include <LLGL/Sampler.h>
-#include <string>
+#include <LLGL/Container/String.h>
 
 
 namespace LLGL
@@ -38,7 +38,7 @@ class NullSampler final : public Sampler
 
     private:
 
-        std::string label_;
+        string label_;
 
 };
 

--- a/sources/Renderer/Null/Texture/NullTexture.h
+++ b/sources/Renderer/Null/Texture/NullTexture.h
@@ -11,8 +11,8 @@
 
 #include <LLGL/Texture.h>
 #include <LLGL/Utils/Image.h>
-#include <string>
-#include <vector>
+#include <LLGL/Container/String.h>
+#include <LLGL/Container/Vector.h>
 
 
 namespace LLGL
@@ -56,9 +56,9 @@ class NullTexture final : public Texture
 
     private:
 
-        std::string         label_;
-        Extent3D            extent_;
-        std::vector<Image>  images_; // MIP-map images
+        string         label_;
+        Extent3D       extent_;
+        vector<Image>  images_; // MIP-map images
 
 };
 

--- a/sources/Renderer/OpenGL/Buffer/GL3PlusSharedContextVertexArray.h
+++ b/sources/Renderer/OpenGL/Buffer/GL3PlusSharedContextVertexArray.h
@@ -13,7 +13,7 @@
 #include <LLGL/Container/ArrayView.h>
 #include "GLVertexAttribute.h"
 #include "GLVertexArrayObject.h"
-#include <vector>
+#include <LLGL/Container/Vector.h>
 
 
 namespace LLGL
@@ -57,9 +57,9 @@ class GL3PlusSharedContextVertexArray
 
     private:
 
-        std::vector<GLVertexAttribute>  attribs_;
-        std::vector<GLContextVAO>       contextDependentVAOs_;
-        std::string                     debugName_;
+        vector<GLVertexAttribute>  attribs_;
+        vector<GLContextVAO>       contextDependentVAOs_;
+        string                     debugName_;
 
 };
 

--- a/sources/Renderer/OpenGL/Buffer/GLBuffer.cpp
+++ b/sources/Renderer/OpenGL/Buffer/GLBuffer.cpp
@@ -212,7 +212,7 @@ void GLBuffer::ClearBufferData(std::uint32_t data)
         glGetBufferParameteriv(bufferTarget, GL_BUFFER_SIZE, &bufferSize);
 
         /* Allocate intermediate buffer to fill the GPU buffer with */
-        std::vector<std::uint32_t> intermediateBuffer(static_cast<std::size_t>(bufferSize + 3) / 4, data);
+        vector<std::uint32_t> intermediateBuffer(static_cast<std::size_t>(bufferSize + 3) / 4, data);
 
         /* Submit intermeidate buffer to GPU buffer */
         glBufferSubData(bufferTarget, 0, static_cast<GLintptr>(bufferSize), intermediateBuffer.data());
@@ -243,7 +243,7 @@ void GLBuffer::ClearBufferSubData(GLintptr offset, GLsizeiptr size, std::uint32_
         GLStateManager::Get().BindGLBuffer(*this);
 
         /* Allocate intermediate buffer to fill the GPU buffer with */
-        std::vector<std::uint32_t> intermediateBuffer(static_cast<std::size_t>(size + 3) / 4, data);
+        vector<std::uint32_t> intermediateBuffer(static_cast<std::size_t>(size + 3) / 4, data);
 
         /* Submit intermeidate buffer to GPU buffer */
         glBufferSubData(GetGLTarget(), offset, size, intermediateBuffer.data());

--- a/sources/Renderer/OpenGL/Buffer/GLBufferArray.h
+++ b/sources/Renderer/OpenGL/Buffer/GLBufferArray.h
@@ -11,7 +11,7 @@
 
 #include <LLGL/BufferArray.h>
 #include "../OpenGL.h"
-#include <vector>
+#include <LLGL/Container/Vector.h>
 #include <cstdint>
 
 
@@ -29,7 +29,7 @@ class GLBufferArray : public BufferArray
         GLBufferArray(std::uint32_t numBuffers, Buffer* const * bufferArray);
 
         // Returns the array of buffer IDs.
-        inline const std::vector<GLuint>& GetIDArray() const
+        inline const vector<GLuint>& GetIDArray() const
         {
             return idArray_;
         }
@@ -40,7 +40,7 @@ class GLBufferArray : public BufferArray
 
     private:
 
-        std::vector<GLuint> idArray_;
+        vector<GLuint> idArray_;
 
 };
 

--- a/sources/Renderer/OpenGL/Buffer/GLBufferWithVAO.cpp
+++ b/sources/Renderer/OpenGL/Buffer/GLBufferWithVAO.cpp
@@ -19,7 +19,7 @@ GLBufferWithVAO::GLBufferWithVAO(long bindFlags, const char* debugName) :
 {
     if (debugName != nullptr)
     {
-        const std::string vaoLabel = debugName + std::string(".VAO");
+        const string vaoLabel = debugName + string(".VAO");
         vertexArray_.SetDebugName(vaoLabel.c_str());
     }
 }
@@ -30,7 +30,7 @@ void GLBufferWithVAO::BuildVertexArray(const ArrayView<VertexAttribute>& vertexA
     if (vertexAttribs.empty())
         vertexAttribs_.clear();
     else
-        vertexAttribs_ = std::vector<VertexAttribute>(vertexAttribs.begin(), vertexAttribs.end());
+        vertexAttribs_ = vector<VertexAttribute>(vertexAttribs.begin(), vertexAttribs.end());
 
     /* Build vertex layout and finalize immediately as it only references a single buffer */
     vertexArray_.BuildVertexLayout(GetID(), vertexAttribs_);

--- a/sources/Renderer/OpenGL/Buffer/GLBufferWithVAO.h
+++ b/sources/Renderer/OpenGL/Buffer/GLBufferWithVAO.h
@@ -29,7 +29,7 @@ class GLBufferWithVAO : public GLBuffer
         void BuildVertexArray(const ArrayView<VertexAttribute>& vertexAttribs);
 
         // Returns the list of vertex attributes.
-        inline const std::vector<VertexAttribute>& GetVertexAttribs() const
+        inline const vector<VertexAttribute>& GetVertexAttribs() const
         {
             return vertexAttribs_;
         }
@@ -42,7 +42,7 @@ class GLBufferWithVAO : public GLBuffer
 
     private:
 
-        std::vector<VertexAttribute>    vertexAttribs_;
+        vector<VertexAttribute>    vertexAttribs_;
         GLSharedContextVertexArray      vertexArray_;
 
 };

--- a/sources/Renderer/OpenGL/Command/GLCommandExecutor.cpp
+++ b/sources/Renderer/OpenGL/Command/GLCommandExecutor.cpp
@@ -37,7 +37,7 @@
 #include "../RenderState/GLQueryHeap.h"
 
 #include <algorithm>
-#include <string.h>
+#include <LLGL/Container/String.h>
 
 #include <LLGL/Backend/OpenGL/NativeCommand.h>
 

--- a/sources/Renderer/OpenGL/Command/GLDeferredCommandBuffer.cpp
+++ b/sources/Renderer/OpenGL/Command/GLDeferredCommandBuffer.cpp
@@ -37,7 +37,7 @@
 #include "../RenderState/GLQueryHeap.h"
 
 #include <algorithm>
-#include <string.h>
+#include <LLGL/Container/String.h>
 #include <cstring> // std::strlen
 
 
@@ -394,7 +394,7 @@ void GLDeferredCommandBuffer::SetResource(std::uint32_t descriptor, Resource& re
     if (binding.combiners > 0)
     {
         /* Bind resource at one or more slots for combined texture-samplers */
-        const std::vector<GLuint>& combinedSamplerSlots = pipelineLayoutGL->GetCombinedSamplerSlots();
+        const vector<GLuint>& combinedSamplerSlots = pipelineLayoutGL->GetCombinedSamplerSlots();
         BindCombinedResource(binding.type, &(combinedSamplerSlots[binding.slot]), binding.combiners, resource);
     }
     else

--- a/sources/Renderer/OpenGL/Command/GLDeferredCommandBuffer.h
+++ b/sources/Renderer/OpenGL/Command/GLDeferredCommandBuffer.h
@@ -13,7 +13,7 @@
 #include "GLCommandOpcode.h"
 #include "../../VirtualCommandBuffer.h"
 #include <memory>
-#include <vector>
+#include <LLGL/Container/Vector.h>
 
 
 namespace LLGL

--- a/sources/Renderer/OpenGL/Command/GLImmediateCommandBuffer.cpp
+++ b/sources/Renderer/OpenGL/Command/GLImmediateCommandBuffer.cpp
@@ -354,7 +354,7 @@ void GLImmediateCommandBuffer::SetResource(std::uint32_t descriptor, Resource& r
     if (binding.combiners > 0)
     {
         /* Bind resource at one or more slots for combined texture-samplers */
-        const std::vector<GLuint>& combinedSamplerSlots = pipelineLayoutGL->GetCombinedSamplerSlots();
+        const vector<GLuint>& combinedSamplerSlots = pipelineLayoutGL->GetCombinedSamplerSlots();
         BindCombinedResource(binding.type, &(combinedSamplerSlots[binding.slot]), binding.combiners, resource);
     }
     else

--- a/sources/Renderer/OpenGL/Ext/GLExtensionLoader.h
+++ b/sources/Renderer/OpenGL/Ext/GLExtensionLoader.h
@@ -9,7 +9,7 @@
 #define LLGL_GL_EXTENSION_LOADER_H
 
 
-#include <set>
+#include <LLGL/Container/Set.h>
 
 
 namespace LLGL
@@ -26,10 +26,10 @@ bool LoadSupportedOpenGLExtensions(bool isCoreProfile, bool abortOnFailure = fal
 bool AreOpenGLExtensionsLoaded();
 
 // Returns the set of OpenGL extensions that are supported by the GL context that was active during the last call to LoadSupportedOpenGLExtensions().
-const std::set<const char*>& GetSupportedOpenGLExtensions();
+const set<const char*>& GetSupportedOpenGLExtensions();
 
 // Returns the set of OpenGL extensions that were loaded during the last call to LoadSupportedOpenGLExtensions().
-const std::set<const char*>& GetLoadedOpenGLExtensions();
+const set<const char*>& GetLoadedOpenGLExtensions();
 
 /* --- Common GL extensions --- */
 

--- a/sources/Renderer/OpenGL/GLCore.h
+++ b/sources/Renderer/OpenGL/GLCore.h
@@ -10,7 +10,7 @@
 
 
 #include "OpenGL.h"
-#include <string>
+#include <LLGL/Container/String.h>
 
 
 namespace LLGL

--- a/sources/Renderer/OpenGL/GLObjectUtils.cpp
+++ b/sources/Renderer/OpenGL/GLObjectUtils.cpp
@@ -9,7 +9,7 @@
 #include "Ext/GLExtensions.h"
 #include "Ext/GLExtensionRegistry.h"
 #include "RenderState/GLStateManager.h"
-#include <string>
+#include <LLGL/Container/String.h>
 #include <cstring> // std::strlen
 
 
@@ -48,7 +48,7 @@ void GLSetObjectLabelSubscript(GLenum identifier, GLuint name, const char* label
     if (label != nullptr)
     {
         /* Append subscript to label */
-        std::string labelWithSubscript = label;
+        string labelWithSubscript = label;
 
         labelWithSubscript += '[';
         labelWithSubscript += subscript;
@@ -65,7 +65,7 @@ void GLSetObjectLabelIndexed(GLenum identifier, GLuint name, const char* label, 
     if (label != nullptr)
     {
         /* Append subscript to label */
-        std::string subscript = std::to_string(index);
+        string subscript = std::to_string(index);
         GLSetObjectLabelSubscript(identifier, name, label, subscript.c_str());
     }
     else

--- a/sources/Renderer/OpenGL/GLRenderSystem.cpp
+++ b/sources/Renderer/OpenGL/GLRenderSystem.cpp
@@ -675,26 +675,26 @@ void GLRenderSystem::EnableDebugCallback(bool enable)
     #endif // /LLGL_GLEXT_DEBUG
 }
 
-static std::string GLGetString(GLenum name)
+static string GLGetString(GLenum name)
 {
     const GLubyte* bytes = glGetString(name);
-    return (bytes != nullptr ? std::string(reinterpret_cast<const char*>(bytes)) : "");
+    return (bytes != nullptr ? string(reinterpret_cast<const char*>(bytes)) : "");
 }
 
 static void GLQueryRendererInfo(RendererInfo& info)
 {
-    info.rendererName           = GLProfile::GetAPIName() + std::string(" ") + GLGetString(GL_VERSION);
+    info.rendererName           = GLProfile::GetAPIName() + string(" ") + GLGetString(GL_VERSION);
     info.deviceName             = GLGetString(GL_RENDERER);
     info.vendorName             = GLGetString(GL_VENDOR);
-    info.shadingLanguageName    = GLProfile::GetShadingLanguageName() + std::string(" ") + GLGetString(GL_SHADING_LANGUAGE_VERSION);
+    info.shadingLanguageName    = GLProfile::GetShadingLanguageName() + string(" ") + GLGetString(GL_SHADING_LANGUAGE_VERSION);
 
-    const std::set<const char*>& extensionNames = GetLoadedOpenGLExtensions();
-    info.extensionNames = std::vector<UTF8String>(extensionNames.begin(), extensionNames.end());
+    const set<const char*>& extensionNames = GetLoadedOpenGLExtensions();
+    info.extensionNames = vector<UTF8String>(extensionNames.begin(), extensionNames.end());
 
     GLQueryPipelineCacheID(info.pipelineCacheID);
 }
 
-static void AppendCacheIDBytes(std::vector<char>& cacheID, const void* bytes, std::size_t count)
+static void AppendCacheIDBytes(vector<char>& cacheID, const void* bytes, std::size_t count)
 {
     const std::size_t offset = cacheID.size();
     cacheID.resize(offset + count);
@@ -702,13 +702,13 @@ static void AppendCacheIDBytes(std::vector<char>& cacheID, const void* bytes, st
 }
 
 template <typename T>
-static void AppendCacheIDValue(std::vector<char>& cacheID, const T& val)
+static void AppendCacheIDValue(vector<char>& cacheID, const T& val)
 {
     AppendCacheIDBytes(cacheID, &val, sizeof(val));
 }
 
 // Must not be static to be available in GL module
-void GLQueryPipelineCacheID(std::vector<char>& cacheID)
+void GLQueryPipelineCacheID(vector<char>& cacheID)
 {
     #ifdef GL_ARB_get_program_binary
     if (HasExtension(GLExt::ARB_get_program_binary))
@@ -721,7 +721,7 @@ void GLQueryPipelineCacheID(std::vector<char>& cacheID)
             AppendCacheIDValue(cacheID, numBinaryFormats);
 
             /* Append binary format values themselves */
-            std::vector<GLint> formats;
+            vector<GLint> formats;
             formats.resize(numBinaryFormats);
             glGetIntegerv(GL_PROGRAM_BINARY_FORMATS, formats.data());
             AppendCacheIDBytes(cacheID, formats.data(), sizeof(GLint) * formats.size());

--- a/sources/Renderer/OpenGL/GLRenderSystem.h
+++ b/sources/Renderer/OpenGL/GLRenderSystem.h
@@ -39,10 +39,10 @@
 
 #include "../ProxyPipelineCache.h"
 
-#include <string>
+#include <LLGL/Container/String.h>
 #include <memory>
-#include <vector>
-#include <set>
+#include <LLGL/Container/Vector.h>
+#include <LLGL/Container/Set.h>
 
 
 namespace LLGL

--- a/sources/Renderer/OpenGL/GLRenderingCaps.h
+++ b/sources/Renderer/OpenGL/GLRenderingCaps.h
@@ -10,7 +10,7 @@
 
 
 #include <LLGL/RenderSystemFlags.h>
-#include <vector>
+#include <LLGL/Container/Vector.h>
 
 
 namespace LLGL
@@ -21,7 +21,7 @@ namespace LLGL
 void GLQueryRenderingCaps(RenderingCapabilities& caps);
 
 // Queries a string used to identify invalidated pipeline caches. This includes the shader binary format.
-void GLQueryPipelineCacheID(std::vector<char>& cacheID);
+void GLQueryPipelineCacheID(vector<char>& cacheID);
 
 
 } // /namespace LLGL

--- a/sources/Renderer/OpenGL/Platform/GLContextManager.h
+++ b/sources/Renderer/OpenGL/Platform/GLContextManager.h
@@ -12,7 +12,7 @@
 #include "GLContext.h"
 #include <LLGL/RendererConfiguration.h>
 #include <LLGL/Container/DynamicArray.h>
-#include <vector>
+#include <LLGL/Container/Vector.h>
 #include <memory>
 #include <functional>
 
@@ -98,7 +98,7 @@ class GLContextManager
     private:
 
         RendererConfigurationOpenGL             profile_;
-        std::vector<GLPixelFormatWithContext>   pixelFormats_;
+        vector<GLPixelFormatWithContext>   pixelFormats_;
         DynamicByteArray                        customNativeHandle_;
         NewGLContextCallback                    newContextCallback_;
 

--- a/sources/Renderer/OpenGL/Platform/Win32/Win32GLContext.h
+++ b/sources/Renderer/OpenGL/Platform/Win32/Win32GLContext.h
@@ -13,7 +13,7 @@
 #include "../../OpenGL.h"
 #include <LLGL/RendererConfiguration.h>
 #include <LLGL/Platform/NativeHandle.h>
-#include <vector>
+#include <LLGL/Container/Vector.h>
 
 
 namespace LLGL

--- a/sources/Renderer/OpenGL/Profile/GLCore/GLCoreExtensionLoader.cpp
+++ b/sources/Renderer/OpenGL/Profile/GLCore/GLCoreExtensionLoader.cpp
@@ -11,8 +11,8 @@
 #include "GLCoreExtensions.h"
 #include <LLGL/Utils/ForRange.h>
 #include <functional>
-#include <string>
-#include <map>
+#include <LLGL/Container/String.h>
+#include <LLGL/Container/Map.h>
 
 
 namespace LLGL
@@ -20,7 +20,7 @@ namespace LLGL
 
 
 // OpenGL extension map type: Maps the extension name to boolean indicating whether or not the extension was loaded successully.
-using GLExtensionMap = std::map<std::string, bool>;
+using GLExtensionMap = map<string, bool>;
 
 /* --- Internal functions --- */
 
@@ -42,12 +42,12 @@ bool LoadGLProc(T& procAddr, const char* procName)
     return (procAddr != nullptr);
 }
 
-static void ExtractExtensionsFromString(GLExtensionMap& extensions, const std::string& extString)
+static void ExtractExtensionsFromString(GLExtensionMap& extensions, const string& extString)
 {
     size_t first = 0, last = 0;
 
     /* Find next extension name in string */
-    while ( ( last = extString.find(' ', first) ) != std::string::npos )
+    while ( ( last = extString.find(' ', first) ) != string::npos )
     {
         /* Store current extension name in hash-map */
         auto name = extString.substr(first, last - first);
@@ -1010,8 +1010,8 @@ static void IncludeImpliedExtensions(GLExtensionMap& extensions)
 // Global member to store if the extension have already been loaded
 static bool                     g_OpenGLExtensionsLoaded = false;
 static GLExtensionMap           g_OpenGLExtensionsMap;
-static std::set<const char*>    g_supportedOpenGLExtensions;
-static std::set<const char*>    g_loadedOpenGLExtensions;
+static set<const char*>    g_supportedOpenGLExtensions;
+static set<const char*>    g_loadedOpenGLExtensions;
 
 bool LoadSupportedOpenGLExtensions(bool isCoreProfile, bool abortOnFailure)
 {
@@ -1119,7 +1119,7 @@ bool LoadSupportedOpenGLExtensions(bool isCoreProfile, bool abortOnFailure)
         }
     };
 
-    auto EnableExtension = [&](const std::string& extName, GLExt extensionID) -> void
+    auto EnableExtension = [&](const string& extName, GLExt extensionID) -> void
     {
         /* Try to enable OpenGL extension */
         if (g_OpenGLExtensionsMap.find(extName) != g_OpenGLExtensionsMap.end())
@@ -1260,12 +1260,12 @@ bool AreOpenGLExtensionsLoaded()
     return g_OpenGLExtensionsLoaded;
 }
 
-const std::set<const char*>& GetSupportedOpenGLExtensions()
+const set<const char*>& GetSupportedOpenGLExtensions()
 {
     return g_supportedOpenGLExtensions;
 }
 
-const std::set<const char*>& GetLoadedOpenGLExtensions()
+const set<const char*>& GetLoadedOpenGLExtensions()
 {
     return g_loadedOpenGLExtensions;
 }

--- a/sources/Renderer/OpenGL/Profile/GLCore/GLCoreProfileCaps.cpp
+++ b/sources/Renderer/OpenGL/Profile/GLCore/GLCoreProfileCaps.cpp
@@ -47,9 +47,9 @@ static float GLGetFloat(GLenum param)
     return attr;
 }
 
-static std::vector<ShadingLanguage> GLQueryShadingLanguages()
+static vector<ShadingLanguage> GLQueryShadingLanguages()
 {
-    std::vector<ShadingLanguage> languages;
+    vector<ShadingLanguage> languages;
     languages.reserve(16);
 
     if (HasExtension(GLExt::ARB_shader_objects))
@@ -92,7 +92,7 @@ static std::vector<ShadingLanguage> GLQueryShadingLanguages()
 
         if (numBinaryFormats > 0)
         {
-            std::vector<GLint> binaryFormats(static_cast<std::size_t>(numBinaryFormats));
+            vector<GLint> binaryFormats(static_cast<std::size_t>(numBinaryFormats));
             glGetIntegerv(GL_SHADER_BINARY_FORMATS, binaryFormats.data());
 
             if (std::find(binaryFormats.begin(), binaryFormats.end(), GL_SHADER_BINARY_FORMAT_SPIR_V) != binaryFormats.end())
@@ -109,7 +109,7 @@ static std::vector<ShadingLanguage> GLQueryShadingLanguages()
     return languages;
 }
 
-static std::vector<Format> GetDefaultSupportedGLTextureFormats()
+static vector<Format> GetDefaultSupportedGLTextureFormats()
 {
     return
     {
@@ -139,7 +139,7 @@ static void GLGetRenderingAttribs(RenderingCapabilities& caps)
     caps.shadingLanguages   = GLQueryShadingLanguages();
 }
 
-static void GLGetSupportedTextureFormats(std::vector<Format>& textureFormats)
+static void GLGetSupportedTextureFormats(vector<Format>& textureFormats)
 {
     textureFormats = GetDefaultSupportedGLTextureFormats();
 
@@ -168,7 +168,7 @@ static void GLGetSupportedTextureFormats(std::vector<Format>& textureFormats)
 
     const std::uint32_t numCompressedTexFormats = GLGetUInt(GL_NUM_COMPRESSED_TEXTURE_FORMATS);
 
-    std::vector<GLint> compressedTexFormats(numCompressedTexFormats);
+    vector<GLint> compressedTexFormats(numCompressedTexFormats);
     glGetIntegerv(GL_COMPRESSED_TEXTURE_FORMATS, compressedTexFormats.data());
 
     for (GLint internalFormat : compressedTexFormats)

--- a/sources/Renderer/OpenGL/RenderState/GLFence.h
+++ b/sources/Renderer/OpenGL/RenderState/GLFence.h
@@ -11,7 +11,7 @@
 
 #include <LLGL/Fence.h>
 #include "../OpenGL.h"
-#include <string>
+#include <LLGL/Container/String.h>
 #include <cstdint>
 
 
@@ -42,7 +42,7 @@ class GLFence final : public Fence
 
         #ifdef LLGL_DEBUG
         // Only provide name in debug mode, to keep fence objects as lightweight as possible
-        std::string name_;
+        string name_;
         #endif
 
 };

--- a/sources/Renderer/OpenGL/RenderState/GLGraphicsPSO.cpp
+++ b/sources/Renderer/OpenGL/RenderState/GLGraphicsPSO.cpp
@@ -18,22 +18,22 @@
 #include <LLGL/PipelineStateFlags.h>
 #include <LLGL/Constants.h>
 #include <LLGL/Utils/ForRange.h>
-#include <vector>
+#include <LLGL/Container/Vector.h>
 
 
 namespace LLGL
 {
 
 
-static void AddToShaderArray(Shader* shader, std::vector<Shader*>& shaders)
+static void AddToShaderArray(Shader* shader, vector<Shader*>& shaders)
 {
     if (shader != nullptr)
         shaders.push_back(shader);
 }
 
-static std::vector<Shader*> GetShaderArrayFromDesc(const GraphicsPipelineDescriptor& desc)
+static vector<Shader*> GetShaderArrayFromDesc(const GraphicsPipelineDescriptor& desc)
 {
-    std::vector<Shader*> shaders;
+    vector<Shader*> shaders;
     shaders.reserve(5);
 
     AddToShaderArray(desc.vertexShader,         shaders);

--- a/sources/Renderer/OpenGL/RenderState/GLPipelineLayout.cpp
+++ b/sources/Renderer/OpenGL/RenderState/GLPipelineLayout.cpp
@@ -210,7 +210,7 @@ void GLPipelineLayout::BuildDynamicResourceBindings(const PipelineLayoutDescript
 
 void GLPipelineLayout::BuildStaticSamplers(const PipelineLayoutDescriptor& pipelineLayoutDesc)
 {
-    const std::vector<StaticSamplerDescriptor>& staticSamplerDescs = pipelineLayoutDesc.staticSamplers;
+    const vector<StaticSamplerDescriptor>& staticSamplerDescs = pipelineLayoutDesc.staticSamplers;
     staticSamplerSlots_.reserve(staticSamplerDescs.size());
     if (!HasNativeSamplers())
     {

--- a/sources/Renderer/OpenGL/RenderState/GLPipelineLayout.h
+++ b/sources/Renderer/OpenGL/RenderState/GLPipelineLayout.h
@@ -16,7 +16,7 @@
 #include "GLResourceType.h"
 #include "../Texture/GLSampler.h"
 #include "../Texture/GLEmulatedSampler.h"
-#include <vector>
+#include <LLGL/Container/Vector.h>
 
 
 namespace LLGL
@@ -28,7 +28,7 @@ class GLStateManager;
 // GL resource binding for heap resources (part of a ResourceHeap).
 struct GLHeapResourceBinding
 {
-    std::string     name;
+    string          name;
 
     // Interface for BindingIterator<>
     ResourceType    type        = ResourceType::Undefined;
@@ -83,43 +83,43 @@ class GLPipelineLayout final : public PipelineLayout
         void BindStaticSamplers(GLStateManager& stateMngr) const;
 
         // Returns the copied list of heap binding descriptors.
-        inline const std::vector<GLHeapResourceBinding>& GetHeapBindings() const
+        inline const vector<GLHeapResourceBinding>& GetHeapBindings() const
         {
             return heapBindings_;
         }
 
         // Returns the list of dynamic GL resource bindings.
-        inline const std::vector<GLPipelineResourceBinding>& GetBindings() const
+        inline const vector<GLPipelineResourceBinding>& GetBindings() const
         {
             return bindings_;
         }
 
         // Returns the list of static sampler binding slots.
-        inline const std::vector<GLuint>& GetStaticSamplerSlots() const
+        inline const vector<GLuint>& GetStaticSamplerSlots() const
         {
             return staticSamplerSlots_;
         }
 
         // Returns the list of combined texture-sampler binding slots.
-        inline const std::vector<GLuint>& GetCombinedSamplerSlots() const
+        inline const vector<GLuint>& GetCombinedSamplerSlots() const
         {
             return combinedSamplerSlots_;
         }
 
         // Returns the list of dynamic resource names. Only used by GLShaderBindingLayout.
-        inline ArrayView<std::string> GetBindingNames() const
+        inline ArrayView<string> GetBindingNames() const
         {
-            return ArrayView<std::string>{ resourceNames_.data() + (resourceNames_.size() - bindings_.size()), bindings_.size() };
+            return ArrayView<string>{ resourceNames_.data() + (resourceNames_.size() - bindings_.size()), bindings_.size() };
         }
 
         // Returns the list of combined texture-sampler names. Only used by GLShaderBindingLayout.
-        inline ArrayView<std::string> GetCombinedSamplerNames() const
+        inline ArrayView<string> GetCombinedSamplerNames() const
         {
-            return ArrayView<std::string>{ resourceNames_.data(), resourceNames_.size() - bindings_.size() };
+            return ArrayView<string>{ resourceNames_.data(), resourceNames_.size() - bindings_.size() };
         }
 
         // Returns the copied list of uniform descriptors.
-        inline const std::vector<UniformDescriptor>& GetUniforms() const
+        inline const vector<UniformDescriptor>& GetUniforms() const
         {
             return uniforms_;
         }
@@ -156,14 +156,14 @@ class GLPipelineLayout final : public PipelineLayout
 
     private:
 
-        std::vector<std::string>                resourceNames_; // Dynamic resource and static sampler names; Used by GLShaderBindingLayout
-        std::vector<GLHeapResourceBinding>      heapBindings_;
-        std::vector<GLPipelineResourceBinding>  bindings_;
-        std::vector<GLuint>                     staticSamplerSlots_;
-        std::vector<GLSamplerSPtr>              staticSamplers_;
-        std::vector<GLEmulatedSamplerSPtr>      staticEmulatedSamplers_;
-        std::vector<UniformDescriptor>          uniforms_;
-        std::vector<GLuint>                     combinedSamplerSlots_;
+        vector<string>                     resourceNames_; // Dynamic resource and static sampler names; Used by GLShaderBindingLayout
+        vector<GLHeapResourceBinding>      heapBindings_;
+        vector<GLPipelineResourceBinding>  bindings_;
+        vector<GLuint>                     staticSamplerSlots_;
+        vector<GLSamplerSPtr>              staticSamplers_;
+        vector<GLEmulatedSamplerSPtr>      staticEmulatedSamplers_;
+        vector<UniformDescriptor>          uniforms_;
+        vector<GLuint>                     combinedSamplerSlots_;
         const GLbitfield                        barriers_               = 0;
         const bool                              hasNamedBindings_       = false;
 

--- a/sources/Renderer/OpenGL/RenderState/GLPipelineState.cpp
+++ b/sources/Renderer/OpenGL/RenderState/GLPipelineState.cpp
@@ -127,7 +127,7 @@ void GLPipelineState::Bind(GLStateManager& stateMngr)
  */
 
 //TODO: support separate shaders; each separable shader needs its own set of uniform locations
-void GLPipelineState::BuildUniformMap(GLShader::Permutation permutation, const std::vector<UniformDescriptor>& uniforms)
+void GLPipelineState::BuildUniformMap(GLShader::Permutation permutation, const vector<UniformDescriptor>& uniforms)
 {
     if (shaderPipelines_[permutation].get() != nullptr && !uniforms.empty())
     {
@@ -150,11 +150,11 @@ Arrays of uniforms are reflected with a subscript for the first entry,
 e.g. "uniform inputTextures[2];" yields the active uniform name "inputTextures[0]".
 This functions removes the subscript, effecitvely returning "inputTextures" for this example.
 */
-static std::string GetActiveUniformNameAsIdent(const GLchar* uniformName)
+static string GetActiveUniformNameAsIdent(const GLchar* uniformName)
 {
-    std::string ident{ uniformName };
+    string ident{ uniformName };
     const std::size_t subscriptStartPos = ident.find('[');
-    if (subscriptStartPos != std::string::npos)
+    if (subscriptStartPos != string::npos)
         return ident.substr(0, subscriptStartPos);
     return ident;
 }
@@ -174,7 +174,7 @@ void GLPipelineState::BuildNameToActiveUniformMap(GLuint program, GLNameToUnifor
         return;
 
     /* Reserve memory to iterate over all active GL uniforms */
-    std::vector<GLchar> uniformName;
+    vector<GLchar> uniformName;
     uniformName.resize(maxUniformNameLength, '\0');
 
     outNameToUniformMap.reserve(static_cast<std::size_t>(numActiveUniforms));
@@ -184,7 +184,7 @@ void GLPipelineState::BuildNameToActiveUniformMap(GLuint program, GLNameToUnifor
     {
         GLActiveUniform uniform = {};
         glGetActiveUniform(program, i, static_cast<GLsizei>(uniformName.size()), nullptr, &uniform.size, &uniform.type, &uniformName[0]);
-        const std::string uniformIdent = GetActiveUniformNameAsIdent(uniformName.data());
+        const string uniformIdent = GetActiveUniformNameAsIdent(uniformName.data());
         outNameToUniformMap[uniformIdent] = uniform;
     }
 }

--- a/sources/Renderer/OpenGL/RenderState/GLPipelineState.h
+++ b/sources/Renderer/OpenGL/RenderState/GLPipelineState.h
@@ -78,7 +78,7 @@ class GLPipelineState : public PipelineState
         }
 
         // Returns the list of uniforms that maps from index of 'PipelineLayoutDescriptor::uniforms[]' to GL uniform location.
-        inline const std::vector<GLUniformLocation>& GetUniformMap() const
+        inline const vector<GLUniformLocation>& GetUniformMap() const
         {
             return uniformMap_;
         }
@@ -112,12 +112,12 @@ class GLPipelineState : public PipelineState
         };
 
         // Maps a name to its active GL uniform.
-        using GLNameToUniformMap = std::unordered_map<std::string, GLActiveUniform>;
+        using GLNameToUniformMap = std::unordered_map<string, GLActiveUniform>;
 
     private:
 
         // Builds the index-to-uniform map.
-        void BuildUniformMap(GLShader::Permutation permutation, const std::vector<UniformDescriptor>& uniforms);
+        void BuildUniformMap(GLShader::Permutation permutation, const vector<UniformDescriptor>& uniforms);
 
         // Builds the container that maps a name to the index of its active GL uniform.
         void BuildNameToActiveUniformMap(GLuint program, GLNameToUniformMap& outNameToUniformMap);
@@ -138,7 +138,7 @@ class GLPipelineState : public PipelineState
         GLShaderPipelineSPtr            shaderPipelines_[GLShader::PermutationCount];
         GLShaderBindingLayoutSPtr       shaderBindingLayout_;
         GLShaderBufferInterfaceMap      bufferInterfaceMap_;
-        std::vector<GLUniformLocation>  uniformMap_;
+        vector<GLUniformLocation>  uniformMap_;
         Report                          report_;
 
 };

--- a/sources/Renderer/OpenGL/RenderState/GLQueryHeap.h
+++ b/sources/Renderer/OpenGL/RenderState/GLQueryHeap.h
@@ -11,7 +11,7 @@
 
 #include <LLGL/QueryHeap.h>
 #include "../OpenGL.h"
-#include <vector>
+#include <LLGL/Container/Vector.h>
 
 
 namespace LLGL
@@ -40,7 +40,7 @@ class GLQueryHeap final : public QueryHeap
         }
 
         // Returns the list of hardware query IDs.
-        inline const std::vector<GLuint>& GetIDs() const
+        inline const vector<GLuint>& GetIDs() const
         {
             return ids_;
         }
@@ -53,7 +53,7 @@ class GLQueryHeap final : public QueryHeap
 
     private:
 
-        std::vector<GLuint> ids_;
+        vector<GLuint> ids_;
         std::uint32_t       groupSize_  = 1;
 
 };

--- a/sources/Renderer/OpenGL/RenderState/GLResourceHeap.cpp
+++ b/sources/Renderer/OpenGL/RenderState/GLResourceHeap.cpp
@@ -169,7 +169,7 @@ GLResourceHeap::GLResourceHeap(
     if (heap_.Stride() > (1u << k_heapSegmentSizeBits))
     {
         /* Error: Segment size is encoded in under 32 bits, so report if we exceeded the limit */
-        const std::string heapLabel = (desc.debugName != nullptr ? '\"' + std::string(desc.debugName) + '\"' : "<unnamed>");
+        const string heapLabel = (desc.debugName != nullptr ? '\"' + string(desc.debugName) + '\"' : "<unnamed>");
         LLGL_TRAP(
             "GLResourceHeap %s exceeded size limit for segment: allocated %zu bytes, but limit is %u (%u bits)",
             heapLabel.c_str(), heap_.Stride(), (1u << k_heapSegmentSizeBits), k_heapSegmentSizeBits
@@ -1014,7 +1014,7 @@ void GLResourceHeap::WriteResourceViewEmulatedSampler(const ResourceViewDescript
     }
 }
 
-std::vector<GLResourceHeap::GLResourceBinding> GLResourceHeap::FilterAndSortGLBindingSlots(
+vector<GLResourceHeap::GLResourceBinding> GLResourceHeap::FilterAndSortGLBindingSlots(
     GLHeapBindingIterator&      bindingIter,
     ResourceType                resourceType,
     long                        resourceBindFlags,
@@ -1023,7 +1023,7 @@ std::vector<GLResourceHeap::GLResourceBinding> GLResourceHeap::FilterAndSortGLBi
     /* Collect all binding points of the specified resource type */
     bindingIter.Reset(resourceType, resourceBindFlags);
 
-    std::vector<GLResourceBinding> resourceBindings;
+    vector<GLResourceBinding> resourceBindings;
     resourceBindings.reserve(bindingIter.GetCount());
 
     for (std::size_t index = 0; const GLHeapResourceBinding* bindingDesc = bindingIter.Next(&index);)

--- a/sources/Renderer/OpenGL/RenderState/GLResourceHeap.h
+++ b/sources/Renderer/OpenGL/RenderState/GLResourceHeap.h
@@ -149,7 +149,7 @@ class GLResourceHeap final : public ResourceHeap
         void WriteResourceViewSampler(const ResourceViewDescriptor& desc, char* heapPtr, std::uint32_t index);
         void WriteResourceViewEmulatedSampler(const ResourceViewDescriptor& desc, char* heapPtr, std::uint32_t index);
 
-        std::vector<GLResourceBinding> FilterAndSortGLBindingSlots(
+        vector<GLResourceBinding> FilterAndSortGLBindingSlots(
             GLHeapBindingIterator&      bindingIter,
             ResourceType                resourceType,
             long                        resourceBindFlags,

--- a/sources/Renderer/OpenGL/RenderState/GLStateManager.h
+++ b/sources/Renderer/OpenGL/RenderState/GLStateManager.h
@@ -15,7 +15,7 @@
 #include <LLGL/CommandBufferFlags.h>
 #include "../OpenGL.h"
 #include "../../../Core/Assertion.h"
-#include <stack>
+#include <LLGL/Container/Stack.h>
 #include <cstdint>
 
 
@@ -428,12 +428,12 @@ class GLStateManager
 
         bool                                frontFacingDirtyBit_        = false;
 
-        std::stack<CapabilityStackEntry>    capabilitiesStack_;
-        std::stack<BufferStackEntry>        bufferStack_;
-        std::stack<TextureStackEntry>       textureState_;
-        std::stack<FramebufferStackEntry>   framebufferStack_;
-        std::stack<RenderbufferStackEntry>  renderbufferStack_;
-        std::stack<ShaderProgramStackEntry> shaderProgramStack_;
+        stack<CapabilityStackEntry>         capabilitiesStack_;
+        stack<BufferStackEntry>             bufferStack_;
+        stack<TextureStackEntry>            textureState_;
+        stack<FramebufferStackEntry>        framebufferStack_;
+        stack<RenderbufferStackEntry>       renderbufferStack_;
+        stack<ShaderProgramStackEntry>      shaderProgramStack_;
 
 };
 

--- a/sources/Renderer/OpenGL/RenderState/GLStatePool.cpp
+++ b/sources/Renderer/OpenGL/RenderState/GLStatePool.cpp
@@ -32,7 +32,7 @@ namespace LLGL
 // Searches a compatible state object with complexity O(log n)
 template <typename T, typename TCompare = T, typename TBase = T>
 std::shared_ptr<T> FindCompatibleStateObject(
-    std::vector<std::shared_ptr<TBase>>&    container,
+    vector<std::shared_ptr<TBase>>&    container,
     const TCompare&                         compareObject,
     std::size_t&                            index)
 {
@@ -49,7 +49,7 @@ std::shared_ptr<T> FindCompatibleStateObject(
 }
 
 template <typename T, typename TCompare, typename TBase, typename... Args>
-std::shared_ptr<T> CreateRenderStateObjectExt(std::vector<std::shared_ptr<TBase>>& container, Args&&... args)
+std::shared_ptr<T> CreateRenderStateObjectExt(vector<std::shared_ptr<TBase>>& container, Args&&... args)
 {
     /* Try to find render state object with same parameter */
     const TCompare stateToCompare{ std::forward<Args>(args)... };
@@ -66,7 +66,7 @@ std::shared_ptr<T> CreateRenderStateObjectExt(std::vector<std::shared_ptr<TBase>
 }
 
 template <typename T, typename... Args>
-std::shared_ptr<T> CreateRenderStateObject(std::vector<std::shared_ptr<T>>& container, Args&&... args)
+std::shared_ptr<T> CreateRenderStateObject(vector<std::shared_ptr<T>>& container, Args&&... args)
 {
     /* Try to find render state object with same parameter */
     T stateToCompare{ std::forward<Args>(args)... };
@@ -84,7 +84,7 @@ std::shared_ptr<T> CreateRenderStateObject(std::vector<std::shared_ptr<T>>& cont
 
 template <typename T>
 void ReleaseRenderStateObject(
-    std::vector<std::shared_ptr<T>>&    container,
+    vector<std::shared_ptr<T>>&    container,
     const std::function<void(T*)>&      callback,
     std::shared_ptr<T>&&                renderState)
 {

--- a/sources/Renderer/OpenGL/RenderState/GLStatePool.h
+++ b/sources/Renderer/OpenGL/RenderState/GLStatePool.h
@@ -17,7 +17,7 @@
 #include "../Shader/GLShaderBindingLayout.h"
 #include "../Shader/GLShaderPipeline.h"
 #include "../Shader/GLShader.h"
-#include <vector>
+#include <LLGL/Container/Vector.h>
 
 
 namespace LLGL
@@ -82,11 +82,11 @@ class GLStatePool
 
     private:
 
-        std::vector<GLDepthStencilStateSPtr>    depthStencilStates_;
-        std::vector<GLRasterizerStateSPtr>      rasterizerStates_;
-        std::vector<GLBlendStateSPtr>           blendStates_;
-        std::vector<GLShaderBindingLayoutSPtr>  shaderBindingLayouts_;
-        std::vector<GLShaderPipelineSPtr>       shaderPipelines_;
+        vector<GLDepthStencilStateSPtr>    depthStencilStates_;
+        vector<GLRasterizerStateSPtr>      rasterizerStates_;
+        vector<GLBlendStateSPtr>           blendStates_;
+        vector<GLShaderBindingLayoutSPtr>  shaderBindingLayouts_;
+        vector<GLShaderPipelineSPtr>       shaderPipelines_;
 
 };
 

--- a/sources/Renderer/OpenGL/Shader/GLLegacyShader.cpp
+++ b/sources/Renderer/OpenGL/Shader/GLLegacyShader.cpp
@@ -58,7 +58,7 @@ bool GLLegacyShader::GetCompileStatus(GLuint shader)
     return (status != GL_FALSE);
 }
 
-std::string GLLegacyShader::GetGLShaderLog(GLuint shader)
+string GLLegacyShader::GetGLShaderLog(GLuint shader)
 {
     /* Query info log length */
     GLint infoLogLength = 0;
@@ -67,7 +67,7 @@ std::string GLLegacyShader::GetGLShaderLog(GLuint shader)
     if (infoLogLength > 0)
     {
         /* Store info log in byte buffer (because GL writes it's own null-terminator character!) */
-        std::vector<char> infoLog;
+        vector<char> infoLog;
         infoLog.resize(infoLogLength, '\0');
 
         /* Query info log output */
@@ -75,7 +75,7 @@ std::string GLLegacyShader::GetGLShaderLog(GLuint shader)
         glGetShaderInfoLog(shader, infoLogLength, &charsWritten, infoLog.data());
 
         /* Convert byte buffer to string */
-        return std::string(infoLog.data(), static_cast<std::size_t>(charsWritten));
+        return string(infoLog.data(), static_cast<std::size_t>(charsWritten));
     }
 
     return "";
@@ -118,7 +118,7 @@ void GLLegacyShader::CompileSource(const ShaderDescriptor& shaderDesc)
 
         if (shaderDesc.sourceType == ShaderSourceType::CodeFile)
         {
-            const std::string fileContent = ReadFileString(shaderDesc.source);
+            const string fileContent = ReadFileString(shaderDesc.source);
             GLShader::PatchShaderSource(sourceCallback, fileContent.c_str(), shaderDesc, enabledFlags);
         }
         else
@@ -144,7 +144,7 @@ void GLLegacyShader::LoadBinary(const ShaderDescriptor& shaderDesc)
     if (HasExtension(GLExt::ARB_gl_spirv) && HasExtension(GLExt::ARB_ES2_compatibility))
     {
         /* Get shader binary */
-        std::vector<char>   fileContent;
+        vector<char>   fileContent;
         const void*         binaryBuffer    = nullptr;
         GLsizei             binaryLength    = 0;
 

--- a/sources/Renderer/OpenGL/Shader/GLLegacyShader.h
+++ b/sources/Renderer/OpenGL/Shader/GLLegacyShader.h
@@ -39,7 +39,7 @@ class GLLegacyShader final : public GLShader
         static bool GetCompileStatus(GLuint shader);
 
         // Returns the native GL shader log.
-        static std::string GetGLShaderLog(GLuint shader);
+        static string GetGLShaderLog(GLuint shader);
 
     private:
 

--- a/sources/Renderer/OpenGL/Shader/GLProgramPipeline.cpp
+++ b/sources/Renderer/OpenGL/Shader/GLProgramPipeline.cpp
@@ -93,7 +93,7 @@ void GLProgramPipeline::BindResourceSlots(const GLShaderBindingLayout& bindingLa
 void GLProgramPipeline::QueryInfoLogs(Report& report)
 {
     bool hasErrors = false;
-    std::string log;
+    string log;
 
     for_range(i, GetSignature().GetNumShaders())
         separableShaders_[i]->QueryInfoLog(log, hasErrors);
@@ -101,7 +101,7 @@ void GLProgramPipeline::QueryInfoLogs(Report& report)
     report.Reset(std::move(log), hasErrors);
 }
 
-void GLProgramPipeline::QueryTexBufferNames(std::set<std::string>& outSamplerBufferNames, std::set<std::string>& outImageBufferNames) const
+void GLProgramPipeline::QueryTexBufferNames(set<string>& outSamplerBufferNames, set<string>& outImageBufferNames) const
 {
     outSamplerBufferNames.clear();
     outImageBufferNames.clear();

--- a/sources/Renderer/OpenGL/Shader/GLProgramPipeline.h
+++ b/sources/Renderer/OpenGL/Shader/GLProgramPipeline.h
@@ -35,7 +35,7 @@ class GLProgramPipeline final : public GLShaderPipeline
         void Bind(GLStateManager& stateMngr) override;
         void BindResourceSlots(const GLShaderBindingLayout& bindingLayout, const GLShaderBufferInterfaceMap* bufferInterfaceMap = nullptr) override;
         void QueryInfoLogs(Report& report) override;
-        void QueryTexBufferNames(std::set<std::string>& outSamplerBufferNames, std::set<std::string>& outImageBufferNames) const override;
+        void QueryTexBufferNames(set<string>& outSamplerBufferNames, set<string>& outImageBufferNames) const override;
 
     private:
 

--- a/sources/Renderer/OpenGL/Shader/GLSeparableShader.cpp
+++ b/sources/Renderer/OpenGL/Shader/GLSeparableShader.cpp
@@ -63,7 +63,7 @@ void GLSeparableShader::BindResourceSlots(const GLShaderBindingLayout& bindingLa
     }
 }
 
-void GLSeparableShader::QueryInfoLog(std::string& text, bool& hasErrors)
+void GLSeparableShader::QueryInfoLog(string& text, bool& hasErrors)
 {
     if (!GLShaderProgram::GetLinkStatus(GetID()))
         hasErrors = true;
@@ -151,7 +151,7 @@ void GLSeparableShader::BindResourceSlots(const GLShaderBindingLayout& bindingLa
     // dummy
 }
 
-void GLSeparableShader::QueryInfoLog(std::string& text, bool& hasErrors)
+void GLSeparableShader::QueryInfoLog(string& text, bool& hasErrors)
 {
     // dummy
 }

--- a/sources/Renderer/OpenGL/Shader/GLSeparableShader.h
+++ b/sources/Renderer/OpenGL/Shader/GLSeparableShader.h
@@ -41,7 +41,7 @@ class GLSeparableShader final : public GLShader
         void BindResourceSlots(const GLShaderBindingLayout& bindingLayout, const GLShaderBufferInterfaceMap* bufferInterfaceMap = nullptr);
 
         // Queries the program info log and appends it to the output text.
-        void QueryInfoLog(std::string& text, bool& hasErrors);
+        void QueryInfoLog(string& text, bool& hasErrors);
 
     private:
 
@@ -68,7 +68,7 @@ class GLSeparableShader final : public GLShader
         GLSeparableShader(const ShaderDescriptor& desc);
 
         void BindResourceSlots(const GLShaderBindingLayout& bindingLayout, const GLShaderBufferInterfaceMap* bufferInterfaceMap = nullptr);
-        void QueryInfoLog(std::string& text, bool& hasErrors);
+        void QueryInfoLog(string& text, bool& hasErrors);
 
 };
 

--- a/sources/Renderer/OpenGL/Shader/GLShader.cpp
+++ b/sources/Renderer/OpenGL/Shader/GLShader.cpp
@@ -15,7 +15,7 @@
 #include "../../../Core/Exception.h"
 #include "../../../Core/ReportUtils.h"
 #include <LLGL/Utils/ForRange.h>
-#include <vector>
+#include <LLGL/Container/Vector.h>
 #include <stdexcept>
 #include <algorithm>
 
@@ -168,7 +168,7 @@ void GLShader::PatchShaderSourceWithOptions(
     }
 }
 
-void GLShader::ReportStatusAndLog(bool status, const std::string& log)
+void GLShader::ReportStatusAndLog(bool status, const string& log)
 {
     ResetReportWithNewline(report_, log.c_str(), !status);
 }

--- a/sources/Renderer/OpenGL/Shader/GLShader.h
+++ b/sources/Renderer/OpenGL/Shader/GLShader.h
@@ -61,7 +61,7 @@ class GLShader : public Shader
         GLenum GetGLType() const;
 
         // Returns the transform feedback varying names.
-        inline const std::vector<const char*>& GetTransformFeedbackVaryings() const
+        inline const vector<const char*>& GetTransformFeedbackVaryings() const
         {
             return transformFeedbackVaryings_;
         }
@@ -115,7 +115,7 @@ class GLShader : public Shader
         GLShader(const bool isSeparable, const ShaderDescriptor& desc);
 
         // Resets the report with the specified compile/link status and log.
-        void ReportStatusAndLog(bool status, const std::string& log);
+        void ReportStatusAndLog(bool status, const string& log);
 
         // Stores the native shader ID.
         inline void SetID(GLuint id, Permutation permutation = PermutationDefault)
@@ -135,9 +135,9 @@ class GLShader : public Shader
         const bool                      isSeparable_;
         GLuint                          id_[PermutationCount]       = {}; // ID from either glCreateShader or glCreateShaderProgramv
         LinearStringContainer           shaderAttribNames_;
-        std::vector<GLShaderAttribute>  shaderAttribs_;
+        vector<GLShaderAttribute>  shaderAttribs_;
         std::size_t                     numVertexAttribs_           = 0;
-        std::vector<const char*>        transformFeedbackVaryings_;
+        vector<const char*>        transformFeedbackVaryings_;
         Report                          report_;
 
 };

--- a/sources/Renderer/OpenGL/Shader/GLShaderBindingLayout.cpp
+++ b/sources/Renderer/OpenGL/Shader/GLShaderBindingLayout.cpp
@@ -182,7 +182,7 @@ void GLShaderBindingLayout::BuildUniformBindings(const GLPipelineLayout& pipelin
     /* Gather all uniform bindings from dynamic resource descriptors */
     for_range(i, pipelineLayout.GetBindingNames().size())
     {
-        const std::string& name = pipelineLayout.GetBindingNames()[i];
+        const string& name = pipelineLayout.GetBindingNames()[i];
         if (!name.empty())
         {
             const GLPipelineResourceBinding& binding = pipelineLayout.GetBindings()[i];
@@ -199,7 +199,7 @@ void GLShaderBindingLayout::BuildUniformBindings(const GLPipelineLayout& pipelin
     /* Append all uniform bindings for combined texture-samplers */
     for_range(i, pipelineLayout.GetCombinedSamplerNames().size())
     {
-        const std::string& name = pipelineLayout.GetCombinedSamplerNames()[i];
+        const string& name = pipelineLayout.GetCombinedSamplerNames()[i];
         if (!name.empty())
             AppendUniformBinding(name, pipelineLayout.GetCombinedSamplerSlots()[i]);
     }
@@ -220,7 +220,7 @@ void GLShaderBindingLayout::BuildUniformBlockBindings(const GLPipelineLayout& pi
     /* Gather all uniform-block bindings from dynamic resource descriptors */
     for_range(i, pipelineLayout.GetBindings().size())
     {
-        const std::string& name = pipelineLayout.GetBindingNames()[i];
+        const string& name = pipelineLayout.GetBindingNames()[i];
         if (!name.empty())
         {
             const GLPipelineResourceBinding& binding = pipelineLayout.GetBindings()[i];
@@ -243,25 +243,25 @@ void GLShaderBindingLayout::BuildShaderStorageBindings(const GLPipelineLayout& p
     for_range(i, pipelineLayout.GetBindings().size())
     {
         const GLPipelineResourceBinding& binding = pipelineLayout.GetBindings()[i];
-        const std::string& name = pipelineLayout.GetBindingNames()[i];
+        const string& name = pipelineLayout.GetBindingNames()[i];
         if (!name.empty() && binding.IsSSBO())
             AppendShaderStorageBinding(name, binding.slot);
     }
 }
 
-void GLShaderBindingLayout::AppendUniformBinding(const std::string& name, std::uint32_t slot, std::uint32_t size)
+void GLShaderBindingLayout::AppendUniformBinding(const string& name, std::uint32_t slot, std::uint32_t size)
 {
     bindings_.push_back({ name, slot, size });
     ++numUniformBindings_;
 }
 
-void GLShaderBindingLayout::AppendUniformBlockBinding(const std::string& name, std::uint32_t slot)
+void GLShaderBindingLayout::AppendUniformBlockBinding(const string& name, std::uint32_t slot)
 {
     bindings_.push_back({ name, slot, 1u });
     ++numUniformBlockBindings_;
 }
 
-void GLShaderBindingLayout::AppendShaderStorageBinding(const std::string& name, std::uint32_t slot)
+void GLShaderBindingLayout::AppendShaderStorageBinding(const string& name, std::uint32_t slot)
 {
     bindings_.push_back({ name, slot, 1u });
     ++numShaderStorageBindings_;

--- a/sources/Renderer/OpenGL/Shader/GLShaderBindingLayout.h
+++ b/sources/Renderer/OpenGL/Shader/GLShaderBindingLayout.h
@@ -9,8 +9,8 @@
 #define LLGL_GL_SHADER_BINDING_LAYOUT_H
 
 
-#include <string>
-#include <vector>
+#include <LLGL/Container/String.h>
+#include <LLGL/Container/Vector.h>
 #include <cstdint>
 #include <memory>
 #include "../RenderState/GLPipelineLayout.h"
@@ -57,7 +57,7 @@ class GLShaderBindingLayout
 
         struct NamedResourceBinding
         {
-            std::string     name;
+            string          name;
             std::uint32_t   slot;
             std::uint32_t   size; // Number of array elements
         };
@@ -68,9 +68,9 @@ class GLShaderBindingLayout
         void BuildUniformBlockBindings(const GLPipelineLayout& pipelineLayout);
         void BuildShaderStorageBindings(const GLPipelineLayout& pipelineLayout);
 
-        void AppendUniformBinding(const std::string& name, std::uint32_t slot, std::uint32_t size = 1u);
-        void AppendUniformBlockBinding(const std::string& name, std::uint32_t slot);
-        void AppendShaderStorageBinding(const std::string& name, std::uint32_t slot);
+        void AppendUniformBinding(const string& name, std::uint32_t slot, std::uint32_t size = 1u);
+        void AppendUniformBlockBinding(const string& name, std::uint32_t slot);
+        void AppendShaderStorageBinding(const string& name, std::uint32_t slot);
 
     private:
 
@@ -85,7 +85,7 @@ class GLShaderBindingLayout
         std::uint8_t                        numUniformBindings_         = 0;
         std::uint8_t                        numUniformBlockBindings_    = 0;
         std::uint8_t                        numShaderStorageBindings_   = 0;
-        std::vector<NamedResourceBinding>   bindings_;
+        vector<NamedResourceBinding>   bindings_;
 
 };
 

--- a/sources/Renderer/OpenGL/Shader/GLShaderBufferInterfaceMap.cpp
+++ b/sources/Renderer/OpenGL/Shader/GLShaderBufferInterfaceMap.cpp
@@ -29,10 +29,10 @@ void GLShaderBufferInterfaceMap::BuildMap(const GLPipelineLayout& pipelineLayout
     LLGL_ASSERT(bufferMap_.empty(), "shader buffer interface map should only be built once");
 
     /* Query all active texture buffer names in shader pipeline */
-    std::set<std::string> samplerBufferNames, imageBufferNames;
+    set<string> samplerBufferNames, imageBufferNames;
     shaderPipeline.QueryTexBufferNames(samplerBufferNames, imageBufferNames);
 
-    auto MapResourceNameToBufferInterface = [&samplerBufferNames, &imageBufferNames](const std::string& name) -> GLBufferInterface
+    auto MapResourceNameToBufferInterface = [&samplerBufferNames, &imageBufferNames](const string& name) -> GLBufferInterface
     {
         /* If binding name matches a sampler buffer uniform, interpret binding descriptor as sampler buffer */
         if (samplerBufferNames.find(name) != samplerBufferNames.end())
@@ -59,7 +59,7 @@ void GLShaderBufferInterfaceMap::BuildMap(const GLPipelineLayout& pipelineLayout
     for_range(i, pipelineLayout.GetBindings().size())
     {
         const GLPipelineResourceBinding& binding = pipelineLayout.GetBindings()[i];
-        const std::string& name = pipelineLayout.GetBindingNames()[i];
+        const string& name = pipelineLayout.GetBindingNames()[i];
         if (!name.empty() && binding.IsSSBO())
             AppendDynamicEntry(MapResourceNameToBufferInterface(name));
     }

--- a/sources/Renderer/OpenGL/Shader/GLShaderBufferInterfaceMap.h
+++ b/sources/Renderer/OpenGL/Shader/GLShaderBufferInterfaceMap.h
@@ -9,7 +9,7 @@
 #define LLGL_GL_SHADER_BUFFER_INTERFACE_MAP_H
 
 
-#include <vector>
+#include <LLGL/Container/Vector.h>
 #include <LLGL/Container/ArrayView.h>
 #include "../RenderState/GLPipelineLayout.h"
 
@@ -107,7 +107,7 @@ class GLShaderBufferInterfaceMap
 
     private:
 
-        std::vector<GLBufferInterface>  bufferMap_;                         // Maps a buffer binding to a shader interface type
+        vector<GLBufferInterface>  bufferMap_;                         // Maps a buffer binding to a shader interface type
         std::size_t                     numSSBOs_                   : 15;   // Number of actual SSBOs in this bitmap
         std::size_t                     numHeapEntries_             : 15;
         std::size_t                     hasHeapSSBOEntriesOnly_     : 1;

--- a/sources/Renderer/OpenGL/Shader/GLShaderPipeline.h
+++ b/sources/Renderer/OpenGL/Shader/GLShaderPipeline.h
@@ -12,8 +12,8 @@
 #include "GLShader.h"
 #include "GLPipelineSignature.h"
 #include <memory>
-#include <string>
-#include <set>
+#include <LLGL/Container/String.h>
+#include <LLGL/Container/Set.h>
 
 
 namespace LLGL
@@ -46,7 +46,7 @@ class GLShaderPipeline
         virtual void QueryInfoLogs(Report& report) = 0;
 
         // Returns the set of all texture buffer names (samplerBuffer/imageBuffer) in the entire shader pipeline.
-        virtual void QueryTexBufferNames(std::set<std::string>& outSamplerBufferNames, std::set<std::string>& outImageBufferNames) const = 0;
+        virtual void QueryTexBufferNames(set<string>& outSamplerBufferNames, set<string>& outImageBufferNames) const = 0;
 
         // Returns the native pipeline ID. Can be either from glCreateProgramPipelines or glCreateProgram.
         inline GLuint GetID() const

--- a/sources/Renderer/OpenGL/Shader/GLShaderProgram.cpp
+++ b/sources/Renderer/OpenGL/Shader/GLShaderProgram.cpp
@@ -20,7 +20,7 @@
 #include <LLGL/VertexAttribute.h>
 #include <LLGL/Constants.h>
 #include <LLGL/Utils/ForRange.h>
-#include <vector>
+#include <LLGL/Container/Vector.h>
 #include <stdexcept>
 
 
@@ -133,11 +133,11 @@ void GLShaderProgram::BindResourceSlots(const GLShaderBindingLayout& bindingLayo
 void GLShaderProgram::QueryInfoLogs(Report& report)
 {
     const bool hasErrors = !GLShaderProgram::GetLinkStatus(GetID());
-    std::string log = GLShaderProgram::GetGLProgramLog(GetID());
+    string log = GLShaderProgram::GetGLProgramLog(GetID());
     report.Reset(std::move(log), hasErrors);
 }
 
-void GLShaderProgram::QueryTexBufferNames(std::set<std::string>& outSamplerBufferNames, std::set<std::string>& outImageBufferNames) const
+void GLShaderProgram::QueryTexBufferNames(set<string>& outSamplerBufferNames, set<string>& outImageBufferNames) const
 {
     outSamplerBufferNames.clear();
     outImageBufferNames.clear();
@@ -151,7 +151,7 @@ bool GLShaderProgram::GetLinkStatus(GLuint program)
     return (status != GL_FALSE);
 }
 
-std::string GLShaderProgram::GetGLProgramLog(GLuint program)
+string GLShaderProgram::GetGLProgramLog(GLuint program)
 {
     /* Query info log length */
     GLint infoLogLength = 0;
@@ -160,7 +160,7 @@ std::string GLShaderProgram::GetGLProgramLog(GLuint program)
     if (infoLogLength > 0)
     {
         /* Store info log in byte buffer (because GL writes it's own null-terminator character!) */
-        std::vector<char> infoLog;
+        vector<char> infoLog;
         infoLog.resize(infoLogLength, '\0');
 
         /* Query info log output */
@@ -168,7 +168,7 @@ std::string GLShaderProgram::GetGLProgramLog(GLuint program)
         glGetProgramInfoLog(program, infoLogLength, &charsWritten, infoLog.data());
 
         /* Convert byte buffer to string */
-        return std::string(infoLog.data(), static_cast<std::size_t>(charsWritten));
+        return string(infoLog.data(), static_cast<std::size_t>(charsWritten));
     }
 
     return "";
@@ -225,7 +225,7 @@ static void BuildTransformFeedbackVaryingsNV(GLuint program, std::size_t numVary
         return;
 
     /* Specify transform-feedback varyings by locations */
-    std::vector<GLint> varyingLocations;
+    vector<GLint> varyingLocations;
     varyingLocations.reserve(numVaryings);
 
     for_range(i, numVaryings)
@@ -291,7 +291,7 @@ static bool GLQueryActiveAttribs(
     GLenum              attribNameLengthType,
     GLint&              outNumAttribs,
     GLint&              outMaxNameLength,
-    std::vector<char>&  nameBuffer)
+    vector<char>&  nameBuffer)
 {
     /* Query number of active attributes */
     glGetProgramiv(program, attribCountType, &outNumAttribs);
@@ -313,7 +313,7 @@ static bool GLQueryActiveResources(
     GLenum              programInterface,
     GLint&              outNumResources,
     GLint&              outMaxNameLength,
-    std::vector<char>&  nameBuffer)
+    vector<char>&  nameBuffer)
 {
     #if LLGL_GLEXT_SHADER_STORAGE_BUFFER_OBJECT
 
@@ -442,12 +442,12 @@ struct GLReflectVertexAttribute
 static void GLQueryVertexAttributes(GLuint program, ShaderReflection& reflection)
 {
     /* Query active vertex attributes */
-    std::vector<char> attribName;
+    vector<char> attribName;
     GLint numAttribs = 0, maxNameLength = 0;
     if (!GLQueryActiveAttribs(program, GL_ACTIVE_ATTRIBUTES, GL_ACTIVE_ATTRIBUTE_MAX_LENGTH, numAttribs, maxNameLength, attribName))
         return;
 
-    std::vector<GLReflectVertexAttribute> attributes;
+    vector<GLReflectVertexAttribute> attributes;
     attributes.reserve(static_cast<std::size_t>(numAttribs));
 
     /* Iterate over all vertex attributes */
@@ -521,7 +521,7 @@ static void GLQueryStreamOutputAttributes(GLuint program, ShaderReflection& refl
     #endif
     {
         /* Query active varyings */
-        std::vector<char> attribName;
+        vector<char> attribName;
         GLint numVaryings = 0, maxNameLength = 0;
         if (!GLQueryActiveAttribs(program, GL_TRANSFORM_FEEDBACK_VARYINGS, GL_TRANSFORM_FEEDBACK_VARYING_MAX_LENGTH, numVaryings, maxNameLength, attribName))
             return;
@@ -554,7 +554,7 @@ static void GLQueryStreamOutputAttributes(GLuint program, ShaderReflection& refl
     else if (HasExtension(GLExt::NV_transform_feedback))
     {
         /* Query active varyings */
-        std::vector<char> attribName;
+        vector<char> attribName;
         GLint numVaryings = 0, maxNameLength = 0;
         if (!GLQueryActiveAttribs(program, GL_ACTIVE_VARYINGS_NV, GL_ACTIVE_VARYING_MAX_LENGTH_NV, numVaryings, maxNameLength, attribName))
             return;
@@ -682,7 +682,7 @@ static void GLQueryConstantBuffers(GLuint program, ShaderReflection& reflection)
         return;
 
     /* Query active uniform blocks */
-    std::vector<char> blockName;
+    vector<char> blockName;
     GLint numUniformBlocks = 0, maxNameLength = 0;
     if (!GLQueryActiveAttribs(program, GL_ACTIVE_UNIFORM_BLOCKS, GL_ACTIVE_UNIFORM_BLOCK_MAX_NAME_LENGTH, numUniformBlocks, maxNameLength, blockName))
         return;
@@ -728,7 +728,7 @@ static void GLQueryStorageBuffers(GLuint program, ShaderReflection& reflection)
 
     GLint numStorageBlocks = 0;
     GLint maxNameLength = 0;
-    std::vector<char> blockName;
+    vector<char> blockName;
     if (!GLQueryActiveResources(program, GL_SHADER_STORAGE_BLOCK, numStorageBlocks, maxNameLength, blockName))
         return;
 
@@ -767,7 +767,7 @@ static void GLQueryStorageBuffers(GLuint program, ShaderReflection& reflection)
 static void GLQueryUniforms(GLuint program, ShaderReflection& reflection)
 {
     /* Query active uniforms */
-    std::vector<char> uniformName;
+    vector<char> uniformName;
     GLint numUniforms = 0, maxNameLength = 0;
     if (!GLQueryActiveAttribs(program, GL_ACTIVE_UNIFORMS, GL_ACTIVE_UNIFORM_MAX_LENGTH, numUniforms, maxNameLength, uniformName))
         return;
@@ -886,10 +886,10 @@ void GLShaderProgram::QueryReflection(GLuint program, GLenum shaderStage, Shader
     #endif
 }
 
-void GLShaderProgram::QueryTexBufferNames(GLuint program, std::set<std::string>& samplerBufferNames, std::set<std::string>& imageBufferNames)
+void GLShaderProgram::QueryTexBufferNames(GLuint program, set<string>& samplerBufferNames, set<string>& imageBufferNames)
 {
     /* Query active uniform blocks */
-    std::vector<char> blockName;
+    vector<char> blockName;
     GLint numUniforms = 0, maxNameLength = 0;
     if (!GLQueryActiveAttribs(program, GL_ACTIVE_UNIFORMS, GL_ACTIVE_UNIFORM_MAX_LENGTH, numUniforms, maxNameLength, blockName))
         return;
@@ -901,7 +901,7 @@ void GLShaderProgram::QueryTexBufferNames(GLuint program, std::set<std::string>&
         GLint size = 0;
         GLenum type = 0;
         glGetActiveUniform(program, i, maxNameLength, &nameLength, &size, &type, blockName.data());
-        std::string uniformName(blockName.data(), static_cast<std::size_t>(nameLength));
+        string uniformName(blockName.data(), static_cast<std::size_t>(nameLength));
 
         /* Map sampler buffer and image buffer names to output sets */
         switch (type)

--- a/sources/Renderer/OpenGL/Shader/GLShaderProgram.h
+++ b/sources/Renderer/OpenGL/Shader/GLShaderProgram.h
@@ -12,8 +12,8 @@
 #include <LLGL/ShaderReflection.h>
 #include "GLShaderPipeline.h"
 #include "GLShaderUniform.h"
-#include <string>
-#include <set>
+#include <LLGL/Container/String.h>
+#include <LLGL/Container/Set.h>
 
 
 namespace LLGL
@@ -32,7 +32,7 @@ class GLShaderProgram final : public GLShaderPipeline
         void Bind(GLStateManager& stateMngr) override;
         void BindResourceSlots(const GLShaderBindingLayout& bindingLayout, const GLShaderBufferInterfaceMap* bufferInterfaceMap = nullptr) override;
         void QueryInfoLogs(Report& report) override;
-        void QueryTexBufferNames(std::set<std::string>& outSamplerBufferNames, std::set<std::string>& outImageBufferNames) const override;
+        void QueryTexBufferNames(set<string>& outSamplerBufferNames, set<string>& outImageBufferNames) const override;
 
     public:
 
@@ -50,7 +50,7 @@ class GLShaderProgram final : public GLShaderPipeline
         static bool GetLinkStatus(GLuint program);
 
         // Returns the native GL shader program log.
-        static std::string GetGLProgramLog(GLuint program);
+        static string GetGLProgramLog(GLuint program);
 
         // Invokes glBindAttribLocation on the specified program for all vertex attributes.
         static void BindAttribLocations(GLuint program, std::size_t numVertexAttribs, const GLShaderAttribute* vertexAttribs);
@@ -68,7 +68,7 @@ class GLShaderProgram final : public GLShaderPipeline
         static void QueryReflection(GLuint program, GLenum shaderStage, ShaderReflection& reflection);
 
         // Queries all texture buffer names of the specified program and inserts them into the set.
-        static void QueryTexBufferNames(GLuint program, std::set<std::string>& samplerBufferNames, std::set<std::string>& imageBufferNames);
+        static void QueryTexBufferNames(GLuint program, set<string>& samplerBufferNames, set<string>& imageBufferNames);
 
     private:
 

--- a/sources/Renderer/OpenGL/Shader/GLShaderSourcePatcher.cpp
+++ b/sources/Renderer/OpenGL/Shader/GLShaderSourcePatcher.cpp
@@ -94,7 +94,7 @@ static std::size_t FindStartOfDirective(const char* source, std::size_t off)
             return off;
     }
     while (off-- > 0);
-    return std::string::npos;
+    return string::npos;
 }
 
 // Returns the source position after the '#version'-directive. This is always at the beginning of a new line.
@@ -134,20 +134,20 @@ static std::size_t FindEndOfVersionDirective(const char* source)
             ++s;
         }
     }
-    return std::string::npos;
+    return string::npos;
 }
 
 GLShaderSourcePatcher::GLShaderSourcePatcher(const char* source) :
     source_ { source }
 {
     const auto posAfterVersion = FindEndOfVersionDirective(source);
-    if (posAfterVersion != std::string::npos)
+    if (posAfterVersion != string::npos)
         statementInsertPos_ = posAfterVersion;
 }
 
-static std::string GenerateGlslVersionDirective(const char* version)
+static string GenerateGlslVersionDirective(const char* version)
 {
-    std::string s = "#version ";
+    string s = "#version ";
     s += version;
     s += '\n';
     return s;
@@ -157,11 +157,11 @@ void GLShaderSourcePatcher::OverrideVersion(const char* version)
 {
     /* First remove current '#version'-directive (in case new one must be at first source line) */
     const std::size_t startOfVersionDirective = FindStartOfDirective(source_.c_str(), statementInsertPos_);
-    if (startOfVersionDirective != std::string::npos)
+    if (startOfVersionDirective != string::npos)
         source_.erase(startOfVersionDirective, statementInsertPos_ - startOfVersionDirective);
 
     /* Generate new '#version'-directive */
-    const std::string newVersionDirective = GenerateGlslVersionDirective(version);
+    const string newVersionDirective = GenerateGlslVersionDirective(version);
     source_.insert(0, newVersionDirective);
 
     /* Replace old insertion point for statements after new directive */
@@ -173,7 +173,7 @@ void GLShaderSourcePatcher::AddDefines(const ShaderMacro* defines)
     if (defines != nullptr)
     {
         /* Generate macro definition code */
-        std::string defineCode;
+        string defineCode;
 
         for (; defines->name != nullptr; ++defines)
         {
@@ -197,7 +197,7 @@ void GLShaderSourcePatcher::AddPragmaDirective(const char* statement)
     if (statement != nullptr && *statement != '\0')
     {
         /* Generate '#pragma'-directive code and insert into source */
-        std::string pragmaCode = "#pragma ";
+        string pragmaCode = "#pragma ";
         pragmaCode += statement;
         pragmaCode += '\n';
         InsertAfterVersionDirective(pragmaCode);
@@ -206,7 +206,7 @@ void GLShaderSourcePatcher::AddPragmaDirective(const char* statement)
 
 struct SourceScanState
 {
-    std::string patched;
+    string patched;
     std::size_t codeBlockDepth          = 0;
     const char* head                    = nullptr;
     const char* lastPatched             = nullptr;
@@ -329,7 +329,7 @@ void GLShaderSourcePatcher::AddFinalVertexTransformStatements(const char* statem
  * ======= Private: =======
  */
 
-void GLShaderSourcePatcher::InsertAfterVersionDirective(const std::string& statement)
+void GLShaderSourcePatcher::InsertAfterVersionDirective(const string& statement)
 {
     /* Insert statement into source after version */
     source_.insert(statementInsertPos_, statement);
@@ -382,12 +382,12 @@ static std::size_t FindEntryPointSourceLocation(const char* source, std::size_t 
             ++s;
         }
     }
-    return std::string::npos;
+    return string::npos;
 }
 
 void GLShaderSourcePatcher::CacheEntryPointSourceLocation()
 {
-    if (entryPointStartPos_ == std::string::npos)
+    if (entryPointStartPos_ == string::npos)
         entryPointStartPos_ = FindEntryPointSourceLocation(GetSource(), statementInsertPos_);
 }
 
@@ -395,13 +395,13 @@ void GLShaderSourcePatcher::ResetInsertionPoints(std::size_t newStatementInsertP
 {
     if (newStatementInsertPos > statementInsertPos_)
     {
-        if (entryPointStartPos_ != std::string::npos)
+        if (entryPointStartPos_ != string::npos)
             entryPointStartPos_ += (newStatementInsertPos - statementInsertPos_);
         statementInsertPos_ = newStatementInsertPos;
     }
     else if (newStatementInsertPos < statementInsertPos_)
     {
-        if (entryPointStartPos_ != std::string::npos)
+        if (entryPointStartPos_ != string::npos)
             entryPointStartPos_ -= (statementInsertPos_ - newStatementInsertPos);
         statementInsertPos_ = newStatementInsertPos;
     }

--- a/sources/Renderer/OpenGL/Shader/GLShaderSourcePatcher.h
+++ b/sources/Renderer/OpenGL/Shader/GLShaderSourcePatcher.h
@@ -9,7 +9,7 @@
 #define LLGL_GL_SHADER_SOURCE_PATCHER_H
 
 
-#include <string>
+#include <LLGL/Container/String.h>
 
 
 namespace LLGL
@@ -52,7 +52,7 @@ class GLShaderSourcePatcher
     private:
 
         // Inserts the specified statement after the '#version'-directive and any previously inserted statement.
-        void InsertAfterVersionDirective(const std::string& statement);
+        void InsertAfterVersionDirective(const string& statement);
 
         // Finds and stores the source location of the entry point, i.e. points to the first character after of the entry point declaration "void main()".
         void CacheEntryPointSourceLocation();
@@ -62,9 +62,9 @@ class GLShaderSourcePatcher
 
     private:
 
-        std::string source_;
+        string source_;
         std::size_t statementInsertPos_ = 0;
-        std::size_t entryPointStartPos_ = std::string::npos;
+        std::size_t entryPointStartPos_ = string::npos;
 
 };
 

--- a/sources/Renderer/OpenGL/Texture/GLRenderTarget.h
+++ b/sources/Renderer/OpenGL/Texture/GLRenderTarget.h
@@ -15,7 +15,7 @@
 #include "GLRenderbuffer.h"
 #include "GLTexture.h"
 #include <functional>
-#include <vector>
+#include <LLGL/Container/Vector.h>
 #include <memory>
 
 
@@ -98,7 +98,7 @@ class GLRenderTarget final : public RenderTarget
         For WebGL, we maintain a list of resolve attachments to swap them in and out of GL_COLOR_ATTACHMENT0 binding point,
         since glDrawBuffers() behaves differently than in Desktop GL.
         */
-        std::vector<GLFramebufferAttachment>    resolveAttachments_;
+        vector<GLFramebufferAttachment>    resolveAttachments_;
         #endif
 
         /*
@@ -106,7 +106,7 @@ class GLRenderTarget final : public RenderTarget
         Otherwise we would need multi-sampled textures (e.g. "glTexImage2DMultisample")
         which is only supported since OpenGL 3.2+, but renderbuffers are supported since OpenGL 3.0+.
         */
-        std::vector<GLRenderbuffer>             renderbuffers_;
+        vector<GLRenderbuffer>             renderbuffers_;
 
         SmallVector<GLenum, 2>                  drawBuffers_;                       // Values for glDrawBuffers for the primary FBO
         SmallVector<GLenum, 2>                  drawBuffersResolve_;                // Values for glDrawBuffers for the resolve FBO

--- a/sources/Renderer/OpenGL/Texture/GLTexImage.cpp
+++ b/sources/Renderer/OpenGL/Texture/GLTexImage.cpp
@@ -21,27 +21,27 @@ namespace LLGL
 
 
 // Generates an image buffer with floating-points for RGBA components.
-static std::vector<ColorRGBAf> GenImageDataRGBAf(std::uint32_t numPixels, const float (&color)[4])
+static vector<ColorRGBAf> GenImageDataRGBAf(std::uint32_t numPixels, const float (&color)[4])
 {
-    return std::vector<ColorRGBAf>(static_cast<std::size_t>(numPixels), ColorRGBAf{ color[0], color[1], color[2], color[3] });
+    return vector<ColorRGBAf>(static_cast<std::size_t>(numPixels), ColorRGBAf{ color[0], color[1], color[2], color[3] });
 }
 
 // Generates an image buffer with floating-points for the Red component.
-static std::vector<float> GenImageDataRf(std::uint32_t numPixels, float value)
+static vector<float> GenImageDataRf(std::uint32_t numPixels, float value)
 {
-    return std::vector<float>(static_cast<std::size_t>(numPixels), value);
+    return vector<float>(static_cast<std::size_t>(numPixels), value);
 }
 
 // Generates an image buffer with floating-points for the Red component and unsigned bytes for the Green component.
-static std::vector<GLDepthStencilPair> GenImageDataD32fS8ui(std::uint32_t numPixels, float depth, std::uint8_t stencil)
+static vector<GLDepthStencilPair> GenImageDataD32fS8ui(std::uint32_t numPixels, float depth, std::uint8_t stencil)
 {
-    return std::vector<GLDepthStencilPair>(static_cast<std::size_t>(numPixels), GLDepthStencilPair{ depth, stencil });
+    return vector<GLDepthStencilPair>(static_cast<std::size_t>(numPixels), GLDepthStencilPair{ depth, stencil });
 }
 
 // Generates an image buffer with unsigned bytes for the stencil index.
-static std::vector<std::uint8_t> GenImageDataS8ui(std::uint32_t numPixels, std::uint8_t stencil)
+static vector<std::uint8_t> GenImageDataS8ui(std::uint32_t numPixels, std::uint8_t stencil)
 {
-    return std::vector<std::uint8_t>(static_cast<std::size_t>(numPixels), stencil);
+    return vector<std::uint8_t>(static_cast<std::size_t>(numPixels), stencil);
 }
 
 // Returns true if the specified hardware format requires an integer type, e.g. GL_RGBA_INTEGER
@@ -747,7 +747,7 @@ static void GLTexImageCube(const TextureDescriptor& desc, const ImageView* image
         Format internalFormat = FindSuitableDepthFormat(desc);
 
         #if !LLGL_GL_ENABLE_OPENGL2X
-        std::vector<GLDepthStencilPair> image;
+        vector<GLDepthStencilPair> image;
         const void* initialData = nullptr;
 
         if (IsClearValueEnabled(desc))
@@ -779,7 +779,7 @@ static void GLTexImageCube(const TextureDescriptor& desc, const ImageView* image
     {
         Format internalFormat = FindSuitableDepthFormat(desc);
 
-        std::vector<float> image;
+        vector<float> image;
         const void* initialData = nullptr;
 
         if (IsClearValueEnabled(desc))

--- a/sources/Renderer/OpenGL/Texture/GLTextureViewPool.h
+++ b/sources/Renderer/OpenGL/Texture/GLTextureViewPool.h
@@ -11,7 +11,7 @@
 
 #include <LLGL/TextureFlags.h>
 #include <cstdint>
-#include <vector>
+#include <LLGL/Container/Vector.h>
 #include "../OpenGL.h"
 #include "../../TextureUtils.h"
 
@@ -93,7 +93,7 @@ class GLTextureViewPool
     private:
 
         // Container of all managed texture views.
-        std::vector<GLTextureView>  textureViews_;
+        vector<GLTextureView>  textureViews_;
 
         // Number of textures that are already freed, but not removed from the texture view array yet.
         std::size_t                 numReusableEntries_ = 0;

--- a/sources/Renderer/RenderSystem.cpp
+++ b/sources/Renderer/RenderSystem.cpp
@@ -22,7 +22,7 @@
 
 #include <LLGL/RenderSystem.h>
 #include "RenderSystemRegistry.h"
-#include <string>
+#include <LLGL/Container/String.h>
 #include <unordered_map>
 
 #include "../Core/PrintfUtils.h"
@@ -48,7 +48,7 @@ namespace LLGL
 struct RenderSystem::Pimpl
 {
     int                     rendererID  = 0;
-    std::string             name;
+    string                  name;
     bool                    hasInfo     = false;
     RendererInfo            info;
     bool                    hasCaps     = false;
@@ -67,7 +67,7 @@ RenderSystem::~RenderSystem()
     delete pimpl_;
 }
 
-std::vector<std::string> RenderSystem::FindModules()
+vector<string> RenderSystem::FindModules()
 {
     #if LLGL_BUILD_STATIC_LIB
     return StaticModules::GetStaticModules();
@@ -231,7 +231,7 @@ Report& RenderSystem::GetMutableReport()
 
 void RenderSystem::Errorf(const char* format, ...)
 {
-    std::string report;
+    string report;
     LLGL_STRING_PRINTF(report, format);
     GetMutableReport().Reset(std::move(report), true);
 }

--- a/sources/Renderer/RenderSystemFlags.cpp
+++ b/sources/Renderer/RenderSystemFlags.cpp
@@ -15,7 +15,7 @@ namespace LLGL
 {
 
 
-static bool ReportValidationFailure(const ValidateRenderingCapsFunc& callback, const std::string& info, const std::string& attrib)
+static bool ReportValidationFailure(const ValidateRenderingCapsFunc& callback, const string& info, const string& attrib)
 {
     if (callback)
         return callback(info, attrib);
@@ -44,7 +44,7 @@ LLGL_EXPORT bool ValidateRenderingCaps(
         {
             bool continueValidation = ReportValidationFailure(
                 callback,
-                "shading language not supported: " + std::string(ToString(shaderLang)),
+                "shading language not supported: " + string(ToString(shaderLang)),
                 "shadingLanguages[" + std::to_string(i) + ']'
             );
             LLGL_CONTINUE_VALIDATION_IF(continueValidation);
@@ -59,7 +59,7 @@ LLGL_EXPORT bool ValidateRenderingCaps(
         {
             bool continueValidation = ReportValidationFailure(
                 callback,
-                "texture format not supported: " + std::string(ToString(texFormat)),
+                "texture format not supported: " + string(ToString(texFormat)),
                 "textureFormats[" + std::to_string(i) + ']'
             );
             LLGL_CONTINUE_VALIDATION_IF(continueValidation);

--- a/sources/Renderer/RenderSystemModule.cpp
+++ b/sources/Renderer/RenderSystemModule.cpp
@@ -18,7 +18,7 @@ namespace LLGL
 
 RenderSystemModule::RenderSystemModule(
     const char*                 name,
-    std::string&&               filename,
+    string&&                    filename,
     std::unique_ptr<Module>&&   module)
 :
     name_     { name                },
@@ -33,7 +33,7 @@ RenderSystemModule::RenderSystemModule(
     freeProc_       = reinterpret_cast< PFN_RENDERSYSTEM_FREE       >(module_->LoadProcedure("LLGL_RenderSystem_Free"      ));
 }
 
-std::vector<std::string> RenderSystemModule::FindModules()
+vector<string> RenderSystemModule::FindModules()
 {
     /* Iterate over all known modules (preferred modules first) and return those that are available on the current platform */
     constexpr const char* knownModules[] =
@@ -60,11 +60,11 @@ std::vector<std::string> RenderSystemModule::FindModules()
         "Null",
     };
 
-    std::vector<std::string> moduleNames;
+    vector<string> moduleNames;
 
     for (const char* name : knownModules)
     {
-        std::string moduleFilename = Module::GetModuleFilename(name);
+        string moduleFilename = Module::GetModuleFilename(name);
         if (Module::IsAvailable(moduleFilename.c_str()))
             moduleNames.push_back(name);
     }
@@ -75,7 +75,7 @@ std::vector<std::string> RenderSystemModule::FindModules()
 RenderSystemModulePtr RenderSystemModule::Load(const char* name, Report* outReport)
 {
     /* Load render system module */
-    std::string             moduleFilename = Module::GetModuleFilename(name);
+    string                  moduleFilename = Module::GetModuleFilename(name);
     std::unique_ptr<Module> module;
 
     #if LLGL_EXCEPTIONS_SUPPORTED

--- a/sources/Renderer/RenderSystemModule.h
+++ b/sources/Renderer/RenderSystemModule.h
@@ -11,8 +11,8 @@
 
 #include "../Platform/Module.h"
 #include <LLGL/RenderSystem.h>
-#include <vector>
-#include <string>
+#include <LLGL/Container/Vector.h>
+#include <LLGL/Container/String.h>
 #include <memory>
 
 
@@ -37,7 +37,7 @@ class RenderSystemModule
     public:
 
         // Returns a name list of available render system modules.
-        static std::vector<std::string> FindModules();
+        static vector<string> FindModules();
 
         // Loads the specified render system module. Returns null on failure.
         static RenderSystemModulePtr Load(const char* name, Report* outReport = nullptr);
@@ -49,13 +49,13 @@ class RenderSystemModule
         }
 
         // Returns the module name, e.g. "Direct3D12".
-        inline const std::string& GetName() const
+        inline const string& GetName() const
         {
             return name_;
         }
 
         // Returns the module filename, e.g. "LLGL_Direct3D12D.dll".
-        inline const std::string& GetFilename() const
+        inline const string& GetFilename() const
         {
             return filename_;
         }
@@ -90,14 +90,14 @@ class RenderSystemModule
 
         RenderSystemModule(
             const char*                 name,
-            std::string&&               filename,
+            string&&                    filename,
             std::unique_ptr<Module>&&   module
         );
 
     private:
 
-        std::string                 name_;
-        std::string                 filename_;
+        string                      name_;
+        string                      filename_;
         std::unique_ptr<Module>     module_;
         unsigned                    useCount_       = 0;
 

--- a/sources/Renderer/RenderSystemRegistry.h
+++ b/sources/Renderer/RenderSystemRegistry.h
@@ -11,7 +11,7 @@
 
 #include "RenderSystemModule.h"
 #include <LLGL/Container/SmallVector.h>
-#include <vector>
+#include <LLGL/Container/Vector.h>
 
 
 namespace LLGL
@@ -56,7 +56,7 @@ class RenderSystemRegistry
 
     private:
 
-        std::vector<RenderSystemModulePtr>  modules_;
+        vector<RenderSystemModulePtr>  modules_;
         SmallVector<RenderSystemEntry, 1>   renderSystemEntries_;
 
 };

--- a/sources/Renderer/RenderingDebugger.cpp
+++ b/sources/Renderer/RenderingDebugger.cpp
@@ -11,7 +11,7 @@
 #include <LLGL/Container/Strings.h>
 #include "../Core/StringUtils.h"
 #include "../Platform/Debug.h"
-#include <map>
+#include <LLGL/Container/Map.h>
 
 
 namespace LLGL
@@ -35,7 +35,7 @@ struct CompareStringLess
 };
 
 template <typename T>
-using UTF8StringMap = std::map<UTF8String, T, CompareStringLess>;
+using UTF8StringMap = map<UTF8String, T, CompareStringLess>;
 
 struct RenderingDebugger::Pimpl
 {
@@ -92,7 +92,7 @@ bool RenderingDebugger::GetBreakOnError() const
 void RenderingDebugger::Errorf(const ErrorType type, const char* format, ...)
 {
     /* Print formatted string */
-    std::string message;
+    string message;
     LLGL_STRING_PRINTF(message, format);
 
     /* Check if there is already an entry for the exact same message */
@@ -117,7 +117,7 @@ void RenderingDebugger::Errorf(const ErrorType type, const char* format, ...)
 void RenderingDebugger::Warningf(const WarningType type, const char* format, ...)
 {
     /* Print formatted string */
-    std::string message;
+    string message;
     LLGL_STRING_PRINTF(message, format);
 
     /* Check if there is already an entry for the exact same message */
@@ -156,13 +156,13 @@ void RenderingDebugger::RecordProfile(const FrameProfile& profile)
 
 void RenderingDebugger::PostError(const ErrorType type, const StringView& message)
 {
-    const std::string str(message.begin(), message.end());
+    const string str(message.begin(), message.end());
     Errorf(type, "%s", str.c_str());
 }
 
 void RenderingDebugger::PostWarning(const WarningType type, const StringView& message)
 {
-    const std::string str(message.begin(), message.end());
+    const string str(message.begin(), message.end());
     Warningf(type, "%s", str.c_str());
 }
 

--- a/sources/Renderer/ResourceUtils.h
+++ b/sources/Renderer/ResourceUtils.h
@@ -16,7 +16,7 @@
 #include <LLGL/PipelineLayoutFlags.h>
 #include <LLGL/Container/ArrayView.h>
 #include <LLGL/Container/DynamicVector.h>
-#include <string>
+#include <LLGL/Container/String.h>
 
 
 namespace LLGL

--- a/sources/Renderer/SegmentedBuffer.h
+++ b/sources/Renderer/SegmentedBuffer.h
@@ -13,7 +13,7 @@
 #include "../Core/CoreUtils.h"
 #include <LLGL/Utils/ForRange.h>
 #include <string.h>
-#include <vector>
+#include <LLGL/Container/Vector.h>
 #include <type_traits>
 #include <cstdint>
 #include <limits.h>
@@ -83,7 +83,7 @@ class SegmentedBufferAllocator
         SegmentedBufferAllocator& operator = (SegmentedBufferAllocator&&) = default;
 
         // Constructs the allocator with a buffer and segment size.
-        inline SegmentedBufferAllocator(std::vector<TBaseType>& buffer, std::size_t payloadSize) :
+        inline SegmentedBufferAllocator(vector<TBaseType>& buffer, std::size_t payloadSize) :
             buffer_ { buffer                                                                  },
             offset_ { buffer.size() * sizeof(TBaseType)                                       },
             size_   { GetAlignedSize(payloadSize + sizeof(TSegmentHeader), sizeof(TBaseType)) }
@@ -131,7 +131,7 @@ class SegmentedBufferAllocator
 
     private:
 
-        std::vector<TBaseType>& buffer_;
+        vector<TBaseType>& buffer_;
         std::size_t             offset_;
         std::size_t             size_;
 
@@ -234,7 +234,7 @@ class SegmentedBuffer
 
         std::size_t             stride_         = 0;
         std::size_t             payloadOffset_  = 0;
-        std::vector<value_type> buffer_;
+        vector<value_type> buffer_;
 
 };
 

--- a/sources/Renderer/StaticModuleInterface.cpp
+++ b/sources/Renderer/StaticModuleInterface.cpp
@@ -65,7 +65,7 @@ namespace StaticModules
 {
 
 
-std::vector<std::string> GetStaticModules()
+vector<string> GetStaticModules()
 {
     return
     {

--- a/sources/Renderer/StaticModuleInterface.h
+++ b/sources/Renderer/StaticModuleInterface.h
@@ -12,7 +12,7 @@
 
 
 #include <LLGL/RenderSystemFlags.h>
-#include <string>
+#include <LLGL/Container/String.h>
 
 
 namespace LLGL
@@ -25,7 +25,7 @@ namespace StaticModules
 
 
 // Returns the list of staticly compiled modules.
-std::vector<std::string> GetStaticModules();
+vector<string> GetStaticModules();
 
 // Returns the renderer name of the specified module (module name "Direct3D11" may result in "Direct3D 11" for instance).
 const char* GetRendererName(const StringLiteral& moduleName);

--- a/sources/Renderer/VideoAdapter.h
+++ b/sources/Renderer/VideoAdapter.h
@@ -13,7 +13,7 @@
 #include <LLGL/DisplayFlags.h>
 #include <LLGL/Container/UTF8String.h>
 #include "../Core/Vendor.h"
-#include <vector>
+#include <LLGL/Container/Vector.h>
 #include <cstdint>
 
 
@@ -25,7 +25,7 @@ namespace LLGL
 struct VideoAdapterOutputInfo
 {
     // List of all display modes for this video output.
-    std::vector<DisplayMode> displayModes;
+    vector<DisplayMode> displayModes;
 };
 
 // Simple structure with meta data about a video adapter.
@@ -34,7 +34,7 @@ struct VideoAdapterInfo
     UTF8String                          name;
     DeviceVendor                        vendor      = DeviceVendor::Undefined;
     std::uint64_t                       videoMemory = 0;
-    std::vector<VideoAdapterOutputInfo> outputs;
+    vector<VideoAdapterOutputInfo> outputs;
 };
 
 

--- a/tests/Test_Compute.cpp
+++ b/tests/Test_Compute.cpp
@@ -9,12 +9,12 @@
 #include <LLGL/Utils/Parse.h>
 #include <LLGL/Trap.h>
 #include <Gauss/Gauss.h>
-#include <vector>
+#include <LLGL/Container/Vector.h>
 
 // Fill an array list of 4D-vectors for testing purposes
-static std::vector<Gs::Vector4f> GetTestVector(std::size_t size)
+static vector<Gs::Vector4f> GetTestVector(std::size_t size)
 {
-    std::vector<Gs::Vector4f> vec(size);
+    vector<Gs::Vector4f> vec(size);
 
     for (unsigned int i = 0; i < size; ++i)
     {

--- a/tests/Test_D3D12.cpp
+++ b/tests/Test_D3D12.cpp
@@ -86,7 +86,7 @@ int main()
 
         auto& window = LLGL::CastTo<LLGL::Window>(swapChain->GetSurface());
 
-        auto title = "LLGL Test 3 ( " + std::string(renderer->GetName()) + " )";
+        auto title = "LLGL Test 3 ( " + string(renderer->GetName()) + " )";
         window.SetTitle(title);
         window.Show();
 

--- a/tests/Test_Image.cpp
+++ b/tests/Test_Image.cpp
@@ -15,7 +15,7 @@
 #include <stb/stb_image_write.h>
 
 
-LLGL::Image LoadImage(const std::string& filename, const LLGL::ImageFormat format = LLGL::ImageFormat::RGB)
+LLGL::Image LoadImage(const string& filename, const LLGL::ImageFormat format = LLGL::ImageFormat::RGB)
 {
     int requiredComp = static_cast<int>(LLGL::ImageFormatSize(format));
 
@@ -36,7 +36,7 @@ LLGL::Image LoadImage(const std::string& filename, const LLGL::ImageFormat forma
     return img;
 }
 
-void SaveImagePNG(const LLGL::Image& img, const std::string& filename, std::uint32_t slice = 0)
+void SaveImagePNG(const LLGL::Image& img, const string& filename, std::uint32_t slice = 0)
 {
     int         w       = static_cast<int>(img.GetExtent().width);
     int         h       = static_cast<int>(img.GetExtent().height);

--- a/tests/Test_OpenGL.cpp
+++ b/tests/Test_OpenGL.cpp
@@ -11,7 +11,7 @@
 #include <LLGL/Trap.h>
 #include <Gauss/Gauss.h>
 #include <memory>
-#include <string>
+#include <LLGL/Container/String.h>
 
 
 #define TEST_RENDER_TARGET      0
@@ -107,7 +107,7 @@ int main()
         //const auto& renderCaps = renderer->GetRenderingCaps();
 
         // Setup window title
-        window->SetTitle("LLGL OpenGL Test ( " + std::string(renderer->GetName()) + " )");
+        window->SetTitle("LLGL OpenGL Test ( " + string(renderer->GetName()) + " )");
 
         // Setup input controller
         LLGL::Input input{ *window };

--- a/tests/Test_Performance.cpp
+++ b/tests/Test_Performance.cpp
@@ -7,7 +7,7 @@
 
 #include <LLGL/LLGL.h>
 #include <LLGL/Utils/Image.h>
-#include <vector>
+#include <LLGL/Container/Vector.h>
 #include <functional>
 
 
@@ -64,7 +64,7 @@ class PerformanceTest
         LLGL::CommandBuffer*        commands        = nullptr;
 
         LLGL::QueryHeap*            timerQuery      = nullptr;
-        std::vector<LLGL::Texture*> textures;
+        vector<LLGL::Texture*> textures;
 
         TestConfig                  config;
 
@@ -108,7 +108,7 @@ class PerformanceTest
             LLGL::Log::Printf("\n");
         }
 
-        void MeasureTime(const std::string& title, const std::function<void()>& callback)
+        void MeasureTime(const string& title, const std::function<void()>& callback)
         {
             // Measure time with query
             commands->Begin();
@@ -154,7 +154,7 @@ class PerformanceTest
 
     public:
 
-        void Load(const std::string& rendererModule, const TestConfig& testConfig)
+        void Load(const string& rendererModule, const TestConfig& testConfig)
         {
             // Store test configuration
             config = testConfig;
@@ -211,7 +211,7 @@ int main(int argc, char* argv[])
 {
     LLGL::Log::RegisterCallbackStd();
 
-    std::string rendererModule = "OpenGL";
+    string rendererModule = "OpenGL";
 
     TestConfig testConfig;
     testConfig.numTextures  = 2;

--- a/tests/Test_SeparateShaders.cpp
+++ b/tests/Test_SeparateShaders.cpp
@@ -84,7 +84,7 @@ int main(int argc, char* argv[])
         auto layout = renderer->CreatePipelineLayout(LLGL::Parse("heap{cbuffer(Settings@0):vert:frag}"));
 
         // Shaders
-        auto CreateSeparateShader = [&renderer, &vertexFormat](LLGL::ShaderType type, std::string filename)
+        auto CreateSeparateShader = [&renderer, &vertexFormat](LLGL::ShaderType type, string filename)
         {
             filename = "Shaders/" + filename;
             auto shaderDesc = LLGL::ShaderDescFromFile(type, filename.c_str(), nullptr, nullptr, LLGL::ShaderCompileFlags::SeparateShader);

--- a/tests/Test_Window.cpp
+++ b/tests/Test_Window.cpp
@@ -7,7 +7,7 @@
 
 #include <LLGL/LLGL.h>
 #include <memory>
-#include <string>
+#include <LLGL/Container/String.h>
 
 
 static void printWindowSize(LLGL::Window& wnd)
@@ -63,7 +63,7 @@ int main()
             auto renderer = LLGL::RenderSystem::Load("OpenGL");
 
             window->SetTitle(
-                std::string(windowDesc.title.c_str()) + " ( " + std::string(renderer->GetName()) + " )"
+                string(windowDesc.title.c_str()) + " ( " + string(renderer->GetName()) + " )"
             );
         }
         catch (const std::exception& e)

--- a/tests/Testbed/TestbedContext.cpp
+++ b/tests/Testbed/TestbedContext.cpp
@@ -77,7 +77,7 @@ bool HasProgramArgument(int argc, char* argv[], const char* search, const char**
     return false;
 }
 
-static std::string FindOutputDir(int argc, char* argv[])
+static string FindOutputDir(int argc, char* argv[])
 {
     for (int i = 0; i < argc; ++i)
     {
@@ -87,9 +87,9 @@ static std::string FindOutputDir(int argc, char* argv[])
     return k_defaultOutputDir;
 }
 
-static std::vector<std::string> FindSelectedTests(int argc, char* argv[])
+static vector<string> FindSelectedTests(int argc, char* argv[])
 {
-    std::vector<std::string> selection;
+    vector<string> selection;
 
     // Gather all selected tests
     for (int i = 0; i < argc; ++i)
@@ -99,7 +99,7 @@ static std::vector<std::string> FindSelectedTests(int argc, char* argv[])
             const char* curr = argv[i] + 5;
             while (const char* next = ::strchr(curr, ','))
             {
-                selection.push_back(std::string(curr, next));
+                selection.push_back(string(curr, next));
                 curr = next + 1;
             }
             if (*curr != '\0')
@@ -114,7 +114,7 @@ static std::vector<std::string> FindSelectedTests(int argc, char* argv[])
     return selection;
 }
 
-static std::string SanitizePath(std::string path)
+static string SanitizePath(string path)
 {
     for (char& chr : path)
     {
@@ -126,7 +126,7 @@ static std::string SanitizePath(std::string path)
     return path;
 }
 
-static std::string GetSanitizedOutputDir(int argc, char* argv[])
+static string GetSanitizedOutputDir(int argc, char* argv[])
 {
     return SanitizePath(FindOutputDir(argc, argv));
 }
@@ -251,7 +251,7 @@ TestbedContext::TestbedContext(const char* moduleName, int version, int argc, ch
 TestbedContext::~TestbedContext()
 {
     // Write output report file if specified
-    const std::string reportFilename = opt.outputDir + moduleName + "/Report.txt";
+    const string reportFilename = opt.outputDir + moduleName + "/Report.txt";
     std::ofstream reportFile{ reportFilename };
     if (reportFile.good())
         reportFile.write(report_.GetText(), ::strlen(report_.GetText()));
@@ -275,9 +275,9 @@ static const char* TestResultToStr(TestResult result)
 
 void TestbedContext::PrintSeparator()
 {
-    constexpr char              separatorChar   = '=';
-    constexpr std::size_t       separatorLen    = 80;
-    static const std::string    separatorLine(separatorLen, separatorChar);
+    constexpr char         separatorChar   = '=';
+    constexpr std::size_t  separatorLen    = 80;
+    static const string    separatorLine(separatorLen, separatorChar);
     Log::Printf("%s\n", separatorLine.c_str());
 }
 
@@ -316,11 +316,11 @@ static void PrintTestResult(TestResult result, const char* name, bool highlighte
     ::fflush(stdout);
 }
 
-static void PrintUnknownTests(const std::vector<std::string>& selectedTests, const std::vector<const char*>& knownTests)
+static void PrintUnknownTests(const vector<string>& selectedTests, const vector<const char*>& knownTests)
 {
     // Gather unknown test names
-    std::vector<std::string> unknownTests;
-    for (const std::string& name : selectedTests)
+    vector<string> unknownTests;
+    for (const string& name : selectedTests)
     {
         if (std::find_if(knownTests.begin(), knownTests.end(), [&name](const char* s) -> bool { return (name == s); }) == knownTests.end())
             unknownTests.push_back(name);
@@ -329,8 +329,8 @@ static void PrintUnknownTests(const std::vector<std::string>& selectedTests, con
     // Print unknown test names
     if (!unknownTests.empty())
     {
-        std::string unknownTestsStr;
-        for (const std::string& name : unknownTests)
+        string unknownTestsStr;
+        for (const string& name : unknownTests)
         {
             if (!unknownTestsStr.empty())
                 unknownTestsStr += ", ";
@@ -445,7 +445,7 @@ unsigned TestbedContext::RunRendererIndependentTests(int argc, char* argv[])
     // Check if there were any unknown tests selected
     if (!opt.selectedTests.empty())
     {
-        std::vector<const char*> knownTests;
+        vector<const char*> knownTests;
         #define GATHER_KNOWN_TESTS
         #include "UnitTests/DeclTests.inl"
         #undef GATHER_KNOWN_TESTS
@@ -848,9 +848,9 @@ bool TestbedContext::HasUniqueBindingSlots() const
     return (renderer->GetRendererID() == RendererID::Vulkan);
 }
 
-static std::string FormatCharArray(const unsigned char* data, std::size_t count, std::size_t bytesPerGroup, std::size_t maxWidth)
+static string FormatCharArray(const unsigned char* data, std::size_t count, std::size_t bytesPerGroup, std::size_t maxWidth)
 {
-    std::string s;
+    string s;
     s.reserve(count * 3);
 
     char formatted[3] = {};
@@ -875,9 +875,9 @@ static std::string FormatCharArray(const unsigned char* data, std::size_t count,
     return s;
 }
 
-static std::string FormatFloatArray(const float* data, std::size_t count, std::size_t maxWidth)
+static string FormatFloatArray(const float* data, std::size_t count, std::size_t maxWidth)
 {
-    std::string s;
+    string s;
     s.reserve(count * 5);
 
     char formatted[16] = {};
@@ -917,7 +917,7 @@ TestbedContext::Options TestbedContext::ParseOptions(int argc, char* argv[])
     return opt;
 }
 
-std::string TestbedContext::FormatByteArray(const void* data, std::size_t size, std::size_t bytesPerGroup, bool formatAsFloats)
+string TestbedContext::FormatByteArray(const void* data, std::size_t size, std::size_t bytesPerGroup, bool formatAsFloats)
 {
     constexpr std::size_t maxWidth = 80;
     if (formatAsFloats)
@@ -1133,7 +1133,7 @@ void TestbedContext::CreatePipelineLayouts()
 
 bool TestbedContext::LoadTextures()
 {
-    auto LoadTextureFromFile = [this](const char* name, const std::string& filename) -> Texture*
+    auto LoadTextureFromFile = [this](const char* name, const string& filename) -> Texture*
     {
         auto PrintLoadingInfo = [&filename]()
         {
@@ -1180,7 +1180,7 @@ bool TestbedContext::LoadTextures()
         return tex;
     };
 
-    const std::string texturePath = "../Media/Textures/";
+    const string texturePath = "../Media/Textures/";
 
     textures[TextureGrid10x10]      = LoadTextureFromFile("Grid10x10", texturePath + "Grid10x10.png");
     textures[TextureGradient]       = LoadTextureFromFile("Gradient", texturePath + "Gradient.png");
@@ -1330,7 +1330,7 @@ void TestbedContext::CreateModelRect(IndexedTriangleMeshBuffer& scene, IndexedTr
     scene.FinalizeMesh(outMesh);
 }
 
-void TestbedContext::ConvertToColoredVertexList(const IndexedTriangleMeshBuffer& scene, std::vector<ColoredVertex>& outVertices, const LLGL::ColorRGBAf& color)
+void TestbedContext::ConvertToColoredVertexList(const IndexedTriangleMeshBuffer& scene, vector<ColoredVertex>& outVertices, const LLGL::ColorRGBAf& color)
 {
     outVertices.reserve(scene.indices.size());
 
@@ -1369,7 +1369,7 @@ void TestbedContext::CreateConstantBuffers()
 }
 
 Shader* TestbedContext::LoadShaderFromFile(
-    const std::string&  filename,
+    const string&  filename,
     ShaderType          type,
     const char*         entry,
     const char*         profile,
@@ -1377,7 +1377,7 @@ Shader* TestbedContext::LoadShaderFromFile(
     VertFmt             vertFmt,
     VertFmt             vertOutFmt)
 {
-    auto StringEndsWith = [](const std::string& str, const std::string& suffix) -> bool
+    auto StringEndsWith = [](const string& str, const string& suffix) -> bool
     {
         return (str.size() >= suffix.size() && str.compare(str.size() - suffix.size(), suffix.size(), suffix.c_str()) == 0);
     };
@@ -1393,12 +1393,12 @@ Shader* TestbedContext::LoadShaderFromFile(
         PrintLoadingInfo();
 
     // Resolve file path
-    const std::string shaderRootDir = "Shaders/";
+    const string shaderRootDir = "Shaders/";
 
-    std::string filePath = shaderRootDir;
+    string filePath = shaderRootDir;
 
-    std::string::size_type filePartEnd = filename.find('.');
-    filePath += (filePartEnd != std::string::npos ? filename.substr(0, filePartEnd) : filename);
+    string::size_type filePartEnd = filename.find('.');
+    filePath += (filePartEnd != string::npos ? filename.substr(0, filePartEnd) : filename);
     filePath += '/';
     filePath += filename;
 
@@ -1441,7 +1441,7 @@ Shader* TestbedContext::LoadShaderFromFile(
     return shader;
 };
 
-static bool SaveImage(const void* pixels, int comp, const Extent2D& extent, const std::string& filename, bool verbose)
+static bool SaveImage(const void* pixels, int comp, const Extent2D& extent, const string& filename, bool verbose)
 {
     auto PrintInfo = [&filename]
     {
@@ -1466,22 +1466,22 @@ static bool SaveImage(const void* pixels, int comp, const Extent2D& extent, cons
     return (result != 0);
 }
 
-static bool SaveImage(const std::vector<ColorRGBub>& pixels, const Extent2D& extent, const std::string& filename, bool verbose = false)
+static bool SaveImage(const vector<ColorRGBub>& pixels, const Extent2D& extent, const string& filename, bool verbose = false)
 {
     return SaveImage(pixels.data(), 3, extent, filename, verbose);
 }
 
-static bool SaveImage(const std::vector<ColorRGBAub>& pixels, const Extent2D& extent, const std::string& filename, bool verbose = false)
+static bool SaveImage(const vector<ColorRGBAub>& pixels, const Extent2D& extent, const string& filename, bool verbose = false)
 {
     return SaveImage(pixels.data(), 4, extent, filename, verbose);
 }
 
-void PrintLoadImageInfo(const std::string& filename)
+void PrintLoadImageInfo(const string& filename)
 {
     Log::Printf("Load PNG image: %s", filename.c_str());
 };
 
-static bool LoadImage(std::vector<ColorRGBub>& pixels, Extent2D& extent, const std::string& filename, bool verbose = false)
+static bool LoadImage(vector<ColorRGBub>& pixels, Extent2D& extent, const string& filename, bool verbose = false)
 {
     if (verbose)
         PrintLoadImageInfo(filename);
@@ -1509,7 +1509,7 @@ static bool LoadImage(std::vector<ColorRGBub>& pixels, Extent2D& extent, const s
     return true;
 }
 
-static bool LoadImage(Image& img, const std::string& filename, bool verbose = false)
+static bool LoadImage(Image& img, const string& filename, bool verbose = false)
 {
     if (verbose)
         PrintLoadImageInfo(filename);
@@ -1547,14 +1547,14 @@ static bool LoadImage(Image& img, const std::string& filename, bool verbose = fa
     return true;
 }
 
-Image TestbedContext::LoadImageFromFile(const std::string& filename, bool verbose)
+Image TestbedContext::LoadImageFromFile(const string& filename, bool verbose)
 {
     Image img;
     LoadImage(img, filename, verbose);
     return img;
 }
 
-void TestbedContext::SaveImageToFile(const LLGL::Image& img, const std::string& filename, bool verbose)
+void TestbedContext::SaveImageToFile(const LLGL::Image& img, const string& filename, bool verbose)
 {
     SaveImage(
         img.GetData(),
@@ -1576,20 +1576,20 @@ bool TestbedContext::IsRGBA8ubInThreshold(const std::uint8_t lhs[4], const std::
     );
 }
 
-void TestbedContext::SaveColorImage(const std::vector<ColorRGBub>& image, const LLGL::Extent2D& extent, const std::string& name)
+void TestbedContext::SaveColorImage(const vector<ColorRGBub>& image, const LLGL::Extent2D& extent, const string& name)
 {
-    const std::string path = opt.outputDir + moduleName + "/";
+    const string path = opt.outputDir + moduleName + "/";
     SaveImage(image, extent, path + name + ".Result.png", opt.verbose);
 }
 
-void TestbedContext::SaveDepthImage(const std::vector<float>& image, const Extent2D& extent, const std::string& filename)
+void TestbedContext::SaveDepthImage(const vector<float>& image, const Extent2D& extent, const string& filename)
 {
     SaveDepthImage(image, extent, filename, 0.1f, 100.0f);
 }
 
-void TestbedContext::SaveDepthImage(const std::vector<float>& image, const LLGL::Extent2D& extent, const std::string& name, float nearPlane, float farPlane)
+void TestbedContext::SaveDepthImage(const vector<float>& image, const LLGL::Extent2D& extent, const string& name, float nearPlane, float farPlane)
 {
-    std::vector<ColorRGBub> colors;
+    vector<ColorRGBub> colors;
     colors.resize(image.size());
 
     const bool remapDepthValues     = true;
@@ -1625,19 +1625,19 @@ void TestbedContext::SaveDepthImage(const std::vector<float>& image, const LLGL:
         colors[i] = ColorRGBub{ color };
     }
 
-    const std::string path = opt.outputDir + moduleName + "/";
+    const string path = opt.outputDir + moduleName + "/";
     SaveImage(colors, extent, path + name + ".Result.png", opt.verbose);
 }
 
-void TestbedContext::SaveStencilImage(const std::vector<std::uint8_t>& image, const LLGL::Extent2D& extent, const std::string& name)
+void TestbedContext::SaveStencilImage(const vector<std::uint8_t>& image, const LLGL::Extent2D& extent, const string& name)
 {
-    std::vector<ColorRGBub> colors;
+    vector<ColorRGBub> colors;
     colors.resize(image.size());
 
     for (std::size_t i = 0; i < image.size(); ++i)
         colors[i] = ColorRGBub{ image[i] };
 
-    const std::string path = opt.outputDir + moduleName + "/";
+    const string path = opt.outputDir + moduleName + "/";
     SaveImage(colors, extent, path + name + ".Result.png", opt.verbose);
 }
 
@@ -1663,7 +1663,7 @@ LLGL::Texture* TestbedContext::CaptureFramebuffer(LLGL::CommandBuffer& cmdBuffer
     return capture;
 }
 
-void TestbedContext::SaveCapture(LLGL::Texture* capture, const std::string& name, bool writeStencilOnly)
+void TestbedContext::SaveCapture(LLGL::Texture* capture, const string& name, bool writeStencilOnly)
 {
     if (capture != nullptr)
     {
@@ -1676,7 +1676,7 @@ void TestbedContext::SaveCapture(LLGL::Texture* capture, const std::string& name
             if (writeStencilOnly)
             {
                 // Readback framebuffer stencil indices
-                std::vector<std::uint8_t> stencilData;
+                vector<std::uint8_t> stencilData;
                 stencilData.resize(extent.width * extent.height);
 
                 MutableImageView dstImageView;
@@ -1693,7 +1693,7 @@ void TestbedContext::SaveCapture(LLGL::Texture* capture, const std::string& name
             else
             {
                 // Readback framebuffer depth components
-                std::vector<float> depthData;
+                vector<float> depthData;
                 depthData.resize(extent.width * extent.height);
 
                 MutableImageView dstImageView;
@@ -1711,7 +1711,7 @@ void TestbedContext::SaveCapture(LLGL::Texture* capture, const std::string& name
         else
         {
             // Readback framebuffer color
-            std::vector<ColorRGBub> colorData;
+            vector<ColorRGBub> colorData;
             colorData.resize(extent.width * extent.height);
 
             MutableImageView dstImageView;
@@ -1746,16 +1746,16 @@ static ColorRGBub GetHeatMapColor(int diff, int scale = 1)
     return ColorRGBub{ heapMapLUT[diff*3], heapMapLUT[diff*3+1], heapMapLUT[diff*3+2] };
 }
 
-TestbedContext::DiffResult TestbedContext::DiffImages(const std::string& name, int threshold, unsigned tolerance, int scale)
+TestbedContext::DiffResult TestbedContext::DiffImages(const string& name, int threshold, unsigned tolerance, int scale)
 {
     // Load input images and validate they have the same dimensions
-    std::vector<ColorRGBub> pixelsA, pixelsB;
-    std::vector<ColorRGBAub> pixelsDiff;
+    vector<ColorRGBub> pixelsA, pixelsB;
+    vector<ColorRGBAub> pixelsDiff;
     Extent2D extentA, extentB;
 
-    const std::string resultPath    = opt.outputDir + moduleName + "/";
-    const std::string refPath       = "Reference/";
-    const std::string diffPath      = opt.outputDir + moduleName + "/";
+    const string resultPath    = opt.outputDir + moduleName + "/";
+    const string refPath       = "Reference/";
+    const string diffPath      = opt.outputDir + moduleName + "/";
 
     if (!LoadImage(pixelsA, extentA, refPath + name + ".Ref.png", opt.verbose))
         return DiffErrorLoadRefFailed;
@@ -1906,15 +1906,15 @@ void TestbedContext::Histogram::Print(unsigned rows) const
 
     const unsigned minCount = std::max(1u, maxCount / rows);
 
-    const std::string minCountStr = std::to_string(minCount);
-    const std::string maxCountStr = std::to_string(maxCount);
-    const std::string blankCountStr = std::string(maxCountStr.size(), ' ');
+    const string minCountStr = std::to_string(minCount);
+    const string maxCountStr = std::to_string(maxCount);
+    const string blankCountStr = string(maxCountStr.size(), ' ');
 
     const char* indent = "  ";
-    const std::string caption = "Histogram:";
+    const string caption = "Histogram:";
     const std::size_t captionPos = (caption.size() < rangeSize ? rangeSize - caption.size() : 0)/2;
 
-    Log::Printf("%s%s%s\n", indent, std::string(captionPos + blankCountStr.size() + 3, ' ').c_str(), caption.c_str());
+    Log::Printf("%s%s%s\n", indent, string(captionPos + blankCountStr.size() + 3, ' ').c_str(), caption.c_str());
 
     // Print each row of histogram
     for_range(y, rows)
@@ -1924,7 +1924,7 @@ void TestbedContext::Histogram::Print(unsigned rows) const
         if (y == 0)
             Log::Printf("%s | ", maxCountStr.c_str());
         else if (y + 1 == rows)
-            Log::Printf("%s%s | ", std::string(maxCountStr.size() - minCountStr.size(), ' ').c_str(), minCountStr.c_str());
+            Log::Printf("%s%s | ", string(maxCountStr.size() - minCountStr.size(), ' ').c_str(), minCountStr.c_str());
         else
             Log::Printf("%s | ", blankCountStr.c_str());
 
@@ -1946,8 +1946,8 @@ void TestbedContext::Histogram::Print(unsigned rows) const
 
     // Print diff ranges
     static_assert(rangeSize > 3, "Histogram::rangeSize must be greater than 3");
-    Log::Printf("%s%s --%s\n", indent, blankCountStr.c_str(), std::string(rangeSize, '-').c_str());
-    Log::Printf("%s%s   1%sFF\n", indent, blankCountStr.c_str(), std::string(rangeSize - 3, ' ').c_str());
+    Log::Printf("%s%s --%s\n", indent, blankCountStr.c_str(), string(rangeSize, '-').c_str());
+    Log::Printf("%s%s   1%sFF\n", indent, blankCountStr.c_str(), string(rangeSize - 3, ' ').c_str());
 }
 
 

--- a/tests/Testbed/TestbedContext.h
+++ b/tests/Testbed/TestbedContext.h
@@ -16,7 +16,7 @@
 #include <LLGL/Utils/Image.h>
 #include <Gauss/Matrix.h>
 #include <Gauss/Vector4.h>
-#include <vector>
+#include <LLGL/Container/Vector.h>
 #include <functional>
 #include <initializer_list>
 
@@ -214,7 +214,7 @@ class TestbedContext
 
         struct Options
         {
-            std::string                 outputDir;
+            string                      outputDir;
             bool                        verbose     = false;
             bool                        pedantic    = false; // Ignore thresholds, always compare strictly against reference values
             bool                        greedy      = false; // Continue testing on failure
@@ -222,7 +222,7 @@ class TestbedContext
             bool                        showTiming  = false;
             bool                        fastTest    = false; // Skip slow buffer/texture creations to speed up test run
             LLGL::Extent2D              resolution;
-            std::vector<std::string>    selectedTests;
+            vector<string>              selectedTests;
 
             bool ContainsTest(const char* name) const;
         };
@@ -255,8 +255,8 @@ class TestbedContext
 
         struct IndexedTriangleMeshBuffer
         {
-            std::vector<StandardVertex> vertices;
-            std::vector<std::uint32_t>  indices;
+            vector<StandardVertex> vertices;
+            vector<std::uint32_t>  indices;
             std::uint32_t               firstVertex = 0;
             std::uint32_t               firstIndex  = 0;
 
@@ -316,7 +316,7 @@ class TestbedContext
 
     protected:
 
-        const std::string               moduleName;
+        const string                    moduleName;
         const Options                   opt;
         const LLGL::ClearValue          bgColorDarkBlue         = { 0.2f, 0.2f, 0.4f, 1.0f };
         const LLGL::ClearValue          bgColorLightBlue        = { 127.0f/255.0f, 127.0f/255.0f, 1.0f, 1.0f };
@@ -350,12 +350,12 @@ class TestbedContext
 
         static Options ParseOptions(int argc, char* argv[]);
 
-        static std::string FormatByteArray(const void* data, std::size_t size, std::size_t bytesPerGroup = 1, bool formatAsFloats = false);
+        static string FormatByteArray(const void* data, std::size_t size, std::size_t bytesPerGroup = 1, bool formatAsFloats = false);
 
         static double ToMillisecs(std::uint64_t t0, std::uint64_t t1);
 
-        static LLGL::Image LoadImageFromFile(const std::string& filename, bool verbose = false);
-        static void SaveImageToFile(const LLGL::Image& img, const std::string& filename, bool verbose = false);
+        static LLGL::Image LoadImageFromFile(const string& filename, bool verbose = false);
+        static void SaveImageToFile(const LLGL::Image& img, const string& filename, bool verbose = false);
 
         static bool IsRGBA8ubInThreshold(const std::uint8_t lhs[4], const std::uint8_t rhs[4], int threshold = 1);
 
@@ -375,12 +375,12 @@ class TestbedContext
         void CreateModelCube(IndexedTriangleMeshBuffer& scene, IndexedTriangleMesh& outMesh);
         void CreateModelRect(IndexedTriangleMeshBuffer& scene, IndexedTriangleMesh& outMesh);
 
-        void ConvertToColoredVertexList(const IndexedTriangleMeshBuffer& scene, std::vector<ColoredVertex>& outVertices, const LLGL::ColorRGBAf& color = {});
+        void ConvertToColoredVertexList(const IndexedTriangleMeshBuffer& scene, vector<ColoredVertex>& outVertices, const LLGL::ColorRGBAf& color = {});
 
         void CreateConstantBuffers();
 
         LLGL::Shader* LoadShaderFromFile(
-            const std::string&          filename,
+            const string&               filename,
             LLGL::ShaderType            type,
             const char*                 entry       = nullptr,
             const char*                 profile     = nullptr,
@@ -389,16 +389,16 @@ class TestbedContext
             VertFmt                     vertOutFmt  = VertFmtCount
         );
 
-        void SaveColorImage(const std::vector<LLGL::ColorRGBub>& image, const LLGL::Extent2D& extent, const std::string& name);
-        void SaveDepthImage(const std::vector<float>& image, const LLGL::Extent2D& extent, const std::string& name);
-        void SaveDepthImage(const std::vector<float>& image, const LLGL::Extent2D& extent, const std::string& name, float nearPlane, float farPlane);
-        void SaveStencilImage(const std::vector<std::uint8_t>& image, const LLGL::Extent2D& extent, const std::string& name);
+        void SaveColorImage(const vector<LLGL::ColorRGBub>& image, const LLGL::Extent2D& extent, const string& name);
+        void SaveDepthImage(const vector<float>& image, const LLGL::Extent2D& extent, const string& name);
+        void SaveDepthImage(const vector<float>& image, const LLGL::Extent2D& extent, const string& name, float nearPlane, float farPlane);
+        void SaveStencilImage(const vector<std::uint8_t>& image, const LLGL::Extent2D& extent, const string& name);
 
         LLGL::Texture* CaptureFramebuffer(LLGL::CommandBuffer& cmdBuffer, LLGL::Format format, const LLGL::Extent2D& extent);
-        void SaveCapture(LLGL::Texture* capture, const std::string& name, bool writeStencilOnly = false);
+        void SaveCapture(LLGL::Texture* capture, const string& name, bool writeStencilOnly = false);
 
         // Creates a heat-map image from the two input filenames and returns the highest difference pixel value. A negative value indicates an error.
-        DiffResult DiffImages(const std::string& name, int threshold = 1, unsigned tolerance = 0, int scale = 1);
+        DiffResult DiffImages(const string& name, int threshold = 1, unsigned tolerance = 0, int scale = 1);
 
         void RecordTestResult(TestResult result, const char* name);
 

--- a/tests/Testbed/TestbedMain.cpp
+++ b/tests/Testbed/TestbedMain.cpp
@@ -6,7 +6,7 @@
  */
 
 #include "TestbedContext.h"
-#include <string>
+#include <LLGL/Container/String.h>
 #include <regex>
 #include <exception>
 #include <stdio.h>
@@ -47,7 +47,7 @@ static unsigned RunTestbedForRenderer(const char* moduleName, int version, int a
 
 struct ModuleAndVersion
 {
-    std::string name;
+    string name;
     int         version;
 
     ModuleAndVersion(const char* name, int version = 0) :
@@ -56,14 +56,14 @@ struct ModuleAndVersion
     {
     }
 
-    ModuleAndVersion(const std::string& name, int version = 0) :
+    ModuleAndVersion(const string& name, int version = 0) :
         name    { name    },
         version { version }
     {
     }
 };
 
-static ModuleAndVersion GetRendererModule(const std::string& name)
+static ModuleAndVersion GetRendererModule(const string& name)
 {
     if (name == "gl" || name == "opengl")
         return "OpenGL";
@@ -88,13 +88,13 @@ static void PrintHelpDocs()
 {
     // Find available modules
     auto availableModules = RenderSystem::FindModules();
-    std::string availableModulesStr;
+    string availableModulesStr;
 
     auto ListModuleIfAvailable = [&availableModules, &availableModulesStr](const char* name, const char* docu) -> void
     {
         auto it = std::find_if(
             availableModules.begin(), availableModules.end(),
-            [name](const std::string& entry) -> bool
+            [name](const string& entry) -> bool
             {
                 return (entry.compare(name) == 0);
             }
@@ -165,7 +165,7 @@ static int GuardedMain(int argc, char* argv[])
     }
 
     // Gather all explicitly specified module names
-    std::vector<ModuleAndVersion> enabledModules;
+    vector<ModuleAndVersion> enabledModules;
     for (int i = 1; i < argc; ++i)
     {
         if (argv[i][0] != '-')
@@ -174,9 +174,9 @@ static int GuardedMain(int argc, char* argv[])
 
     if (enabledModules.empty())
     {
-        std::vector<std::string> availableModules = RenderSystem::FindModules();
+        vector<string> availableModules = RenderSystem::FindModules();
         enabledModules.reserve(availableModules.size());
-        for (const std::string& module : availableModules)
+        for (const string& module : availableModules)
             enabledModules.push_back(module);
     }
 

--- a/tests/Testbed/TestbedUtils.cpp
+++ b/tests/Testbed/TestbedUtils.cpp
@@ -19,7 +19,7 @@ bool StringEndsWith(const char* str, const char* end)
     return StringEndsWithPrimary(str, ::strlen(str), end, ::strlen(end));
 }
 
-bool StringEndsWith(const std::string& str, const std::string& end)
+bool StringEndsWith(const string& str, const string& end)
 {
     return StringEndsWithPrimary(str.c_str(), str.size(), end.c_str(), end.size());
 }

--- a/tests/Testbed/TestbedUtils.h
+++ b/tests/Testbed/TestbedUtils.h
@@ -9,12 +9,12 @@
 #define LLGL_TESTBED_UTILS_H
 
 
-#include <string>
+#include <LLGL/Container/String.h>
 
 
 // Returns true if the specified string ends with the specified ending.
 bool StringEndsWith(const char* str, const char* end);
-bool StringEndsWith(const std::string& str, const std::string& end);
+bool StringEndsWith(const string& str, const string& end);
 
 
 #endif

--- a/tests/Testbed/Testset.cpp
+++ b/tests/Testbed/Testset.cpp
@@ -92,9 +92,9 @@ static std::uint8_t RandomUint8()
     return static_cast<std::uint8_t>(::rand() % 256);
 }
 
-std::vector<LLGL::ColorRGBAub> GenerateColorsRgbaUb(std::size_t count)
+vector<LLGL::ColorRGBAub> GenerateColorsRgbaUb(std::size_t count)
 {
-    std::vector<LLGL::ColorRGBAub> colors;
+    vector<LLGL::ColorRGBAub> colors;
     colors.resize(count);
     for_range(i, count)
     {
@@ -111,9 +111,9 @@ static float RandomFloat32()
     return (static_cast<float>(::rand()) / static_cast<float>(RAND_MAX));
 }
 
-std::vector<float> GenerateFloats(std::size_t count)
+vector<float> GenerateFloats(std::size_t count)
 {
-    std::vector<float> colors;
+    vector<float> colors;
     count *= 2;
     colors.resize(count);
     for_range(i, count)

--- a/tests/Testbed/Testset.h
+++ b/tests/Testbed/Testset.h
@@ -12,7 +12,7 @@
 #include <LLGL/Container/ArrayView.h>
 #include <LLGL/Utils/ColorRGBA.h>
 #include <LLGL/Utils/ColorRGB.h>
-#include <vector>
+#include <LLGL/Container/Vector.h>
 
 
 // Shifts the bits of the specified 32-bit integer to flip little-endian to big-endian and wise verse.
@@ -35,8 +35,8 @@ LLGL::ArrayView<LLGL::ColorRGBf> GetColorsRgbF4();
 LLGL::ArrayView<LLGL::ColorRGBf> GetColorsRgbF8();
 LLGL::ArrayView<float> GetColorsRgF8();
 
-std::vector<LLGL::ColorRGBAub> GenerateColorsRgbaUb(std::size_t count);
-std::vector<float> GenerateFloats(std::size_t count);
+vector<LLGL::ColorRGBAub> GenerateColorsRgbaUb(std::size_t count);
+vector<float> GenerateFloats(std::size_t count);
 
 
 } // /namespace Testset

--- a/tests/Testbed/UnitTests/TestBarrierReadAfterWrite.cpp
+++ b/tests/Testbed/UnitTests/TestBarrierReadAfterWrite.cpp
@@ -179,15 +179,15 @@ DEF_TEST( BarrierReadAfterWrite )
     // Read back results
     TestResult result = TestResult::Passed;
 
-    std::vector<std::uint32_t> expectedResults;
+    vector<std::uint32_t> expectedResults;
     expectedResults.resize((numIterations + 1)*(sizeof(Entry)/sizeof(std::uint32_t)), propagateValue);
 
     auto ValidatePropagatedValues = [this, &result, &expectedResults, frame](const char* name, const void* data, std::size_t dataSize) -> void
     {
         if (::memcmp(expectedResults.data(), data, dataSize) != 0)
         {
-            const std::string expectedValuesStr = FormatByteArray(expectedResults.data(), dataSize);
-            const std::string actualValuesStr = FormatByteArray(data, dataSize);
+            const string expectedValuesStr = FormatByteArray(expectedResults.data(), dataSize);
+            const string actualValuesStr = FormatByteArray(data, dataSize);
             Log::Errorf(
                 Log::ColorFlags::StdError,
                 "Mismatch between propagated values in %s and expected values [frame %u]:\n"
@@ -199,7 +199,7 @@ DEF_TEST( BarrierReadAfterWrite )
         }
         else if (opt.sanityCheck)
         {
-            const std::string actualValuesStr = FormatByteArray(data, dataSize);
+            const string actualValuesStr = FormatByteArray(data, dataSize);
             Log::Printf(
                 Log::ColorFlags::StdAnnotation,
                 "Propagated values in %s as expected [frame %u]:\n%s\n",
@@ -209,13 +209,13 @@ DEF_TEST( BarrierReadAfterWrite )
     };
 
     // Evaluate buffer results
-    std::vector<std::uint32_t> buf1Results;
+    vector<std::uint32_t> buf1Results;
     buf1Results.resize(numIterations + 1);
     const std::size_t buf1ResultsSize = buf1Results.size() * sizeof(buf1Results[0]);
     renderer->ReadBuffer(*buf1, 0, buf1Results.data(), buf1ResultsSize);
     ValidatePropagatedValues(buf1_Name, buf1Results.data(), buf1ResultsSize);
 
-    std::vector<Entry> buf2Results;
+    vector<Entry> buf2Results;
     buf2Results.resize(numIterations + 1);
     const std::size_t buf2ResultsSize = buf2Results.size() * sizeof(buf2Results[0]);
     renderer->ReadBuffer(*buf2, 0, buf2Results.data(), buf2ResultsSize);
@@ -224,7 +224,7 @@ DEF_TEST( BarrierReadAfterWrite )
     // Evaluate texture results
     const TextureRegion readbackTexRegion{ Offset3D{}, Extent3D{ numIterations + 1, 1, 1 } };
 
-    std::vector<std::uint32_t> tex1Results;
+    vector<std::uint32_t> tex1Results;
     tex1Results.resize(numIterations + 1);
     MutableImageView tex1ResultsView;
     {
@@ -236,7 +236,7 @@ DEF_TEST( BarrierReadAfterWrite )
     renderer->ReadTexture(*tex1, readbackTexRegion, tex1ResultsView);
     ValidatePropagatedValues(tex1_Name, tex1Results.data(), tex1ResultsView.dataSize);
 
-    std::vector<Entry> tex2Results;
+    vector<Entry> tex2Results;
     tex2Results.resize(numIterations + 1);
     MutableImageView tex2ResultsView;
     {

--- a/tests/Testbed/UnitTests/TestBufferToTextureCopy.cpp
+++ b/tests/Testbed/UnitTests/TestBufferToTextureCopy.cpp
@@ -71,7 +71,7 @@ DEF_TEST( BufferToTextureCopy )
         }
 
         // Create texture to copy from source buffer and to destination buffer
-        const std::string texName = std::string("interm.") + name;
+        const string texName = string("interm.") + name;
         TextureDescriptor texDesc;
         {
             texDesc.type        = type;
@@ -85,7 +85,7 @@ DEF_TEST( BufferToTextureCopy )
 
         // Create destination buffer to read back image data
         const char* nameWithoutTexPrefix = (::strncmp(name, "tex", 3) == 0 ? name + 3 : name);
-        const std::string dstBufName = std::string("dst.buf") + nameWithoutTexPrefix;
+        const string dstBufName = string("dst.buf") + nameWithoutTexPrefix;
         BufferDescriptor dstBufDesc;
         {
             dstBufDesc.size         = srcBufSize;
@@ -96,7 +96,7 @@ DEF_TEST( BufferToTextureCopy )
         // Run test through all MIP-maps and array layers (should not be more than 2 each)
         const std::uint32_t texDims = NumTextureDimensions(type);
 
-        std::vector<char> srcData, dstData;
+        vector<char> srcData, dstData;
         const bool formatAsFloats = IsFloatFormat(format);
 
         for_range(mip, mips)
@@ -120,7 +120,7 @@ DEF_TEST( BufferToTextureCopy )
                 // Copy source buffer to texture and back to destination buffer
                 cmdBuffer->Begin();
                 {
-                    const std::string debugGroup = std::string(name) + " (mip: " + std::to_string(mip) + ", layer: " + std::to_string(layer) + ")";
+                    const string debugGroup = string(name) + " (mip: " + std::to_string(mip) + ", layer: " + std::to_string(layer) + ")";
                     cmdBuffer->PushDebugGroup(debugGroup.c_str());
                     {
                         cmdBuffer->FillBuffer(*dstBuf, 0, FLIP_ENDIAN(0xDEADBEEF), srcBufSize);
@@ -140,8 +140,8 @@ DEF_TEST( BufferToTextureCopy )
 
                 if (::memcmp(srcData.data(), dstData.data(), srcBufSize) != 0)
                 {
-                    const std::string srcDataStr = TestbedContext::FormatByteArray(srcData.data(), srcData.size(), 4, formatAsFloats);
-                    const std::string dstDataStr = TestbedContext::FormatByteArray(dstData.data(), dstData.size(), 4, formatAsFloats);
+                    const string srcDataStr = TestbedContext::FormatByteArray(srcData.data(), srcData.size(), 4, formatAsFloats);
+                    const string dstDataStr = TestbedContext::FormatByteArray(dstData.data(), dstData.size(), 4, formatAsFloats);
                     Log::Errorf(
                         "Mismatch between data of texture %s [MIP %u, Layer %u] and copy result:\n"
                         " -> Expected: [%s]\n"
@@ -152,7 +152,7 @@ DEF_TEST( BufferToTextureCopy )
                 }
                 else if (opt.sanityCheck)
                 {
-                    const std::string dataStr = TestbedContext::FormatByteArray(srcData.data(), srcData.size(), 4, formatAsFloats);
+                    const string dataStr = TestbedContext::FormatByteArray(srcData.data(), srcData.size(), 4, formatAsFloats);
                     Log::Printf(
                         Log::ColorFlags::StdAnnotation,
                         "Sanity check for %s [MIP %u, Layer %u]:\n"

--- a/tests/Testbed/UnitTests/TestBufferUpdate.cpp
+++ b/tests/Testbed/UnitTests/TestBufferUpdate.cpp
@@ -95,7 +95,7 @@ DEF_TEST( BufferUpdate )
     }
     CREATE_BUFFER(buf4Large, buf4LargeDesc, "buf4Large", nullptr);
 
-    std::vector<std::uint32_t> buf4LargeData;
+    vector<std::uint32_t> buf4LargeData;
     buf4LargeData.resize(static_cast<std::size_t>(buf4LargeDesc.size) / sizeof(std::uint32_t), 0xF000BAAA); // Initialize with test value
 
     cmdBuffer->Begin();
@@ -105,7 +105,7 @@ DEF_TEST( BufferUpdate )
     cmdBuffer->End();
 
     // Read feedback data
-    std::vector<std::uint32_t> buf4LargeReadback;
+    vector<std::uint32_t> buf4LargeReadback;
     buf4LargeReadback.resize(buf4LargeData.size(), 0xDEADBEEF); // Initialize with different value
 
     renderer->ReadBuffer(*buf4Large, 0, buf4LargeReadback.data(), buf4LargeReadback.size() * sizeof(std::uint32_t));

--- a/tests/Testbed/UnitTests/TestCommandBufferMultiThreading.cpp
+++ b/tests/Testbed/UnitTests/TestCommandBufferMultiThreading.cpp
@@ -29,14 +29,14 @@ class ThreadOrderInfo
             threadIDList_ += std::to_string(threadID);
         }
 
-        std::string Flush()
+        string Flush()
         {
             return std::move(threadIDList_);
         }
 
     private:
 
-        std::string threadIDList_;
+        string threadIDList_;
         std::mutex  threadIDListMutex_;
 
 };
@@ -242,10 +242,10 @@ DEF_TEST( CommandBufferMultiThreading )
     // Print threading order info
     if (opt.showTiming)
     {
-        const std::string frameNo = (frame < 10 ? "Frame  " : "Frame ") + std::to_string(frame);
-        std::string enterOrder = threadEnterOrder.Flush();
+        const string frameNo = (frame < 10 ? "Frame  " : "Frame ") + std::to_string(frame);
+        string enterOrder = threadEnterOrder.Flush();
         Log::Printf("Thread enter order: [%s] %s (Encoding:   %.4f ms)\n", frameNo.c_str(), enterOrder.c_str(), encodingTime);
-        std::string exitOrder = threadExitOrder.Flush();
+        string exitOrder = threadExitOrder.Flush();
         Log::Printf("Thread exit order:  [%s] %s (Submission: %.4f ms)\n", frameNo.c_str(), exitOrder.c_str(), submissionTime);
     }
 
@@ -259,7 +259,7 @@ DEF_TEST( CommandBufferMultiThreading )
         Log::Printf("Average timing: Encoding ( %.4f ms ), Submission ( %.4f ms )\n", avgEncodingTime, avgSubmissionTime);
 
     // Read result from render target textures
-    std::vector<ColorRGBub> outputImage;
+    vector<ColorRGBub> outputImage;
     outputImage.resize(texSize.width * texSize.height);
 
     MutableImageView dstImageView;
@@ -281,7 +281,7 @@ DEF_TEST( CommandBufferMultiThreading )
 
         renderer->ReadTexture(*outputTextures[i], texRegion, dstImageView);
 
-        const std::string outputImageName = "MultiThreading_Worker" + std::to_string(i);
+        const string outputImageName = "MultiThreading_Worker" + std::to_string(i);
         SaveColorImage(outputImage, texSize, outputImageName);
 
         const DiffResult diff = DiffImages(outputImageName, diffThreshold);

--- a/tests/Testbed/UnitTests/TestCommandBufferSecondary.cpp
+++ b/tests/Testbed/UnitTests/TestCommandBufferSecondary.cpp
@@ -169,7 +169,7 @@ DEF_TEST( CommandBufferSecondary )
     cmdBuffer->End();
 
     // Read result from readback texture
-    std::vector<ColorRGBub> readbackImage;
+    vector<ColorRGBub> readbackImage;
     readbackImage.resize(resolution.width * resolution.height);
 
     MutableImageView dstImageView;
@@ -181,7 +181,7 @@ DEF_TEST( CommandBufferSecondary )
     }
     renderer->ReadTexture(*readbackTex, texRegion, dstImageView);
 
-    const std::string readbackImageName = "SecondaryCommandBuffer";
+    const string readbackImageName = "SecondaryCommandBuffer";
     SaveColorImage(readbackImage, resolution, readbackImageName);
 
     // Ignore single pixel differences because GL implementation of CIS server might produce slightyl different rasterization

--- a/tests/Testbed/UnitTests/TestContainers.cpp
+++ b/tests/Testbed/UnitTests/TestContainers.cpp
@@ -12,8 +12,8 @@
 #include <LLGL/Utils/ForRange.h>
 #include <locale>
 #include <codecvt> //TODO: replace this as it's deprecated in C++17
-#include <string>
-#include <vector>
+#include <LLGL/Container/String.h>
+#include <LLGL/Container/Vector.h>
 #include <initializer_list>
 #include <algorithm>
 
@@ -32,8 +32,8 @@ DEF_RITEST( ContainerDynamicArray )
         const std::size_t dataSize = arr.size();
         if (::memcmp(arr.data(), cmpData, dataSize) != 0)
         {
-            const std::string arrStr = TestbedContext::FormatByteArray(arr.data(), dataSize, sizeof(char));
-            const std::string cmpStr = TestbedContext::FormatByteArray(cmpData, dataSize, sizeof(char));
+            const string arrStr = TestbedContext::FormatByteArray(arr.data(), dataSize, sizeof(char));
+            const string cmpStr = TestbedContext::FormatByteArray(cmpData, dataSize, sizeof(char));
             Log::Errorf(
                 "Mismatch between DynamicByteArray '%s{%u}' [%s] and initial data [%s]\n",
                 name, static_cast<unsigned>(arr.size()), arrStr.c_str(), cmpStr.c_str()
@@ -64,8 +64,8 @@ DEF_RITEST( ContainerDynamicArray )
         const std::size_t dataSize = arr.size()*sizeof(int);
         if (::memcmp(arr.data(), cmpData, dataSize) != 0)
         {
-            const std::string arrStr = TestbedContext::FormatByteArray(arr.data(), dataSize, sizeof(int));
-            const std::string cmpStr = TestbedContext::FormatByteArray(cmpData, dataSize, sizeof(int));
+            const string arrStr = TestbedContext::FormatByteArray(arr.data(), dataSize, sizeof(int));
+            const string cmpStr = TestbedContext::FormatByteArray(cmpData, dataSize, sizeof(int));
             Log::Errorf(
                 "Mismatch between DynamicArray<int> '%s{%u}' [%s] and initial data [%s]\n",
                 name, static_cast<unsigned>(arr.size()), arrStr.c_str(), cmpStr.c_str()
@@ -109,8 +109,8 @@ DEF_RITEST( ContainerDynamicArray )
         const std::size_t dataSize = arr.size()*sizeof(int);
         if (::memcmp(arr.data(), cmpData, dataSize) != 0)
         {
-            const std::string arrStr = TestbedContext::FormatByteArray(arr.data(), dataSize, sizeof(TrivialStruct));
-            const std::string cmpStr = TestbedContext::FormatByteArray(cmpData, dataSize, sizeof(TrivialStruct));
+            const string arrStr = TestbedContext::FormatByteArray(arr.data(), dataSize, sizeof(TrivialStruct));
+            const string cmpStr = TestbedContext::FormatByteArray(cmpData, dataSize, sizeof(TrivialStruct));
             Log::Errorf(
                 "Mismatch between DynamicArray<TrivialStruct> '%s{%u}' [%s] and initial data [%s]\n",
                 name, static_cast<unsigned>(arr.size()), arrStr.c_str(), cmpStr.c_str()
@@ -144,8 +144,8 @@ DEF_RITEST( ContainerSmallVector )
     {
         if (::memcmp(vec, cmp, size) != 0)
         {
-            const std::string vecStr = TestbedContext::FormatByteArray(vec, size, 4);
-            const std::string cmpStr = TestbedContext::FormatByteArray(cmp, size, 4);
+            const string vecStr = TestbedContext::FormatByteArray(vec, size, 4);
+            const string cmpStr = TestbedContext::FormatByteArray(cmp, size, 4);
             Log::Errorf(
                 "Mismatch between SmallVector '%s' [%s] and initial data [%s]\n",
                 name, vecStr.c_str(), cmpStr.c_str()
@@ -196,7 +196,7 @@ DEF_RITEST( ContainerSmallVector )
 
     // Test inserting elements beyond static capacity
     SmallVector<int, 2> iv2_n;
-    std::vector<int> iv_std;
+    vector<int> iv_std;
 
     for (int i = 0; i < 1024; ++i)
     {
@@ -268,12 +268,12 @@ DEF_RITEST( ContainerUTF8String )
     }
 
     SmallVector<wchar_t> su3UTF16 = su3.to_utf16();
-    std::wstring su3Wide = su3UTF16.data();
+    wstring su3Wide = su3UTF16.data();
     const wchar_t* su3WideExpected = L"Hello \x4E16\x754C\x3002";
     if (su3Wide != su3WideExpected)
     {
-        const std::string su3Ansi           = std::wstring_convert<std::codecvt_utf8_utf16<wchar_t>>{}.to_bytes(su3Wide);
-        const std::string su3AnsiExpected   = std::wstring_convert<std::codecvt_utf8_utf16<wchar_t>>{}.to_bytes(su3WideExpected);
+        const string su3Ansi           = std::wstring_convert<std::codecvt_utf8_utf16<wchar_t>>{}.to_bytes(su3Wide);
+        const string su3AnsiExpected   = std::wstring_convert<std::codecvt_utf8_utf16<wchar_t>>{}.to_bytes(su3WideExpected);
         Log::Errorf(
             "Mismatch between UTF8String concatenation 'su3Wide' \"%s\" and initial value \"%s\"\n",
             su3Ansi.c_str(), su3AnsiExpected.c_str()
@@ -308,7 +308,7 @@ DEF_RITEST( ContainerUTF8String )
         sa6 = subA;
         sa6 += subB;
 
-        const std::string sa6Expected = std::string(subA.begin(), subA.end()) + std::string(subB.begin(), subB.end());
+        const string sa6Expected = string(subA.begin(), subA.end()) + string(subB.begin(), subB.end());
 
         if (sa6.size() != subA.size() + subB.size() || ::memcmp(sa6.data(), sa6Expected.data(), sa6Expected.size()) != 0)
         {
@@ -434,7 +434,7 @@ DEF_RITEST( ContainerStringLiteral )
 
     // Test absence of ambiguity (Compile-time only test)
     {
-        StringLiteral l6{ std::string("Test") };
+        StringLiteral l6{ string("Test") };
         StringLiteral l7{ l6 };
     }
 
@@ -447,7 +447,7 @@ template <typename T>
 TestResult TestStringSort(const std::initializer_list<const char*> inStrings, bool sanityCheck, const char* llglStringTypeName)
 {
     // Fill both STL and LLGL string containers
-    std::vector<std::string> stdStrings;
+    vector<string> stdStrings;
     DynamicVector<T> llglStrings;
 
     stdStrings.reserve(inStrings.size());
@@ -478,10 +478,10 @@ TestResult TestStringSort(const std::initializer_list<const char*> inStrings, bo
         constexpr std::size_t chartColumnDist = 20; // Distance between beginning of "STL strings:" and "LLGL strings:"
         const char* caption =
         (
-            "std::string         %s\n"
+            "string         %s\n"
             "-----------         %s\n"
         );
-        const std::string llglStringTypeUnderline(::strlen(llglStringTypeName), '-');
+        const string llglStringTypeUnderline(::strlen(llglStringTypeName), '-');
 
         if (printAsErrors)
             Log::Errorf(caption, llglStringTypeName, llglStringTypeUnderline.c_str());
@@ -490,9 +490,9 @@ TestResult TestStringSort(const std::initializer_list<const char*> inStrings, bo
 
         for_range(i, stdStrings.size())
         {
-            const std::string lhs{ stdStrings[i].data(), stdStrings[i].size() };
-            const std::string rhs{ llglStrings[i].data(), llglStrings[i].size() };
-            const std::string spaces(lhs.size() < chartColumnDist ? chartColumnDist - lhs.size() : 1, ' ');
+            const string lhs{ stdStrings[i].data(), stdStrings[i].size() };
+            const string rhs{ llglStrings[i].data(), llglStrings[i].size() };
+            const string spaces(lhs.size() < chartColumnDist ? chartColumnDist - lhs.size() : 1, ' ');
 
             if (printAsErrors)
                 Log::Errorf("%s%s%s\n", lhs.c_str(), spaces.c_str(), rhs.c_str());

--- a/tests/Testbed/UnitTests/TestDepthBuffer.cpp
+++ b/tests/Testbed/UnitTests/TestDepthBuffer.cpp
@@ -123,7 +123,7 @@ DEF_TEST( DepthBuffer )
     const float deltaDepthValue = std::abs(readbackDepthValue - expectedDepthValue);
 
     // Match entire depth and create delta heat map
-    std::vector<float> readbackDepthBuffer;
+    vector<float> readbackDepthBuffer;
     readbackDepthBuffer.resize(texDesc.extent.width * texDesc.extent.height, -1.0f);
     {
         dstImageView.format     = ImageFormat::Depth;

--- a/tests/Testbed/UnitTests/TestImageConversions.cpp
+++ b/tests/Testbed/UnitTests/TestImageConversions.cpp
@@ -14,22 +14,22 @@
 
 DEF_RITEST( ImageConversions )
 {
-    const std::string imagePath = "../Media/Textures/";
-    const std::string refPath   = "Reference/";
-    const std::string outputDir = opt.outputDir;
+    const string imagePath = "../Media/Textures/";
+    const string refPath   = "Reference/";
+    const string outputDir = opt.outputDir;
 
-    auto MakeOutputFilename = [](const std::string& filename, ImageFormat format, unsigned threadCount) -> std::string
+    auto MakeOutputFilename = [](const string& filename, ImageFormat format, unsigned threadCount) -> string
     {
-        std::string s = filename.substr(0, filename.find_last_of('.'));
+        string s = filename.substr(0, filename.find_last_of('.'));
         s += '-';
         s += ToString(format);
         s += '-';
-        s += (threadCount == LLGL_MAX_THREAD_COUNT ? std::string("Max") : std::to_string(threadCount));
+        s += (threadCount == LLGL_MAX_THREAD_COUNT ? string("Max") : std::to_string(threadCount));
         s += ".png";
         return s;
     };
 
-    auto TestConversion = [&](const std::string& filename, unsigned threadCount, double& outTime) -> TestResult
+    auto TestConversion = [&](const string& filename, unsigned threadCount, double& outTime) -> TestResult
     {
         Image img = TestbedContext::LoadImageFromFile(imagePath + filename, opt.verbose);
 
@@ -48,7 +48,7 @@ DEF_RITEST( ImageConversions )
                 totalTime += (endTime - startTime);                                                         \
                 if (img.GetDataSize() != (SIZE))                                                            \
                 {                                                                                           \
-                    const std::string name = MakeOutputFilename(filename, img.GetFormat(), threadCount);    \
+                    const string name = MakeOutputFilename(filename, img.GetFormat(), threadCount);    \
                     Log::Errorf(                                                                            \
                         Log::ColorFlags::StdError,                                                          \
                         "Mismatch between image size '%s' (%u bytes) and expected size (%u bytes)\n",       \

--- a/tests/Testbed/UnitTests/TestImageStrides.cpp
+++ b/tests/Testbed/UnitTests/TestImageStrides.cpp
@@ -24,7 +24,7 @@ DEF_RITEST( ImageStrides )
     const std::uint32_t numPixelsPerRow     = 10;
     const std::uint32_t numPixelsPerLayer   = numPixelsPerRow*6;
 
-    std::vector<LLGL::ColorRGBAub> srcData, expectedData;
+    vector<LLGL::ColorRGBAub> srcData, expectedData;
     srcData.resize(numPixelsPerLayer * imageExtent.depth);
     expectedData.resize(imageExtent.width * imageExtent.height * imageExtent.depth);
     {
@@ -43,7 +43,7 @@ DEF_RITEST( ImageStrides )
         }
     }
 
-    std::vector<LLGL::ColorRGBf> dstData;
+    vector<LLGL::ColorRGBf> dstData;
     dstData.resize(imageExtent.width * imageExtent.height * imageExtent.depth);
 
     // Convert image with padding
@@ -82,8 +82,8 @@ DEF_RITEST( ImageStrides )
 
     if (::memcmp(dstImgRGBA8ub.data(), expectedData.data(), expectedSize) != 0)
     {
-        const std::string expectedDataStr = TestbedContext::FormatByteArray(expectedData.data(), expectedSize, 4);
-        const std::string actualDataStr = TestbedContext::FormatByteArray(dstImgRGBA8ub.data(), dstImgRGBA8ub.size(), 4);
+        const string expectedDataStr = TestbedContext::FormatByteArray(expectedData.data(), expectedSize, 4);
+        const string actualDataStr = TestbedContext::FormatByteArray(dstImgRGBA8ub.data(), dstImgRGBA8ub.size(), 4);
         Log::Errorf(
             Log::ColorFlags::StdError,
             "Mismatch between converted image data and padded input image:\n"
@@ -95,7 +95,7 @@ DEF_RITEST( ImageStrides )
     }
     else if (opt.sanityCheck)
     {
-        const std::string actualDataStr = TestbedContext::FormatByteArray(dstImgRGBA8ub.data(), dstImgRGBA8ub.size(), 4);
+        const string actualDataStr = TestbedContext::FormatByteArray(dstImgRGBA8ub.data(), dstImgRGBA8ub.size(), 4);
         Log::Printf(
             Log::ColorFlags::StdAnnotation,
             "Sanity check for converted image data from padded input image:\n"
@@ -116,8 +116,8 @@ DEF_RITEST( ImageStrides )
                 const ColorRGBub dstCol = dstData[i].Cast<std::uint8_t>();
                 if (srcCol != dstCol)
                 {
-                    const std::string srcColStr = FormatByteArray(srcCol.Ptr(), sizeof(srcCol));
-                    const std::string dstColStr = FormatByteArray(dstCol.Ptr(), sizeof(srcCol));
+                    const string srcColStr = FormatByteArray(srcCol.Ptr(), sizeof(srcCol));
+                    const string dstColStr = FormatByteArray(dstCol.Ptr(), sizeof(srcCol));
                     Log::Errorf(
                         Log::ColorFlags::StdError,
                         "Mismatch between converted image and padded input image at (%u,%u):\n"

--- a/tests/Testbed/UnitTests/TestMipMaps.cpp
+++ b/tests/Testbed/UnitTests/TestMipMaps.cpp
@@ -38,7 +38,7 @@ DEF_TEST( MipMaps )
 {
     TestResult result = TestResult::Passed;
 
-    auto ReadMipMaps = [this](Texture* tex, const std::string& name) -> TestResult
+    auto ReadMipMaps = [this](Texture* tex, const string& name) -> TestResult
     {
         TestResult result = TestResult::Passed;
 
@@ -62,7 +62,7 @@ DEF_TEST( MipMaps )
             // Read current MIP-map from input texture
             const Extent3D mipExtent = tex->GetMipExtent(mip);
 
-            std::vector<ColorRGBub> mipData;
+            vector<ColorRGBub> mipData;
             mipData.resize(mipExtent.width * mipExtent.height);
 
             const TextureRegion texRegion{ TextureSubresource{ 0, mip }, Offset3D{}, mipExtent };
@@ -77,7 +77,7 @@ DEF_TEST( MipMaps )
             renderer->ReadTexture(*tex, texRegion, dstImageView);
 
             // Save result and diff against reference
-            const std::string mipName = name + "_Mip" + std::to_string(mip);
+            const string mipName = name + "_Mip" + std::to_string(mip);
             SaveColorImage(mipData, Extent2D{ mipExtent.width, mipExtent.height }, mipName);
 
             const DiffResult diff = DiffImages(mipName, diffThreshold, diffTolerance);

--- a/tests/Testbed/UnitTests/TestOffscreenC99.cpp
+++ b/tests/Testbed/UnitTests/TestOffscreenC99.cpp
@@ -123,7 +123,7 @@ DEF_TEST( OffscreenC99 )
         LLGLVertexAttribute{ "color",    LLGLFormatRGBA8UNorm, 1, 0, LLGLSystemValueUndefined, 0, offsetof(UnprojectedVertex, color),    sizeof(UnprojectedVertex) },
     };
 
-    std::vector<UnprojectedVertex> vertices;
+    vector<UnprojectedVertex> vertices;
     vertices.resize(16);
 
     const std::uint8_t colorPalette[8][3] =
@@ -298,7 +298,7 @@ DEF_TEST( OffscreenC99 )
     // Read texture result
     static_assert(sizeof(LLGL::ColorRGBub) == 3, "LLGL::ColorRGBAub must have a size of 4 bytes for OffscreenC99 test");
 
-    std::vector<LLGL::ColorRGBub> pixels;
+    vector<LLGL::ColorRGBub> pixels;
     pixels.resize(tex0Desc.extent.width * tex0Desc.extent.height * tex0Desc.extent.depth);
 
     LLGLMutableImageView dstImgView = {};
@@ -318,7 +318,7 @@ DEF_TEST( OffscreenC99 )
     llglReadTexture(tex0, &tex0Region, &dstImgView);
 
     // Match entire color buffer and create delta heat map
-    const std::string colorBufferName = "OffscreenC99";
+    const string colorBufferName = "OffscreenC99";
 
     SaveColorImage(pixels, Extent2D{ tex0Desc.extent.width, tex0Desc.extent.height }, colorBufferName);
 

--- a/tests/Testbed/UnitTests/TestResourceBinding.cpp
+++ b/tests/Testbed/UnitTests/TestResourceBinding.cpp
@@ -110,12 +110,12 @@ DEF_TEST( ResourceBinding )
         for_range(i, 4)
         {
             SAFE_RELEASE(buffers[i]);
-            const std::string bufName = "RWBuffer<int4>[" + std::to_string(i) + "]";
+            const string bufName = "RWBuffer<int4>[" + std::to_string(i) + "]";
             bufDesc.debugName = bufName.c_str();
             buffers[i] = renderer->CreateBuffer(bufDesc);
 
             SAFE_RELEASE(textures[i]);
-            const std::string texName = "RWTexture1D<int4>[" + std::to_string(i) + "]";
+            const string texName = "RWTexture1D<int4>[" + std::to_string(i) + "]";
             texDesc.debugName = texName.c_str();
             textures[i] = renderer->CreateTexture(texDesc);
         }

--- a/tests/Testbed/UnitTests/TestResourceCopy.cpp
+++ b/tests/Testbed/UnitTests/TestResourceCopy.cpp
@@ -258,7 +258,7 @@ DEF_TEST( ResourceCopy )
     cmdBuffer->End();
 
     // Match entire color buffer and create delta heat map
-    const std::string colorBufferName = "ResourceCopy_Frame" + std::to_string(frame);
+    const string colorBufferName = "ResourceCopy_Frame" + std::to_string(frame);
 
     SaveCapture(readbackTex, colorBufferName);
 

--- a/tests/Testbed/UnitTests/TestSceneUpdate.cpp
+++ b/tests/Testbed/UnitTests/TestSceneUpdate.cpp
@@ -132,7 +132,7 @@ DEF_TEST( SceneUpdate )
     }
 
     // Match entire color buffer and create delta heat map
-    const std::string colorBufferName = "SceneUpdate_Frame" + std::to_string(frame);
+    const string colorBufferName = "SceneUpdate_Frame" + std::to_string(frame);
 
     SaveCapture(readbackTex, colorBufferName);
 

--- a/tests/Testbed/UnitTests/TestShaderErrors.cpp
+++ b/tests/Testbed/UnitTests/TestShaderErrors.cpp
@@ -8,7 +8,7 @@
 #include "Testbed.h"
 #include <LLGL/Utils/TypeNames.h>
 #include <LLGL/Utils/Parse.h>
-#include <string>
+#include <LLGL/Container/String.h>
 
 
 /*
@@ -19,7 +19,7 @@ DEF_TEST( ShaderErrors )
 {
     TestResult result = TestResult::Passed;
 
-    auto LoadShaderFile = [this, &result](const std::string& filename, ShaderType type, const char* entry, const char* profile, bool isFileBinary) -> Shader*
+    auto LoadShaderFile = [this, &result](const string& filename, ShaderType type, const char* entry, const char* profile, bool isFileBinary) -> Shader*
     {
         ShaderDescriptor shaderDesc;
         {
@@ -40,7 +40,7 @@ DEF_TEST( ShaderErrors )
 
     auto LoadShader = [this, &IsShadingLanguageSupported, &LoadShaderFile, &result](const char* name, ShaderType type, bool expectErrors) -> Shader*
     {
-        auto ShaderTypeToGlslExt = [](ShaderType type) -> std::string
+        auto ShaderTypeToGlslExt = [](ShaderType type) -> string
         {
             switch (type)
             {
@@ -73,9 +73,9 @@ DEF_TEST( ShaderErrors )
             }
         };
 
-        const std::string shaderPath = "Shaders/SemanticErrors/";
+        const string shaderPath = "Shaders/SemanticErrors/";
 
-        std::string shaderFilename = name;
+        string shaderFilename = name;
         Shader* shader = nullptr;
 
         if (IsShadingLanguageSupported(ShadingLanguage::HLSL))

--- a/tests/Testbed/UnitTests/TestShadowMapping.cpp
+++ b/tests/Testbed/UnitTests/TestShadowMapping.cpp
@@ -150,7 +150,7 @@ DEF_TEST( ShadowMapping )
             shadowMapDesc.extent        = { resolution.width, resolution.height, 1u };
             shadowMapDesc.mipLevels     = 1;
         }
-        const std::string name = std::string("shadowTex-") + ToString(format);
+        const string name = string("shadowTex-") + ToString(format);
         result = CreateTexture(shadowMapDesc, name.c_str(), &resources.tex);
         if (result != TestResult::Passed)
             return result;
@@ -161,7 +161,7 @@ DEF_TEST( ShadowMapping )
             rtDesc.resolution               = resolution;
             rtDesc.depthStencilAttachment   = resources.tex;
         }
-        const std::string rtName = std::string("shadowTarget-") + ToString(format);
+        const string rtName = string("shadowTarget-") + ToString(format);
         result = CreateRenderTarget(rtDesc, rtName.c_str(), &resources.target);
         if (result != TestResult::Passed)
             return result;
@@ -192,7 +192,7 @@ DEF_TEST( ShadowMapping )
     if (opt.fastTest && cfg.slow)
         return (frame + 1 < numFrames ? TestResult::ContinueSkipFrame : result);
 
-    const std::string colorBufferName = "ShadowMapping_" + std::string(ToString(cfg.format)) + "_" + std::to_string(cfg.width) + "x" + std::to_string(cfg.height);
+    const string colorBufferName = "ShadowMapping_" + string(ToString(cfg.format)) + "_" + std::to_string(cfg.width) + "x" + std::to_string(cfg.height);
 
     const std::uint64_t t0 = Timer::Tick();
 
@@ -261,7 +261,7 @@ DEF_TEST( ShadowMapping )
         {
             for (int x = 0; x < 2; ++x)
             {
-                const std::string meshLabel = "Cube(" + std::to_string(x) + "," + std::to_string(y) + ")";
+                const string meshLabel = "Cube(" + std::to_string(x) + "," + std::to_string(y) + ")";
                 cmdBuffer->PushDebugGroup(meshLabel.c_str());
                 TransformWorldMatrix(
                     sceneConstants.wMatrix,
@@ -304,7 +304,7 @@ DEF_TEST( ShadowMapping )
 
         for (std::size_t i = 0; i < sizeof(viewportConfigs)/sizeof(viewportConfigs[0]); ++i)
         {
-            const std::string viewportLabel = "Viewport[" + std::to_string(i) + "]";
+            const string viewportLabel = "Viewport[" + std::to_string(i) + "]";
             cmdBuffer->PushDebugGroup(viewportLabel.c_str());
 
             // Render shadow map

--- a/tests/Testbed/UnitTests/TestStencilBuffer.cpp
+++ b/tests/Testbed/UnitTests/TestStencilBuffer.cpp
@@ -130,7 +130,7 @@ DEF_TEST( StencilBuffer )
     const int deltaStencilValue = std::abs(static_cast<int>(readbackStencilValue) - static_cast<int>(stencilRef));
 
     // Match entire depth and create delta heat map
-    std::vector<std::uint8_t> readbackStencilBuffer;
+    vector<std::uint8_t> readbackStencilBuffer;
     readbackStencilBuffer.resize(texDesc.extent.width * texDesc.extent.height, 0);
     {
         dstImageView.format     = ImageFormat::Stencil;

--- a/tests/Testbed/UnitTests/TestStreamOutput.cpp
+++ b/tests/Testbed/UnitTests/TestStreamOutput.cpp
@@ -53,7 +53,7 @@ DEF_TEST( StreamOutput )
     static QueryHeap* queryHeaps[2];
 
     static std::uint32_t numInitialVertices;
-    static std::vector<ColoredVertex> cubeVertices;
+    static vector<ColoredVertex> cubeVertices;
 
     constexpr std::uint32_t maxSOVertices = 20000;
     constexpr int numVertPreTransforms = 3;
@@ -101,7 +101,7 @@ DEF_TEST( StreamOutput )
         // Create vertex input buffer
         for_range(i, 2)
         {
-            const std::string vertBufName = "SOVertexBuffer[" + std::to_string(i) + "]";
+            const string vertBufName = "SOVertexBuffer[" + std::to_string(i) + "]";
             BufferDescriptor vertBufDesc;
             {
                 vertBufDesc.debugName       = vertBufName.c_str();
@@ -386,7 +386,7 @@ DEF_TEST( StreamOutput )
         result = TestResult::FailedErrors;
 
     // Match entire color buffer and create delta heat map
-    const std::string colorBufferName = "StreamOutput_Frame" + std::to_string(frame);
+    const string colorBufferName = "StreamOutput_Frame" + std::to_string(frame);
 
     SaveCapture(readbackTex, colorBufferName);
 

--- a/tests/Testbed/UnitTests/TestTextureCopy.cpp
+++ b/tests/Testbed/UnitTests/TestTextureCopy.cpp
@@ -58,7 +58,7 @@ DEF_TEST( TextureCopy )
         };
 
         // Create source texture
-        const std::string srcTexName = std::string("src.") + name;
+        const string srcTexName = string("src.") + name;
         TextureDescriptor srcTexDesc;
         {
             srcTexDesc.type         = type;
@@ -71,7 +71,7 @@ DEF_TEST( TextureCopy )
         CREATE_TEXTURE(srcTex, srcTexDesc, srcTexName.c_str(), nullptr);
 
         // Create intermediate texture to copy into
-        const std::string interTexName = std::string("inter.") + name;
+        const string interTexName = string("inter.") + name;
         TextureDescriptor interTexDesc;
         {
             interTexDesc.type           = ToNonArrayTextureType(type);
@@ -84,7 +84,7 @@ DEF_TEST( TextureCopy )
         CREATE_TEXTURE(interTex, interTexDesc, interTexName.c_str(), nullptr);
 
         // Create destination texture to read the results from
-        const std::string dstTexName = std::string("dst.") + name;
+        const string dstTexName = string("dst.") + name;
         TextureDescriptor dstTexDesc;
         {
             dstTexDesc.type         = type;
@@ -141,8 +141,8 @@ DEF_TEST( TextureCopy )
                 // Evaluate results
                 if (::memcmp(colorsRgbaUb8.data(), outputData, sizeof(outputData)) != 0)
                 {
-                    const std::string inputDataStr = TestbedContext::FormatByteArray(colorsRgbaUb8.data(), sizeof(colorsRgbaUb8[0]) * colorsRgbaUb8.size(), 4);
-                    const std::string outputDataStr = TestbedContext::FormatByteArray(outputData, sizeof(outputData), 4);
+                    const string inputDataStr = TestbedContext::FormatByteArray(colorsRgbaUb8.data(), sizeof(colorsRgbaUb8[0]) * colorsRgbaUb8.size(), 4);
+                    const string outputDataStr = TestbedContext::FormatByteArray(outputData, sizeof(outputData), 4);
                     Log::Errorf(
                         "Mismatch between data of texture %s [MIP %u, Layer %u] and copy result:\n"
                         " -> Expected: [%s]\n"

--- a/tests/Testbed/UnitTests/TestTextureStrides.cpp
+++ b/tests/Testbed/UnitTests/TestTextureStrides.cpp
@@ -55,7 +55,7 @@ DEF_TEST( TextureStrides )
     }
 
     // Create primary texture and two with different stride/offset
-    const std::string imagePath = "../Media/Textures/";
+    const string imagePath = "../Media/Textures/";
     Image image = TestbedContext::LoadImageFromFile(imagePath + "Grid10x10.png", opt.verbose);
 
     ImageView imageViewA;
@@ -154,7 +154,7 @@ DEF_TEST( TextureStrides )
     cmdBuffer->End();
 
     // Match entire color buffer and create delta heat map
-    const std::string colorBufferName = "TextureStrides_Frame" + std::to_string(frame);
+    const string colorBufferName = "TextureStrides_Frame" + std::to_string(frame);
 
     SaveCapture(readbackTex, colorBufferName);
 

--- a/tests/Testbed/UnitTests/TestTextureToBufferCopy.cpp
+++ b/tests/Testbed/UnitTests/TestTextureToBufferCopy.cpp
@@ -89,8 +89,8 @@ DEF_TEST( TextureToBufferCopy )
 
         if (::memcmp(srcImage.data, srcImageFeedback.data, imgSizeMip0) != 0)
         {
-            const std::string initialDataStr = TestbedContext::FormatByteArray(srcImage.data, imgSizeMip0, 4, formatAsFloats);
-            const std::string readbackDataStr = TestbedContext::FormatByteArray(srcImageFeedback.data, imgSizeMip0, 4, formatAsFloats);
+            const string initialDataStr = TestbedContext::FormatByteArray(srcImage.data, imgSizeMip0, 4, formatAsFloats);
+            const string readbackDataStr = TestbedContext::FormatByteArray(srcImageFeedback.data, imgSizeMip0, 4, formatAsFloats);
             Log::Errorf(
                 "Mismatch between initial data of texture %s and readback result:\n"
                 " -> Expected: [%s]\n"
@@ -101,7 +101,7 @@ DEF_TEST( TextureToBufferCopy )
         }
 
         // Create buffer to copy from source texture and to destination texture
-        const std::string bufName = std::string("tmpBuf.") + name;
+        const string bufName = string("tmpBuf.") + name;
         BufferDescriptor bufDesc;
         {
             bufDesc.size        = bufSize;
@@ -110,7 +110,7 @@ DEF_TEST( TextureToBufferCopy )
         CREATE_BUFFER(buf, bufDesc, bufName.c_str(), nullptr);
 
         // Create destination texture
-        const std::string dstTexName = std::string("dstTex.") + name;
+        const string dstTexName = string("dstTex.") + name;
         TextureDescriptor dstTexDesc;
         {
             dstTexDesc.type         = TextureType::Texture2D;
@@ -124,8 +124,8 @@ DEF_TEST( TextureToBufferCopy )
         CREATE_TEXTURE(dstTex, dstTexDesc, dstTexName.c_str(), nullptr);
 
         // Run test through all MIP-maps and array layers (should not be more than 2 each)
-        std::vector<char> srcTexImage;
-        std::vector<char> dstTexImage;
+        vector<char> srcTexImage;
+        vector<char> dstTexImage;
 
         for_range(mip, srcTexDesc.mipLevels)
         {
@@ -156,7 +156,7 @@ DEF_TEST( TextureToBufferCopy )
                 // Copy source texture to buffer and back to destination texture
                 cmdBuffer->Begin();
                 {
-                    const std::string debugGroup = std::string(name) + " (mip: " + std::to_string(mip) + ", layer: " + std::to_string(layer) + ")";
+                    const string debugGroup = string(name) + " (mip: " + std::to_string(mip) + ", layer: " + std::to_string(layer) + ")";
                     cmdBuffer->PushDebugGroup(debugGroup.c_str());
                     {
                         cmdBuffer->FillBuffer(*buf, 0, FLIP_ENDIAN(0xDEADBEEF), bufDesc.size);
@@ -194,8 +194,8 @@ DEF_TEST( TextureToBufferCopy )
 
                 if (::memcmp(srcTexImage.data(), dstTexImage.data(), subBufSize) != 0)
                 {
-                    const std::string srcDataStr = TestbedContext::FormatByteArray(srcTexImage.data(), srcTexImage.size(), 4, formatAsFloats);
-                    const std::string dstDataStr = TestbedContext::FormatByteArray(dstTexImage.data(), dstTexImage.size(), 4, formatAsFloats);
+                    const string srcDataStr = TestbedContext::FormatByteArray(srcTexImage.data(), srcTexImage.size(), 4, formatAsFloats);
+                    const string dstDataStr = TestbedContext::FormatByteArray(dstTexImage.data(), dstTexImage.size(), 4, formatAsFloats);
                     Log::Errorf(
                         Log::ColorFlags::StdError,
                         "Mismatch between data of texture %s [MIP %u, Layer %u] and copy result:\n"
@@ -207,7 +207,7 @@ DEF_TEST( TextureToBufferCopy )
                 }
                 else if (opt.sanityCheck)
                 {
-                    const std::string dataStr = TestbedContext::FormatByteArray(srcTexImage.data(), srcTexImage.size(), 4, formatAsFloats);
+                    const string dataStr = TestbedContext::FormatByteArray(srcTexImage.data(), srcTexImage.size(), 4, formatAsFloats);
                     Log::Printf(
                         Log::ColorFlags::StdAnnotation,
                         "Sanity check for texture %s [MIP %u, Layer %u]:\n"
@@ -240,16 +240,16 @@ DEF_TEST( TextureToBufferCopy )
     #define SRC_IMAGE_DESC(DECL, FORMAT, TYPE, SRC) \
         const ImageView DECL{ (FORMAT), (TYPE), (SRC).data(), (SRC).size() * sizeof((SRC)[0]) }
 
-    static std::vector<ColorRGBAub> colorsRgbaUb64 = Testset::GenerateColorsRgbaUb(64);
+    static vector<ColorRGBAub> colorsRgbaUb64 = Testset::GenerateColorsRgbaUb(64);
     SRC_IMAGE_DESC(srcImageRgbaUb64, ImageFormat::RGBA, DataType::UInt8,   colorsRgbaUb64);
 
-    static std::vector<float> colorsRgF64 = Testset::GenerateFloats(64 * 2);
+    static vector<float> colorsRgF64 = Testset::GenerateFloats(64 * 2);
     SRC_IMAGE_DESC(srcImageRgF64,    ImageFormat::RG,   DataType::Float32, colorsRgF64   );
 
-    static std::vector<ColorRGBAub> colorsRgbaUb96 = Testset::GenerateColorsRgbaUb(96);
+    static vector<ColorRGBAub> colorsRgbaUb96 = Testset::GenerateColorsRgbaUb(96);
     SRC_IMAGE_DESC(srcImageRgbaUb96, ImageFormat::RGBA, DataType::UInt8,   colorsRgbaUb96);
 
-    static std::vector<float> colorsRF96 = Testset::GenerateFloats(96);
+    static vector<float> colorsRF96 = Testset::GenerateFloats(96);
     SRC_IMAGE_DESC(srcImageRF96,     ImageFormat::R,    DataType::Float32, colorsRF96    );
 
     #define TEST_TEXTURE_TO_BUFFER_COPY(NAME, TYPE, FORMAT, EXTENT, MIPS, LAYERS, SRC)                                  \

--- a/tests/Testbed/UnitTests/TestTextureWriteAndRead.cpp
+++ b/tests/Testbed/UnitTests/TestTextureWriteAndRead.cpp
@@ -14,7 +14,7 @@ DEF_TEST( TextureWriteAndRead )
 {
     const ArrayView<ColorRGBAub> colorsRgbaUb4 = Testset::GetColorsRgbaUb4();
 
-    static std::vector<ColorRGBAub> colorsRgbaUb16 = Testset::GenerateColorsRgbaUb(16);
+    static vector<ColorRGBAub> colorsRgbaUb16 = Testset::GenerateColorsRgbaUb(16);
 
     auto CreateTextureAndTestImageData = [this](const char* name, const TextureDescriptor& texDesc, const TextureRegion& region, const void* data, std::size_t dataSize) -> TestResult
     {
@@ -35,7 +35,7 @@ DEF_TEST( TextureWriteAndRead )
         renderer->WriteTexture(*tex, region, srcImage);
 
         // Read texture data
-        std::vector<char> outputData;
+        vector<char> outputData;
         outputData.resize(dataSize, char(0xFF));
 
         MutableImageView dstImage;
@@ -53,8 +53,8 @@ DEF_TEST( TextureWriteAndRead )
         // Match input with output texture data
         if (::memcmp(data, outputData.data(), dataSize) != 0)
         {
-            const std::string inputDataStr = TestbedContext::FormatByteArray(data, dataSize, 4);
-            const std::string outputDataStr = TestbedContext::FormatByteArray(outputData.data(), dataSize, 4);
+            const string inputDataStr = TestbedContext::FormatByteArray(data, dataSize, 4);
+            const string outputDataStr = TestbedContext::FormatByteArray(outputData.data(), dataSize, 4);
             Log::Errorf(
                 "Mismatch between data of texture %s and initial data:\n"
                 " -> Expected: [%s]\n"

--- a/tests/Testbed/UnitTests/TestTriangleStripCutOff.cpp
+++ b/tests/Testbed/UnitTests/TestTriangleStripCutOff.cpp
@@ -76,7 +76,7 @@ DEF_TEST( TriangleStripCutOff )
     for_range(i, numFormats)
     {
         psoDesc.indexFormat = indexFormats[i];
-        const std::string psoName = "Test.StripCutOff.Format(" + std::string(ToString(indexFormats[i])) + ")";
+        const string psoName = "Test.StripCutOff.Format(" + string(ToString(indexFormats[i])) + ")";
         CREATE_GRAPHICS_PSO_EXT(pso[i], psoDesc, psoName.c_str());
     }
 
@@ -124,7 +124,7 @@ DEF_TEST( TriangleStripCutOff )
     // Diff color buffer for undefined and fixed index formats
     bool diffFailed = false;
 
-    const std::string colorBuffer0Name = "TriangleStrip_UndefinedFormat";
+    const string colorBuffer0Name = "TriangleStrip_UndefinedFormat";
     SaveCapture(readbackTex[0], colorBuffer0Name);
     const DiffResult diff0 = DiffImages(colorBuffer0Name);
 
@@ -132,7 +132,7 @@ DEF_TEST( TriangleStripCutOff )
     if (result0 != TestResult::Passed)
         diffFailed = true;
 
-    const std::string colorBuffer1Name = "TriangleStrip_FixedFormat";
+    const string colorBuffer1Name = "TriangleStrip_FixedFormat";
     SaveCapture(readbackTex[1], colorBuffer1Name);
     const DiffResult diff1 = DiffImages(colorBuffer1Name);
 

--- a/tests/Testbed/UnitTests/TestUniforms.cpp
+++ b/tests/Testbed/UnitTests/TestUniforms.cpp
@@ -165,7 +165,7 @@ DEF_TEST( Uniforms )
     cmdBuffer->End();
 
     // Match entire color buffer and create delta heat map
-    const std::string colorBufferName = "Uniforms_Frame" + std::to_string(frame);
+    const string colorBufferName = "Uniforms_Frame" + std::to_string(frame);
 
     SaveCapture(readbackTex, colorBufferName);
 

--- a/tests/Testbed/UnitTests/TestViewportAndScissor.cpp
+++ b/tests/Testbed/UnitTests/TestViewportAndScissor.cpp
@@ -210,7 +210,7 @@ DEF_TEST( ViewportAndScissor )
 
     for_range(i, psoCount)
     {
-        const std::string colorBufferName = "ViewportAndScissor_" + std::string(frameNames[i]);
+        const string colorBufferName = "ViewportAndScissor_" + string(frameNames[i]);
 
         // Evaluate at fixed points
         const bool wasScissorEnabled = (psoList[i] != psoNoScissor);

--- a/wrapper/C99/C99Canvas.cpp
+++ b/wrapper/C99/C99Canvas.cpp
@@ -11,8 +11,8 @@
 #include "C99EventListenerContainer.h"
 #include "../sources/Core/CoreUtils.h"
 #include "../sources/Core/Exception.h"
-#include <vector>
-#include <string>
+#include <LLGL/Container/Vector.h>
+#include <LLGL/Container/String.h>
 #include <string.h>
 
 
@@ -83,7 +83,7 @@ using CanvasEventListenerContainer = EventListenerContainer<InternalCanvasEventL
 
 #undef LLGL_CALLBACK_WRAPPER
 
-static std::vector<std::unique_ptr<Canvas>> g_Canvases;
+static vector<std::unique_ptr<Canvas>> g_Canvases;
 static CanvasEventListenerContainer         g_CanvasEventListenerContainer;
 
 static void ConvertCanvasDesc(CanvasDescriptor& dst, const LLGLCanvasDescriptor& src)

--- a/wrapper/C99/C99Display.cpp
+++ b/wrapper/C99/C99Display.cpp
@@ -105,7 +105,7 @@ LLGL_C_EXPORT void llglGetDisplayMode(LLGLDisplay display, LLGLDisplayMode* outD
 
 LLGL_C_EXPORT size_t llglGetSupportedDisplayModes(LLGLDisplay display, size_t maxNumDisplayModes, LLGLDisplayMode* outDisplayModes)
 {
-    std::vector<DisplayMode> internalDisplayModes = LLGL_PTR(Display, display)->GetSupportedDisplayModes();
+    vector<DisplayMode> internalDisplayModes = LLGL_PTR(Display, display)->GetSupportedDisplayModes();
     if (outDisplayModes != nullptr)
     {
         maxNumDisplayModes = std::min(maxNumDisplayModes, internalDisplayModes.size());

--- a/wrapper/C99/C99Log.cpp
+++ b/wrapper/C99/C99Log.cpp
@@ -18,28 +18,28 @@ using namespace LLGL;
 
 LLGL_C_EXPORT void llglLogPrintf(const char* format, ...)
 {
-    std::string text;
+    string text;
     LLGL_STRING_PRINTF(text, format);
     Log::Printf("%s", text.c_str());
 }
 
 LLGL_C_EXPORT void llglLogPrintfExt(const LLGLColorCodes* colors, const char* format, ...)
 {
-    std::string text;
+    string text;
     LLGL_STRING_PRINTF(text, format);
     Log::Printf(*reinterpret_cast<const Log::ColorCodes*>(colors), "%s", text.c_str());
 }
 
 LLGL_C_EXPORT void llglLogErrorf(const char* format, ...)
 {
-    std::string text;
+    string text;
     LLGL_STRING_PRINTF(text, format);
     Log::Errorf("%s", text.c_str());
 }
 
 LLGL_C_EXPORT void llglLogErrorfExt(const LLGLColorCodes* colors, const char* format, ...)
 {
-    std::string text;
+    string text;
     LLGL_STRING_PRINTF(text, format);
     Log::Errorf(*reinterpret_cast<const Log::ColorCodes*>(colors), "%s", text.c_str());
 }

--- a/wrapper/C99/C99RenderSystem.cpp
+++ b/wrapper/C99/C99RenderSystem.cpp
@@ -10,8 +10,8 @@
 #include <LLGL/Utils/ForRange.h>
 #include "C99Internal.h"
 #include <string.h>
-#include <vector>
-#include <string>
+#include <LLGL/Container/Vector.h>
+#include <LLGL/Container/String.h>
 
 
 // namespace LLGL {
@@ -23,7 +23,7 @@ extern CommandQueue* g_CurrentCmdQueue;
 
 static int gl_CurrentRenderSystemID = 0;
 static RenderSystem* g_CurrentRenderSystem = NULL;
-static std::vector<RenderSystemPtr> g_RenderSystems;
+static vector<RenderSystemPtr> g_RenderSystems;
 
 #define LLGL_ASSERT_RENDER_SYSTEM() \
     LLGL_ASSERT_PTR(g_CurrentRenderSystem)
@@ -121,7 +121,7 @@ LLGL_C_EXPORT const char* llglGetRendererName()
 
 struct RendererInfoC99Wrapper
 {
-    std::vector<const char*> extensionNames;
+    vector<const char*> extensionNames;
 };
 
 static void ConvertRendererInfo(RendererInfoC99Wrapper& wrapper, LLGLRendererInfo& dst, const RendererInfo& src)
@@ -148,8 +148,8 @@ LLGL_C_EXPORT void llglGetRendererInfo(LLGLRendererInfo* outInfo)
 
 struct RenderingCapabilitiesC99Wrapper
 {
-    std::vector<LLGLShadingLanguage>    shadingLanguages;
-    std::vector<LLGLFormat>             textureFormats;
+    vector<LLGLShadingLanguage>    shadingLanguages;
+    vector<LLGLFormat>             textureFormats;
 };
 
 static void ConvertRenderingCaps(RenderingCapabilitiesC99Wrapper& wrapper, LLGLRenderingCapabilities& dst, const RenderingCapabilities& src)

--- a/wrapper/C99/C99RenderingDebugger.cpp
+++ b/wrapper/C99/C99RenderingDebugger.cpp
@@ -50,7 +50,7 @@ LLGL_C_EXPORT void llglFlushDebuggerProfile(LLGLRenderingDebugger debugger, LLGL
     LLGL_ASSERT_PTR(outFrameProfile);
 
     static thread_local FrameProfile internalFrameProfile;
-    static thread_local std::vector<LLGLProfileTimeRecord> internalProfileTimeRecords;
+    static thread_local vector<LLGLProfileTimeRecord> internalProfileTimeRecords;
     LLGL_PTR(RenderingDebugger, debugger)->FlushProfile(&internalFrameProfile);
 
     static_assert(

--- a/wrapper/C99/C99Shader.cpp
+++ b/wrapper/C99/C99Shader.cpp
@@ -9,8 +9,8 @@
 #include <LLGL-C/Shader.h>
 #include <LLGL/Utils/ForRange.h>
 #include "C99Internal.h"
-#include <vector>
-#include <string>
+#include <LLGL/Container/Vector.h>
+#include <LLGL/Container/String.h>
 
 
 // namespace LLGL {
@@ -20,12 +20,12 @@ using namespace LLGL;
 
 struct ShaderReflectionC99Wrapper
 {
-    std::vector<LLGLShaderResourceReflection>   resources;
-    std::vector<LLGLUniformDescriptor>          uniforms;
-    std::vector<std::string>                    names;
-    std::vector<LLGLVertexAttribute>            vertexInputAttribs;
-    std::vector<LLGLVertexAttribute>            vertexOutputAttribs;
-    std::vector<LLGLFragmentAttribute>          fragmentOutputAttribs;
+    vector<LLGLShaderResourceReflection>   resources;
+    vector<LLGLUniformDescriptor>          uniforms;
+    vector<string>                    names;
+    vector<LLGLVertexAttribute>            vertexInputAttribs;
+    vector<LLGLVertexAttribute>            vertexOutputAttribs;
+    vector<LLGLFragmentAttribute>          fragmentOutputAttribs;
 };
 
 LLGL_C_EXPORT LLGLReport llglGetShaderReport(LLGLShader shader)

--- a/wrapper/C99/C99Window.cpp
+++ b/wrapper/C99/C99Window.cpp
@@ -11,9 +11,9 @@
 #include "C99EventListenerContainer.h"
 #include "../sources/Core/CoreUtils.h"
 #include "../sources/Core/Exception.h"
-#include <vector>
-#include <string>
 #include <string.h>
+#include <LLGL/Container/Vector.h>
+#include <LLGL/Container/String.h>
 #include <algorithm>
 
 
@@ -103,7 +103,7 @@ using WindowEventListenerContainer = EventListenerContainer<InternalWindowEventL
 
 #undef LLGL_CALLBACK_WRAPPER
 
-static std::vector<std::unique_ptr<Window>> g_Windows;
+static vector<std::unique_ptr<Window>> g_Windows;
 static WindowEventListenerContainer         g_WindowEventListenerContainer;
 
 static void ConvertWindowDesc(WindowDescriptor& dst, const LLGLWindowDescriptor& src)
@@ -118,7 +118,7 @@ static void ConvertWindowDesc(WindowDescriptor& dst, const LLGLWindowDescriptor&
 
 static void ConvertWindowDesc(LLGLWindowDescriptor& dst, const WindowDescriptor& src)
 {
-    static thread_local std::string internalTitle;
+    static thread_local string internalTitle;
     internalTitle = src.title.c_str();
     dst.title               = internalTitle.c_str();
     dst.position            = { src.position.x, src.position.y };


### PR DESCRIPTION
Allow the replacement of STL use with for instance EASTL or anything else with the same interface.

Split all includes on differents files.

cf. LLGL/Container/...