### PR TITLE
Reorder Metal version checks

### DIFF
--- a/sources/Renderer/Metal/MTFeatureSet.mm
+++ b/sources/Renderer/Metal/MTFeatureSet.mm
@@ -21,23 +21,26 @@ namespace LLGL
 // Converts the specified Metal feature set into a fixed version number
 static int FeatureSetToVersion(MTLFeatureSet fset)
 {
-    #if MAC_OS_X_VERSION_MIN_REQUIRED >= MAC_OS_X_VERSION_10_11
-    if (fset >= MTLFeatureSet_macOS_GPUFamily1_v1)
-        return 101; // 1.1
-    #endif
-    #if MAC_OS_X_VERSION_MIN_REQUIRED >= MAC_OS_X_VERSION_10_12
-    if (fset >= MTLFeatureSet_macOS_GPUFamily1_v2)
-        return 102; // 1.2
-    #endif
-    #if MAC_OS_X_VERSION_MIN_REQUIRED >= MAC_OS_X_VERSION_10_13
-    if (fset >= MTLFeatureSet_macOS_GPUFamily1_v3)
-        return 103; // 1.3
-    #endif
     #if MAC_OS_X_VERSION_MIN_REQUIRED >= MAC_OS_X_VERSION_10_14
     if (fset >= MTLFeatureSet_macOS_GPUFamily1_v4)
         return 104; // 1.4
     if (fset >= MTLFeatureSet_macOS_GPUFamily2_v1)
         return 201; // 2.1
+    #endif
+
+    #if MAC_OS_X_VERSION_MIN_REQUIRED >= MAC_OS_X_VERSION_10_13
+    if (fset >= MTLFeatureSet_macOS_GPUFamily1_v3)
+        return 103; // 1.3
+    #endif
+
+    #if MAC_OS_X_VERSION_MIN_REQUIRED >= MAC_OS_X_VERSION_10_12
+    if (fset >= MTLFeatureSet_macOS_GPUFamily1_v2)
+        return 102; // 1.2
+    #endif
+
+    #if MAC_OS_X_VERSION_MIN_REQUIRED >= MAC_OS_X_VERSION_10_11
+    if (fset >= MTLFeatureSet_macOS_GPUFamily1_v1)
+        return 101; // 1.1
     #endif
     return 100; // 1.0
 }

--- a/sources/Renderer/Metal/MTFeatureSet.mm
+++ b/sources/Renderer/Metal/MTFeatureSet.mm
@@ -22,10 +22,10 @@ namespace LLGL
 static int FeatureSetToVersion(MTLFeatureSet fset)
 {
     #if MAC_OS_X_VERSION_MIN_REQUIRED >= MAC_OS_X_VERSION_10_14
-    if (fset >= MTLFeatureSet_macOS_GPUFamily1_v4)
-        return 104; // 1.4
     if (fset >= MTLFeatureSet_macOS_GPUFamily2_v1)
         return 201; // 2.1
+    if (fset >= MTLFeatureSet_macOS_GPUFamily1_v4)
+        return 104; // 1.4
     #endif
 
     #if MAC_OS_X_VERSION_MIN_REQUIRED >= MAC_OS_X_VERSION_10_13


### PR DESCRIPTION
This function always returns 101 because the check for that version goes first. Instead it should check higher versions first.