### PR TITLE
[Vulkan] Add CMake option to disable GPU assisted validation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -913,10 +913,6 @@ if(LLGL_VK_ENABLE_SPIRV_REFLECT)
     message(STATUS "Including Submodule: SPIRV-Headers")
 endif()
 
-if(LLGL_VK_ENABLE_GPU_ASSISTED_VALIDATION)
-    message(STATUS "Enable Vulkan GPU assisted validation")
-endif()
-
 if(NOT "${SUMMARY_FLAGS}" STREQUAL "")
     message(STATUS "Options: ${SUMMARY_FLAGS}")
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -913,6 +913,10 @@ if(LLGL_VK_ENABLE_SPIRV_REFLECT)
     message(STATUS "Including Submodule: SPIRV-Headers")
 endif()
 
+if(LLGL_VK_ENABLE_GPU_ASSISTED_VALIDATION)
+    message(STATUS "Enable Vulkan GPU assisted validation")
+endif()
+
 if(NOT "${SUMMARY_FLAGS}" STREQUAL "")
     message(STATUS "Options: ${SUMMARY_FLAGS}")
 endif()

--- a/sources/Renderer/Vulkan/CMakeLists.txt
+++ b/sources/Renderer/Vulkan/CMakeLists.txt
@@ -16,10 +16,15 @@ project(LLGL_Vulkan)
 
 if(NOT APPLE)
     option(LLGL_VK_ENABLE_SPIRV_REFLECT "Enable shader reflection of SPIR-V modules (requires the SPIRV submodule)" OFF)
+    option(LLGL_VK_ENABLE_GPU_ASSISTED_VALIDATION "Enable Vulkan GPU assisted validation" ON)
 endif()
 
 if(LLGL_VK_ENABLE_SPIRV_REFLECT)
     ADD_DEFINE(LLGL_VK_ENABLE_SPIRV_REFLECT)
+endif()
+
+if(LLGL_VK_ENABLE_GPU_ASSISTED_VALIDATION)
+    ADD_DEFINE(LLGL_VK_ENABLE_GPU_ASSISTED_VALIDATION)
 endif()
 
 

--- a/sources/Renderer/Vulkan/VKRenderSystem.cpp
+++ b/sources/Renderer/Vulkan/VKRenderSystem.cpp
@@ -892,6 +892,7 @@ void VKRenderSystem::CreateInstance(const RendererConfigurationVulkan* config)
 
     #if VK_EXT_validation_features
 
+    #if LLGL_VK_ENABLE_GPU_ASSISTED_VALIDATION
     const VkValidationFeatureEnableEXT validationFeaturesEnabled[] =
     {
         VK_VALIDATION_FEATURE_ENABLE_GPU_ASSISTED_EXT,
@@ -909,6 +910,7 @@ void VKRenderSystem::CreateInstance(const RendererConfigurationVulkan* config)
         validationFeatures.pEnabledValidationFeatures       = validationFeaturesEnabled;
         instanceInfo.pNext = &validationFeatures;
     }
+    #endif
 
     #endif // /VK_EXT_validation_features
 


### PR DESCRIPTION
# Description
As reported in https://github.com/LukasBanana/LLGL/issues/217, combining Vulkan CPU & GPU assisted validation can cause terrible performance. On occasions, one might want to enable CPU validation only and enable GPU validation on demand.

A new `LLGL_VK_ENABLE_GPU_ASSISTED_VALIDATION` CMake option allows one to disable GPU validation if needed. By default the option was kept to `ON` for retrocompatibility purposes.

On Apple platforms, the option is not available, which forcefully disables GPU assisted validation. I took the liberty to do so given there are reports of [issues with GPU-VA with MoltenVK](https://github.com/KhronosGroup/MoltenVK/issues/2492). Let me know if you feel like this is a mistake.

In the C++ side, 

# Testing done
As I'm not sure if there is a way to craft a CI test case for this change, so I performed manual testing.

Test cases:
* Enabled `LLGL_VK_ENABLE_GPU_ASSISTED_VALIDATION` (default behavior) and verified the GPU assisted validation was turned on
* Disabled `LLGL_VK_ENABLE_GPU_ASSISTED_VALIDATION` and verified the GPU assisted validation was turned off

Tested platform:
* OS: Windows 11 Professional 24H2
* Backend: Vulkan backend
* GPU: AMD RX 6950 XT

