### PR TITLE
Cast width and height variables to uint32_t

### DIFF
--- a/sources/Platform/Linux/Wayland/LinuxWindowWayland.cpp
+++ b/sources/Platform/Linux/Wayland/LinuxWindowWayland.cpp
@@ -30,7 +30,6 @@
 #include "protocols/viewporter-client-protocol.h"
 
 #include "LinuxWindowWayland.h"
-#include "LinuxDisplayWayland.h"
 #include "LinuxWaylandState.h"
 
 


### PR DESCRIPTION
This PR fixes a `clang` error:

```
Non-constant-expression cannot be narrowed from type 'int32_t' (aka 'int') to 'std::uint32_t' (aka 'unsigned int') in initializer list
```