### PR TITLE
Fix RenderDoc crashing on OpenGL backend

### DIFF
--- a/sources/Renderer/OpenGL/Platform/Win32/Win32GLContext.cpp
+++ b/sources/Renderer/OpenGL/Platform/Win32/Win32GLContext.cpp
@@ -277,6 +277,7 @@ void Win32GLContext::CreateWGLContext(Surface& surface, Win32GLContext* sharedCo
         {
             if (HGLRC extRenderContext = CreateExplicitWGLContext(hDC_, sharedContext))
             {
+                MakeWGLContextCurrent(hDC_, nullptr);
                 /* Use the extended profile and delete the old standard render context */
                 DeleteWGLContext(hGLRC_);
                 hGLRC_ = extRenderContext;


### PR DESCRIPTION
I examined RenderDoc's source code and figured out why it's crashing on switching contexts (#244).

So, the issue occurs in the `WrappedOpenGL::DeleteContext` function:
https://github.com/baldurk/renderdoc/blob/abd06a8d1c5a48bf3a84a628df9d776714215600/renderdoc/driver/gl/gl_driver.cpp#L1109-L1177

What is happening is that RenderDoc hooks into the `wglDeleteContext` function and wraps it with `WrappedOpenGL::DeleteContext`. Inside that function it releases its internal resources allocated for that context and does some other things.

And then still inside that function it deletes OpenGL buffers allocated during the lifetime of the context. And here is the problem: it calls `glDeleteBuffer` function while the new created OpenGL context is set as current, so it actually deletes not the buffers of the  context being deleted, but the ones of the current context (that we set when we created the swap chain).

So, I made a workaround: simply unset the current context before deleting some context. I tested it and it works correctly.

Fixes #244