### PR TITLE
Add ARM64 build support for Windows

### DIFF
--- a/BuildWin64.bat
+++ b/BuildWin64.bat
@@ -3,7 +3,8 @@
 set SOURCE_DIR=%~dp0
 set OUTPUT_DIR=build_win64
 set BUILD_TYPE=Release
-set BUILD_ARCH=x64
+REM Target architecture can be overridden, e.g. "set BUILD_ARCH=ARM64" before invoking this script
+if "%BUILD_ARCH%" == "" set BUILD_ARCH=x64
 set ENABLE_EXAMPLES=ON
 set ENABLE_TESTS=ON
 set STATIC_LIB=OFF

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,7 +27,10 @@ endif()
 
 # === Target platforms ===
 
-if("${CMAKE_GENERATOR_PLATFORM}" STREQUAL "x64")
+if("${CMAKE_GENERATOR_PLATFORM}" STREQUAL "x64" OR "${CMAKE_GENERATOR_PLATFORM}" STREQUAL "ARM64")
+    set(LLGL_BUILD_64BIT ON)
+elseif(CMAKE_SIZEOF_VOID_P EQUAL 8)
+    # Fallback for single-config generators (e.g. Ninja) that don't set CMAKE_GENERATOR_PLATFORM
     set(LLGL_BUILD_64BIT ON)
 else()
     set(LLGL_BUILD_64BIT OFF)
@@ -584,6 +587,9 @@ elseif(LLGL_MOBILE_PLATFORM)
         set(ARCH_ARM64 ON)
         set(SUMMARY_TARGET_ARCH "arm64")
     endif()
+elseif(WIN32 AND ("${CMAKE_GENERATOR_PLATFORM}" STREQUAL "ARM64" OR "${CMAKE_SYSTEM_PROCESSOR}" MATCHES "[Aa][Rr][Mm]64|[Aa][Aa][Rr][Cc][Hh]64"))
+    set(ARCH_ARM64 ON)
+    set(SUMMARY_TARGET_ARCH "arm64")
 elseif(APPLE OR LLGL_BUILD_64BIT)
     set(ARCH_AMD64 ON)
     set(SUMMARY_TARGET_ARCH "x86-64")

--- a/include/LLGL/Platform/Platform.h
+++ b/include/LLGL/Platform/Platform.h
@@ -42,7 +42,9 @@ Macros for CPU architecture
 see https://sourceforge.net/p/predef/wiki/Architectures/
 */
 
-#if defined _M_ARM || defined __arm__
+#if defined _M_ARM64 || defined __aarch64__
+#   define LLGL_ARCH_ARM64
+#elif defined _M_ARM || defined __arm__
 #   define LLGL_ARCH_ARM
 #elif defined _M_X64 || defined __amd64__
 #   define LLGL_ARCH_AMD64


### PR DESCRIPTION
Detect ARM64 in CMake via CMAKE_GENERATOR_PLATFORM / CMAKE_SYSTEM_PROCESSOR and set the 64-bit and architecture flags accordingly. Add a single-config (e.g. Ninja) fallback through CMAKE_SIZEOF_VOID_P, define LLGL_ARCH_ARM64 in Platform.h, and let BuildWin64.bat honor a pre-set BUILD_ARCH (e.g. ARM64) instead of hard-coding x64.