### PR TITLE
Handle the `StorageBuffer` storage class introduced in SPIR-V 1.3

### DIFF
--- a/sources/Renderer/SPIRV/SpirvReflect.cpp
+++ b/sources/Renderer/SPIRV/SpirvReflect.cpp
@@ -413,6 +413,7 @@ SpirvResult SpirvReflect::OpVariable(const Instr& instr)
     {
         case spv::StorageClassUniform:
         case spv::StorageClassUniformConstant:
+        case spv::StorageClassStorageBuffer:
         {
             auto& var = uniforms_[instr.result];
             {


### PR DESCRIPTION
Since version 1.3, SPIR-V has a separate storage class for SSBOs