### PR TITLE
fix "unformSize" caculation error  

### DIFF
--- a/sources/Renderer/OpenGL/Command/GLDeferredCommandBuffer.cpp
+++ b/sources/Renderer/OpenGL/Command/GLDeferredCommandBuffer.cpp
@@ -711,7 +711,7 @@ void GLDeferredCommandBuffer::SetUniforms(std::uint32_t first, const void* data,
 
         /* Allocate GL command and copy data buffer */
         const auto& uniform = uniformMap[first];
-        const std::uint32_t uniformSize = uniform.wordSize * 4;
+        const std::uint32_t uniformSize = uniform.count * uniform.wordSize * 4;
         auto cmd = AllocCommand<GLCmdSetUniform>(GLOpcodeSetUniform, uniformSize);
         {
             cmd->program    = boundShaderPipeline->GetID(); //TODO: must distinguish between GLShaderProgram and GLProgramPipeline
@@ -721,7 +721,7 @@ void GLDeferredCommandBuffer::SetUniforms(std::uint32_t first, const void* data,
             cmd->size       = static_cast<GLsizeiptr>(uniformSize);
             ::memcpy(cmd + 1, words, uniformSize);
         }
-        words += uniform.wordSize;
+        words += uniform.count * uniform.wordSize;
     }
 }
 

--- a/sources/Renderer/OpenGL/Command/GLImmediateCommandBuffer.cpp
+++ b/sources/Renderer/OpenGL/Command/GLImmediateCommandBuffer.cpp
@@ -616,7 +616,7 @@ void GLImmediateCommandBuffer::SetUniforms(std::uint32_t first, const void* data
         const auto& uniform = uniformMap[first];
         GLSetUniform(uniform.type, uniform.location, uniform.count, words);
 
-        words += uniform.wordSize;
+        words += uniform.count * uniform.wordSize;
     }
 }
 


### PR DESCRIPTION
opengl backend
when there are uniform arrays in shader script，uniform.count will not be 1.
see
`GLImmediateCommandBuffer::SetUniforms(...)` and `GLDeferredCommandBuffer::SetUniforms(...)`