### PR TITLE
Always set stride to 4 for byte address buffers

### DIFF
--- a/sources/Renderer/Direct3D11/Buffer/D3D11BufferWithRV.cpp
+++ b/sources/Renderer/Direct3D11/Buffer/D3D11BufferWithRV.cpp
@@ -54,7 +54,7 @@ D3D11BufferWithRV::D3D11BufferWithRV(ID3D11Device* device, const BufferDescripto
     uavFlags_     { GetUAVFlags(desc)         }
 {
     /* Determine stride size either for structured buffers or regular buffers */
-    const UINT stride = ((uavFlags_ & D3D11_BUFFER_UAV_FLAG_RAW) != 0 ? 4 : GetStorageBufferStride(desc));
+    const UINT stride = (IsByteAddressBuffer(desc) ? 4 : GetStorageBufferStride(desc));
 
     /* Create resource views (SRV and UAV) */
     const DXGI_FORMAT   format      = GetD3DResourceViewFormat(desc);


### PR DESCRIPTION
My app was crashing when I was using `ByteAddressBuffer`'s with an error from D3D11 indicating that the `NumElements` had an incorrect value. I found out that it was because LLGL was not setting the stride properly.

Currently, LLGL uses the stride of **4** bytes (which is correct for all `ByteAddressBuffer`'s) only for the ones that can be bound as `Storage`. Because it checks for the `D3D11_BUFFER_UAV_FLAG_RAW` flag which is set only if the `Storage` binding flag is set.

In my case the buffer was read-only so it was setting an incorrect stride and because of that `NumElements` was incorrect too.

I'm not an expert in Direct3D, so please correct me if I'm wrong, though the change that I made fixed the issue.