### PR TITLE
Fix resource heap validation and Null backend for array bindings

### DIFF
--- a/sources/Renderer/DebugLayer/DbgRenderSystem.cpp
+++ b/sources/Renderer/DebugLayer/DbgRenderSystem.cpp
@@ -12,6 +12,7 @@
 #include "../TextureUtils.h"
 #include "../CheckedCast.h"
 #include "../RenderTargetUtils.h"
+#include "../ResourceUtils.h"
 #include "../../Core/CoreUtils.h"
 #include "../../Core/StringUtils.h"
 #include <LLGL/ImageFlags.h>
@@ -1750,6 +1751,14 @@ void DbgRenderSystem::ValidateResourceHeapDesc(const ResourceHeapDescriptor& res
         const std::uint32_t numResourceViews    = (resourceHeapDesc.numResourceViews > 0 ? resourceHeapDesc.numResourceViews : static_cast<std::uint32_t>(initialResourceViews.size()));
         const std::size_t   numBindings         = bindings.size();
 
+        /*
+        A heap-binding with an array size greater than 1 contributes 'arraySize' descriptors to
+        each descriptor set, not one. The number of resource views must be a multiple of the
+        per-set descriptor count (the sum of the binding array sizes), not of the raw binding
+        count - otherwise valid heaps containing an array binding (e.g. a bindless texture
+        table) are wrongly rejected.
+        */
+        const std::size_t numDescriptorsPerSet = GetNumExpandedHeapDescriptors(bindings);
 
         if (numBindings == 0)
         {
@@ -1765,20 +1774,20 @@ void DbgRenderSystem::ValidateResourceHeapDesc(const ResourceHeapDescriptor& res
                 "cannot create resource heap with both 'numResourceViews' being zero and 'initialResourceViews' being empty"
             );
         }
-        else if (numResourceViews < numBindings)
+        else if (numResourceViews < numDescriptorsPerSet)
         {
             LLGL_DBG_ERROR(
                 ErrorType::InvalidArgument,
-                "cannot create resource heap with less resources (%u) than bindings in pipeline layout (%zu)",
-                numResourceViews, numBindings
+                "cannot create resource heap with less resources (%u) than descriptors per set in pipeline layout (%zu)",
+                numResourceViews, numDescriptorsPerSet
             );
         }
-        else if (numResourceViews % numBindings != 0)
+        else if (numResourceViews % numDescriptorsPerSet != 0)
         {
             LLGL_DBG_ERROR(
                 ErrorType::InvalidArgument,
-                "cannot create resource heap with number of resource views (%u) not being a multiple of bindings in pipeline layout (%zu)",
-                numResourceViews, numBindings
+                "cannot create resource heap with number of resource views (%u) not being a multiple of descriptors per set in pipeline layout (%zu)",
+                numResourceViews, numDescriptorsPerSet
             );
         }
         else if (!initialResourceViews.empty())
@@ -1786,10 +1795,9 @@ void DbgRenderSystem::ValidateResourceHeapDesc(const ResourceHeapDescriptor& res
             if (initialResourceViews.size() == numResourceViews)
             {
                 /* Validate all resource view descriptors against their respective binding descriptor, accounting for array bindings */
+                const DynamicVector<BindingDescriptor> expandedBindings = GetExpandedHeapDescriptors(bindings);
                 for_range(i, resourceHeapDesc.numResourceViews)
-                {
-                    ValidateResourceViewForBinding(initialResourceViews[i], bindings[i % bindings.size()]);
-                }
+                    ValidateResourceViewForBinding(initialResourceViews[i], expandedBindings[i % expandedBindings.size()]);
             }
             else
             {

--- a/sources/Renderer/Null/RenderState/NullResourceHeap.cpp
+++ b/sources/Renderer/Null/RenderState/NullResourceHeap.cpp
@@ -20,7 +20,13 @@ namespace LLGL
 static std::uint32_t GetNumPipelineLayoutBindings(const PipelineLayout* pipelineLayout)
 {
     auto pipelineLayoutNull = LLGL_CAST(const NullPipelineLayout*, pipelineLayout);
-    return std::max(1u, static_cast<std::uint32_t>(pipelineLayoutNull->desc.heapBindings.size()));
+    /*
+    Count the expanded descriptors, i.e. a binding with an array size greater than 1 contributes
+    'arraySize' descriptors per set, not one. This keeps the descriptor-per-set count consistent
+    with 'numResourceViews' (which counts each array element individually), so array bindings are
+    not wrongly rejected by GetNumResourceViewsOrThrow().
+    */
+    return std::max(1u, GetNumExpandedHeapDescriptors(pipelineLayoutNull->desc.heapBindings));
 }
 
 NullResourceHeap::NullResourceHeap(const ResourceHeapDescriptor& desc, const ArrayView<ResourceViewDescriptor>& initialResourceViews) :

--- a/sources/Renderer/ResourceUtils.cpp
+++ b/sources/Renderer/ResourceUtils.cpp
@@ -53,7 +53,7 @@ LLGL_EXPORT StaticSamplerBorderColor GetStaticSamplerBorderColor(const float (&c
     return StaticSamplerBorderColor::TransparentBlack;
 }
 
-static std::uint32_t GetNumExpandedHeapDescriptors(const ArrayView<BindingDescriptor>& bindingDescs)
+LLGL_EXPORT std::uint32_t GetNumExpandedHeapDescriptors(const ArrayView<BindingDescriptor>& bindingDescs)
 {
     std::uint32_t n = 0;
     for (const BindingDescriptor& binding : bindingDescs)

--- a/sources/Renderer/ResourceUtils.h
+++ b/sources/Renderer/ResourceUtils.h
@@ -72,6 +72,9 @@ LLGL_EXPORT std::uint32_t GetNumResourceViewsOrThrow(
 // Returns the enumeration value for a predefined static sampler border color.
 LLGL_EXPORT StaticSamplerBorderColor GetStaticSamplerBorderColor(const float (&color)[4]);
 
+// Returns the number of expanded heap-binding descriptors, i.e. the sum of all binding array sizes (arraySize of 0 counts as 1).
+LLGL_EXPORT std::uint32_t GetNumExpandedHeapDescriptors(const ArrayView<BindingDescriptor>& bindingDescs);
+
 // Returns a list of expanded heap-binding descriptors, i.e. all array resources have been flattened.
 LLGL_EXPORT DynamicVector<BindingDescriptor> GetExpandedHeapDescriptors(const ArrayView<BindingDescriptor>& bindingDescs);
 


### PR DESCRIPTION
A heap binding with arraySize > 1 contributes 'arraySize' descriptors per set, so 'numResourceViews' must be a multiple of the sum of binding array sizes, not the raw binding count. Previously valid heaps containing an array binding (e.g. a bindless texture table) were wrongly rejected.

- Export GetNumExpandedHeapDescriptors() for reuse across backends.
- DbgRenderSystem::ValidateResourceHeapDesc: validate against the expanded descriptors-per-set count, and map each resource view to its binding via GetExpandedHeapDescriptors() instead of a hand-rolled array walk.
- Null backend: count expanded descriptors when computing the descriptor set size.