### PR TITLE
Remove explicit default operators and constructors

### DIFF
--- a/examples/Cpp/ExampleBase/FileUtils.h
+++ b/examples/Cpp/ExampleBase/FileUtils.h
@@ -27,9 +27,6 @@ class AssetReader
 
         AssetReader() = default;
 
-        AssetReader(AssetReader&&) = default;
-        AssetReader& operator = (AssetReader&&) = default;
-
         // Take ownership of the specified content to read an asset.
         AssetReader(std::vector<char>&& content);
 

--- a/include/LLGL/CommandBufferFlags.h
+++ b/include/LLGL/CommandBufferFlags.h
@@ -138,8 +138,6 @@ struct ClearFlags
 struct ClearValue
 {
     ClearValue() = default;
-    ClearValue(const ClearValue&) = default;
-    ClearValue& operator = (const ClearValue&) = default;
 
     //! Constructor for color, depth, and stencil values.
     inline ClearValue(const float color[4], float depth = 1.0f, std::uint32_t stencil = 0) :
@@ -193,8 +191,6 @@ struct ClearValue
 struct AttachmentClear
 {
     AttachmentClear() = default;
-    AttachmentClear(const AttachmentClear&) = default;
-    AttachmentClear& operator = (const AttachmentClear&) = default;
 
     //! Constructor for a color attachment clear command.
     inline AttachmentClear(const float color[4], std::uint32_t colorAttachment) :
@@ -252,8 +248,6 @@ struct AttachmentClear
 struct CommandBufferDescriptor
 {
     CommandBufferDescriptor() = default;
-    CommandBufferDescriptor(const CommandBufferDescriptor&) = default;
-    CommandBufferDescriptor& operator = (const CommandBufferDescriptor&) = default;
 
     //! Constructs the command buffer descriptor with the specified flags.
     inline CommandBufferDescriptor(long flags) :

--- a/include/LLGL/FragmentAttribute.h
+++ b/include/LLGL/FragmentAttribute.h
@@ -32,8 +32,6 @@ namespace LLGL
 struct FragmentAttribute
 {
     FragmentAttribute() = default;
-    FragmentAttribute(const FragmentAttribute&) = default;
-    FragmentAttribute& operator = (const FragmentAttribute&) = default;
 
     //! Constructor for minimal fragment attribute information.
     inline FragmentAttribute(StringLiteral name, std::uint32_t location = 0) :

--- a/include/LLGL/ImageFlags.h
+++ b/include/LLGL/ImageFlags.h
@@ -37,7 +37,6 @@ namespace LLGL
 struct MutableImageView
 {
     MutableImageView() = default;
-    MutableImageView(const MutableImageView&) = default;
 
     //! Constructor to initialize all attributes.
     inline MutableImageView(ImageFormat format, DataType dataType, void* data, std::size_t dataSize) :
@@ -73,7 +72,6 @@ The counterpart for reading a MIP-map from a hardware texture by writing to a de
 struct ImageView
 {
     ImageView() = default;
-    ImageView(const ImageView&) = default;
 
     //! Constructor to initialize all attributes.
     inline ImageView(ImageFormat format, DataType dataType, const void* data, std::size_t dataSize, std::uint32_t rowStride = 0, std::uint32_t layerStride = 0) :
@@ -125,7 +123,6 @@ struct ImageView
 struct LLGL_DEPRECATED("LLGL::SrcImageDescriptor is deprecated since 0.04b; Use LLGL::ImageView instead!", "ImageView") SrcImageDescriptor
 {
     SrcImageDescriptor() = default;
-    SrcImageDescriptor(const SrcImageDescriptor&) = default;
 
     inline SrcImageDescriptor(ImageFormat format, DataType dataType, const void* data, std::size_t dataSize) :
         format   { format   },
@@ -164,7 +161,6 @@ struct LLGL_DEPRECATED("LLGL::SrcImageDescriptor is deprecated since 0.04b; Use 
 struct LLGL_DEPRECATED("LLGL::DstImageDescriptor is deprecated since 0.04b; Use LLGL::MutableImageView instead!", "MutableImageView") DstImageDescriptor
 {
     DstImageDescriptor() = default;
-    DstImageDescriptor(const DstImageDescriptor&) = default;
 
     inline DstImageDescriptor(ImageFormat format, DataType dataType, void* data, std::size_t dataSize) :
         format   { format   },

--- a/include/LLGL/Log.h
+++ b/include/LLGL/Log.h
@@ -163,8 +163,6 @@ struct ColorFlags
 struct ColorCodes
 {
     ColorCodes() = default;
-    ColorCodes(const ColorCodes&) = default;
-    ColorCodes& operator = (const ColorCodes&) = default;
 
     //! Initializes only the text flags.
     inline ColorCodes(long textFlags) :

--- a/include/LLGL/PipelineLayoutFlags.h
+++ b/include/LLGL/PipelineLayoutFlags.h
@@ -133,7 +133,6 @@ enum class UniformType
 struct BindingSlot
 {
     BindingSlot() = default;
-    BindingSlot(const BindingSlot&) = default;
 
     //! Constructs the binding slot with an index and an optional set (for Vulkan).
     inline BindingSlot(std::uint32_t index, std::uint32_t set = 0) :
@@ -175,7 +174,6 @@ struct BindingSlot
 struct BindingDescriptor
 {
     BindingDescriptor() = default;
-    BindingDescriptor(const BindingDescriptor&) = default;
 
     //! Constructors with all primary attributes and a default value for a uniform array.
     inline BindingDescriptor(
@@ -263,7 +261,6 @@ This is the equivalent of a static sampler in a root signature in Direct3D 12.
 struct StaticSamplerDescriptor
 {
     StaticSamplerDescriptor() = default;
-    StaticSamplerDescriptor(const StaticSamplerDescriptor&) = default;
 
     //! Initializes the static sampler with stage flags, binding slot, and sampler state.
     inline StaticSamplerDescriptor(
@@ -332,7 +329,6 @@ struct StaticSamplerDescriptor
 struct UniformDescriptor
 {
     UniformDescriptor() = default;
-    UniformDescriptor(const UniformDescriptor&) = default;
 
     //! Initializes the uniform descriptor with a name, type, and optional array size.
     inline UniformDescriptor(

--- a/include/LLGL/PipelineStateFlags.h
+++ b/include/LLGL/PipelineStateFlags.h
@@ -301,7 +301,6 @@ struct ColorMaskFlags
 struct Viewport
 {
     Viewport() = default;
-    Viewport(const Viewport&) = default;
 
     //! Viewport constructor with default depth range of [0, 1].
     inline Viewport(float x, float y, float width, float height) :
@@ -400,7 +399,6 @@ struct Viewport
 struct Scissor
 {
     Scissor() = default;
-    Scissor(const Scissor&) = default;
 
     //! Scissor constructor with parameters for all attributes.
     inline Scissor(std::int32_t x, std::int32_t y, std::int32_t width, std::int32_t height) :

--- a/include/LLGL/RenderPassFlags.h
+++ b/include/LLGL/RenderPassFlags.h
@@ -66,7 +66,6 @@ enum class AttachmentStoreOp
 struct AttachmentFormatDescriptor
 {
     AttachmentFormatDescriptor() = default;
-    AttachmentFormatDescriptor(const AttachmentFormatDescriptor&) = default;
 
     //! Constructor to initialize the format and optionally the load and store operations.
     inline AttachmentFormatDescriptor(

--- a/include/LLGL/RenderSystemFlags.h
+++ b/include/LLGL/RenderSystemFlags.h
@@ -321,8 +321,6 @@ struct RendererInfo
 struct RenderSystemDescriptor
 {
     RenderSystemDescriptor() = default;
-    RenderSystemDescriptor(const RenderSystemDescriptor&) = default;
-    RenderSystemDescriptor& operator = (const RenderSystemDescriptor&) = default;
 
     //! Constructor to initialize the descriptor with the module name from an std::string.
     inline RenderSystemDescriptor(const std::string& moduleName) :

--- a/include/LLGL/RenderTargetFlags.h
+++ b/include/LLGL/RenderTargetFlags.h
@@ -29,7 +29,6 @@ namespace LLGL
 struct AttachmentDescriptor
 {
     AttachmentDescriptor() = default;
-    AttachmentDescriptor(const AttachmentDescriptor&) = default;
 
     //! Constructor for the specified depth-, or stencil attachment.
     inline AttachmentDescriptor(Format format) :

--- a/include/LLGL/RenderingDebugger.h
+++ b/include/LLGL/RenderingDebugger.h
@@ -133,8 +133,6 @@ class LLGL_EXPORT RenderingDebugger
             public:
 
                 Message() = default;
-                Message(const Message&) = default;
-                Message& operator = (const Message&) = default;
 
                 //! Initializes the message with text, source, and group name information.
                 Message(const StringView& text, const StringView& source, const StringView& groupName);

--- a/include/LLGL/ShaderFlags.h
+++ b/include/LLGL/ShaderFlags.h
@@ -208,8 +208,6 @@ struct StageFlags
 struct ShaderMacro
 {
     ShaderMacro() = default;
-    ShaderMacro(const ShaderMacro&) = default;
-    ShaderMacro& operator = (const ShaderMacro&) = default;
 
     //! Constructor to initialize the shader macro with a name and an optional body definition.
     inline ShaderMacro(const char* name, const char* definition = nullptr) :
@@ -295,9 +293,6 @@ LLGL_DEPRECATED_IGNORE_PUSH()
 struct ShaderDescriptor
 {
     ShaderDescriptor() = default;
-
-    ShaderDescriptor(const ShaderDescriptor&) = default;
-    ShaderDescriptor& operator = (const ShaderDescriptor&) = default;
 
     //! Constructor to initialize the shader descriptor with a source filename.
     inline ShaderDescriptor(const ShaderType type, const char* source) :

--- a/include/LLGL/TextureFlags.h
+++ b/include/LLGL/TextureFlags.h
@@ -120,7 +120,6 @@ struct TextureSwizzleRGBA
 struct TextureSubresource
 {
     TextureSubresource() = default;
-    TextureSubresource(const TextureSubresource&) = default;
 
     //! Constructor to initialize base MIP-map level and base array layer only.
     inline TextureSubresource(std::uint32_t baseArrayLayer, std::uint32_t baseMipLevel) :
@@ -176,7 +175,6 @@ struct TextureSubresource
 struct TextureLocation
 {
     TextureLocation() = default;
-    TextureLocation(const TextureLocation&) = default;
 
     //! Constructor to initialize all attributes.
     inline TextureLocation(const Offset3D& offset, std::uint32_t arrayLayer = 0, std::uint32_t mipLevel = 0) :
@@ -220,7 +218,6 @@ struct TextureLocation
 struct TextureRegion
 {
     TextureRegion() = default;
-    TextureRegion(const TextureRegion&) = default;
 
     //! Constructor to initialize offset and extent only.
     inline TextureRegion(const Offset3D& offset, const Extent3D& extent) :

--- a/include/LLGL/VertexAttribute.h
+++ b/include/LLGL/VertexAttribute.h
@@ -37,8 +37,6 @@ namespace LLGL
 struct LLGL_EXPORT VertexAttribute
 {
     VertexAttribute() = default;
-    VertexAttribute(const VertexAttribute&) = default;
-    VertexAttribute& operator = (const VertexAttribute&) = default;
 
     //! Constructor for minimal vertex attribute information and system value semantics, e.g. \c SV_VertexID (HLSL) or \c gl_VertexID (GLSL).
     VertexAttribute(

--- a/sources/Core/ByteBufferIterator.h
+++ b/sources/Core/ByteBufferIterator.h
@@ -20,8 +20,6 @@ class ByteBufferIterator
     public:
 
         ByteBufferIterator() = default;
-        ByteBufferIterator(const ByteBufferIterator&) = default;
-        ByteBufferIterator& operator = (const ByteBufferIterator&) = default;
 
         // Initializes the byte buffer.
         inline ByteBufferIterator(char* byteBuffer) :
@@ -66,8 +64,6 @@ class ByteBufferConstIterator
     public:
 
         ByteBufferConstIterator() = default;
-        ByteBufferConstIterator(const ByteBufferConstIterator&) = default;
-        ByteBufferConstIterator& operator = (const ByteBufferConstIterator&) = default;
 
         // Initializes the byte buffer.
         inline ByteBufferConstIterator(const char* byteBuffer) :

--- a/sources/Core/FieldIterator.h
+++ b/sources/Core/FieldIterator.h
@@ -32,8 +32,6 @@ class BasicFieldRangeIterator
     public:
 
         BasicFieldRangeIterator() = default;
-        BasicFieldRangeIterator(const BasicFieldRangeIterator&) = default;
-        BasicFieldRangeIterator& operator = (const BasicFieldRangeIterator&) = default;
 
         BasicFieldRangeIterator(pointer first, size_type count) :
             ptr_    { first         },

--- a/sources/Core/Log.cpp
+++ b/sources/Core/Log.cpp
@@ -32,8 +32,6 @@ namespace Log
 struct LogListener
 {
     LogListener() = default;
-    LogListener(const LogListener&) = default;
-    LogListener& operator = (const LogListener&) = default;
 
     inline LogListener(const ReportCallback& callback, void* userData = nullptr) :
         callback { callback },

--- a/sources/Renderer/Direct3D12/Shader/D3D12RootParameter.h
+++ b/sources/Renderer/Direct3D12/Shader/D3D12RootParameter.h
@@ -29,9 +29,6 @@ class D3D12RootParameter
         D3D12RootParameter() = default;
         D3D12RootParameter(D3D12_ROOT_PARAMETER* managedRootParam);
 
-        D3D12RootParameter(const D3D12RootParameter&) = default;
-        D3D12RootParameter& operator = (const D3D12RootParameter&) = default;
-
         void InitAsConstants(const D3D12_ROOT_CONSTANTS& rootConstants, D3D12_SHADER_VISIBILITY visibility = D3D12_SHADER_VISIBILITY_ALL);
         void InitAsConstants(UINT shaderRegister, UINT num32BitValues, D3D12_SHADER_VISIBILITY visibility = D3D12_SHADER_VISIBILITY_ALL);
         void InitAsDescriptor(D3D12_ROOT_PARAMETER_TYPE paramType, UINT shaderRegister, UINT registerSpace = 0, D3D12_SHADER_VISIBILITY visibility = D3D12_SHADER_VISIBILITY_ALL);

--- a/sources/Renderer/Direct3D12/Shader/D3D12RootSignature.h
+++ b/sources/Renderer/Direct3D12/Shader/D3D12RootSignature.h
@@ -26,9 +26,6 @@ class D3D12RootSignature
 
         D3D12RootSignature() = default;
 
-        D3D12RootSignature(const D3D12RootSignature&) = default;
-        D3D12RootSignature& operator = (const D3D12RootSignature&) = default;
-
         void Clear();
         void Reset(UINT maxNumRootParamters, UINT maxNumStaticSamplers);
         void ResetAndAlloc(UINT maxNumRootParamters, UINT maxNumStaticSamplers);

--- a/sources/Renderer/OpenGL/RenderState/GLBlendState.h
+++ b/sources/Renderer/OpenGL/RenderState/GLBlendState.h
@@ -31,8 +31,6 @@ class GLBlendState
     public:
 
         GLBlendState() = default;
-        GLBlendState(const GLBlendState&) = default;
-        GLBlendState& operator = (const GLBlendState&) = default;
 
         GLBlendState(const BlendDescriptor& desc, std::uint32_t numColorAttachments);
 

--- a/sources/Renderer/OpenGL/RenderState/GLDepthStencilState.h
+++ b/sources/Renderer/OpenGL/RenderState/GLDepthStencilState.h
@@ -30,8 +30,6 @@ class GLDepthStencilState
     public:
 
         GLDepthStencilState() = default;
-        GLDepthStencilState(const GLDepthStencilState&) = default;
-        GLDepthStencilState& operator = (const GLDepthStencilState&) = default;
 
         GLDepthStencilState(const DepthDescriptor& depthDesc, const StencilDescriptor& stencilDesc);
 

--- a/sources/Renderer/OpenGL/RenderState/GLRasterizerState.h
+++ b/sources/Renderer/OpenGL/RenderState/GLRasterizerState.h
@@ -31,8 +31,6 @@ class GLRasterizerState
     public:
 
         GLRasterizerState() = default;
-        GLRasterizerState(const GLRasterizerState&) = default;
-        GLRasterizerState& operator = (const GLRasterizerState&) = default;
 
         GLRasterizerState(const RasterizerDescriptor& desc);
 

--- a/sources/Renderer/OpenGL/Shader/GLShaderBindingLayout.h
+++ b/sources/Renderer/OpenGL/Shader/GLShaderBindingLayout.h
@@ -34,8 +34,6 @@ class GLShaderBindingLayout
     public:
 
         GLShaderBindingLayout() = default;
-        GLShaderBindingLayout(const GLShaderBindingLayout&) = default;
-        GLShaderBindingLayout& operator = (const GLShaderBindingLayout&) = default;
 
         GLShaderBindingLayout(const GLPipelineLayout& pipelineLayout);
 

--- a/sources/Renderer/SPIRV/SpirvInstruction.h
+++ b/sources/Renderer/SPIRV/SpirvInstruction.h
@@ -21,7 +21,6 @@ namespace LLGL
 struct SpirvInstruction
 {
     SpirvInstruction() = default;
-    SpirvInstruction(const SpirvInstruction&) = default;
 
     SpirvInstruction(spv::Op opcode, spv::Id type = 0, spv::Id result = 0);
     SpirvInstruction(spv::Op opcode, spv::Id type, spv::Id result, std::uint32_t numOperands, const spv::Id* operands);

--- a/sources/Renderer/SPIRV/SpirvIterator.h
+++ b/sources/Renderer/SPIRV/SpirvIterator.h
@@ -57,8 +57,6 @@ class BasicSpirvForwardIterator
     public:
 
         BasicSpirvForwardIterator() = default;
-        BasicSpirvForwardIterator(const BasicSpirvForwardIterator&) = default;
-        BasicSpirvForwardIterator& operator = (const BasicSpirvForwardIterator&) = default;
 
         BasicSpirvForwardIterator(pointer ptr) :
             ptr_ { ptr }

--- a/sources/Renderer/SPIRV/SpirvModule.h
+++ b/sources/Renderer/SPIRV/SpirvModule.h
@@ -32,8 +32,6 @@ class SpirvModule
     public:
 
         SpirvModule() = default;
-        SpirvModule(SpirvModule&&) = default;
-        SpirvModule& operator = (SpirvModule&&) = default;
 
         SpirvModule(std::vector<value_type>&& data);
         SpirvModule(const void* data, size_type size);
@@ -110,10 +108,6 @@ class SpirvModuleView
     public:
 
         SpirvModuleView() = default;
-        SpirvModuleView(const SpirvModuleView&) = default;
-        SpirvModuleView& operator = (const SpirvModuleView&) = default;
-        SpirvModuleView(SpirvModuleView&&) = default;
-        SpirvModuleView& operator = (SpirvModuleView&&) = default;
 
         SpirvModuleView(const ArrayView<value_type>& words);
         SpirvModuleView(const void* data, std::size_t size);

--- a/sources/Renderer/VirtualCommandBuffer.h
+++ b/sources/Renderer/VirtualCommandBuffer.h
@@ -79,8 +79,6 @@ class VirtualCommandBuffer
             public:
 
                 ChunkIterator() = default;
-                ChunkIterator(const ChunkIterator&) = default;
-                ChunkIterator& operator = (const ChunkIterator&) = default;
 
             public:
 

--- a/sources/Renderer/Vulkan/RenderState/VKResourceHeap.h
+++ b/sources/Renderer/Vulkan/RenderState/VKResourceHeap.h
@@ -98,9 +98,6 @@ class VKResourceHeap final : public ResourceHeap
             }
             #endif // /VK_USE_64_BIT_PTR_DEFINES
 
-            VKBarrierResource(const VKBarrierResource&) = default;
-            VKBarrierResource& operator = (VKBarrierResource&&) = default;
-
             VkBuffer    buffer;
             VkImage     image;
         };

--- a/tests/Testbed/TestbedContext.h
+++ b/tests/Testbed/TestbedContext.h
@@ -280,8 +280,6 @@ class TestbedContext
         struct DiffResult
         {
             DiffResult() = default;
-            DiffResult(const DiffResult&) = default;
-            DiffResult& operator = (const DiffResult&) = default;
 
             DiffResult(DiffErrors error);
             explicit DiffResult(int threshold, unsigned tolerance = 0);


### PR DESCRIPTION
I removed some more explicit default operators and constructors as a follow-up for https://github.com/LukasBanana/LLGL/commit/6f3d13fa4d07c64ad3d357d1740e27b3414daf43