### PR TITLE
Use Metal's D24UNormS8UInt pixel format

### DIFF
--- a/sources/Renderer/Metal/MTTypes.mm
+++ b/sources/Renderer/Metal/MTTypes.mm
@@ -153,7 +153,7 @@ MTLPixelFormat ToMTLPixelFormat(const Format format)
         case Format::D16UNorm:          return MTLPixelFormatDepth16Unorm;
         #endif
         case Format::D32Float:          return MTLPixelFormatDepth32Float;
-        case Format::D24UNormS8UInt:    return MTLPixelFormatDepth32Float_Stencil8; // MTLPixelFormatDepth24Unorm_Stencil8 not supported?
+        case Format::D24UNormS8UInt:    return MTLPixelFormatDepth24Unorm_Stencil8;
         case Format::D32FloatS8X24UInt: return MTLPixelFormatDepth32Float_Stencil8;
 
         /* --- Block compression (BC) formats --- */

--- a/sources/Renderer/Metal/MTTypes.mm
+++ b/sources/Renderer/Metal/MTTypes.mm
@@ -153,7 +153,11 @@ MTLPixelFormat ToMTLPixelFormat(const Format format)
         case Format::D16UNorm:          return MTLPixelFormatDepth16Unorm;
         #endif
         case Format::D32Float:          return MTLPixelFormatDepth32Float;
+        #ifdef LLGL_OS_IOS
+        case Format::D24UNormS8UInt:    return MTLPixelFormatDepth32Float_Stencil8;
+        #else
         case Format::D24UNormS8UInt:    return MTLPixelFormatDepth24Unorm_Stencil8;
+        #endif
         case Format::D32FloatS8X24UInt: return MTLPixelFormatDepth32Float_Stencil8;
 
         /* --- Block compression (BC) formats --- */


### PR DESCRIPTION
When debugging with Xcode it complains about swap chain pixel format mismatch. That's because of the `ToMTLPixelFormat` function which returns wrong Metal pixel format for the `D24UNormS8UInt` format.

This PR associates LLGL's `D24UNormS8UInt` pixel format with Metal's `MTLPixelFormatDepth32Float_Stencil8` if target OS is not iOS