### PR TITLE
Add missing BC6H/BC7 rows to the format attributes table

### DIFF
--- a/sources/Renderer/Format.cpp
+++ b/sources/Renderer/Format.cpp
@@ -170,7 +170,7 @@ static const FormatAttributes g_formatAttribs[] =
     {  64, 4, 4, 1, ImageFormat::Compressed,   DataType::Int8,      Mips | Dim2D_3D | DimCube | Compr | SNorm                  }, // BC4SNorm
     { 128, 4, 4, 2, ImageFormat::Compressed,   DataType::UInt8,     Mips | Dim2D_3D | DimCube | Compr | UNorm                  }, // BC5UNorm
     { 128, 4, 4, 2, ImageFormat::Compressed,   DataType::Int8,      Mips | Dim2D_3D | DimCube | Compr | SNorm                  }, // BC5SNorm
-    { 128, 4, 4, 3, ImageFormat::Compressed,   DataType::Float16,   Mips | Dim2D_3D | DimCube | Compr | SFloat                 }, // BC6HUFloat
+    { 128, 4, 4, 3, ImageFormat::Compressed,   DataType::Float16,   Mips | Dim2D_3D | DimCube | Compr | UFloat                 }, // BC6HUFloat
     { 128, 4, 4, 3, ImageFormat::Compressed,   DataType::Float16,   Mips | Dim2D_3D | DimCube | Compr | SFloat                 }, // BC6HSFloat
     { 128, 4, 4, 4, ImageFormat::Compressed,   DataType::UInt8,     Mips | Dim2D_3D | DimCube | Compr | UNorm                  }, // BC7UNorm
     { 128, 4, 4, 4, ImageFormat::Compressed,   DataType::UInt8,     Mips | Dim2D_3D | DimCube | Compr | UNorm | sRGB           }, // BC7UNorm_sRGB

--- a/sources/Renderer/Format.cpp
+++ b/sources/Renderer/Format.cpp
@@ -170,6 +170,10 @@ static const FormatAttributes g_formatAttribs[] =
     {  64, 4, 4, 1, ImageFormat::Compressed,   DataType::Int8,      Mips | Dim2D_3D | DimCube | Compr | SNorm                  }, // BC4SNorm
     { 128, 4, 4, 2, ImageFormat::Compressed,   DataType::UInt8,     Mips | Dim2D_3D | DimCube | Compr | UNorm                  }, // BC5UNorm
     { 128, 4, 4, 2, ImageFormat::Compressed,   DataType::Int8,      Mips | Dim2D_3D | DimCube | Compr | SNorm                  }, // BC5SNorm
+    { 128, 4, 4, 3, ImageFormat::Compressed,   DataType::Float16,   Mips | Dim2D_3D | DimCube | Compr | SFloat                 }, // BC6HUFloat
+    { 128, 4, 4, 3, ImageFormat::Compressed,   DataType::Float16,   Mips | Dim2D_3D | DimCube | Compr | SFloat                 }, // BC6HSFloat
+    { 128, 4, 4, 4, ImageFormat::Compressed,   DataType::UInt8,     Mips | Dim2D_3D | DimCube | Compr | UNorm                  }, // BC7UNorm
+    { 128, 4, 4, 4, ImageFormat::Compressed,   DataType::UInt8,     Mips | Dim2D_3D | DimCube | Compr | UNorm | sRGB           }, // BC7UNorm_sRGB
 
     /* --- Advanced scalable texture compression (ASTC) formats --- */
 //   bits  w  h  c  format                     dataType

--- a/sources/Renderer/TextureFlags.cpp
+++ b/sources/Renderer/TextureFlags.cpp
@@ -167,6 +167,34 @@ LLGL_EXPORT Extent3D GetMipExtent(const TextureDescriptor& textureDesc, std::uin
 
 LLGL_EXPORT std::size_t GetMemoryFootprint(const TextureType type, const Format format, const Extent3D& extent, const TextureSubresource& subresource)
 {
+    const FormatAttributes& formatAttribs = GetFormatAttribs(format);
+
+    if ((formatAttribs.flags & FormatFlags::IsCompressed) != 0)
+    {
+        /*
+        Block-compressed data is padded to whole blocks per row and column of every MIP level,
+        so the size must be accumulated per level with ceil-division block counts. A plain texel
+        count cannot express this: GetMemoryFootprint(format, numTexels) returns 0 whenever the
+        count is not a multiple of the block area (e.g. any power-of-two extent with 6x6 blocks,
+        or any MIP level smaller than one block).
+        */
+        if (formatAttribs.blockWidth == 0 || formatAttribs.blockHeight == 0)
+            return 0;
+
+        const Extent3D subresourceExtent = CalcTextureExtent(type, extent, subresource.numArrayLayers);
+
+        std::size_t numBlocks = 0;
+        for_range(mipLevel, subresource.numMipLevels)
+        {
+            const Extent3D mipExtent = GetMipExtent(type, subresourceExtent, subresource.baseMipLevel + mipLevel);
+            const std::size_t numBlocksX = (mipExtent.width  + formatAttribs.blockWidth  - 1) / formatAttribs.blockWidth;
+            const std::size_t numBlocksY = (mipExtent.height + formatAttribs.blockHeight - 1) / formatAttribs.blockHeight;
+            numBlocks += numBlocksX * numBlocksY * mipExtent.depth;
+        }
+
+        return (numBlocks * formatAttribs.bitSize) / 8;
+    }
+
     const std::uint32_t numTexels = NumMipTexels(type, extent, subresource);
     return GetMemoryFootprint(format, numTexels);
 }

--- a/sources/Renderer/Vulkan/VKRenderSystem.cpp
+++ b/sources/Renderer/Vulkan/VKRenderSystem.cpp
@@ -332,9 +332,10 @@ static VkImageLayout FindOptimalInitialVkImageLayout(Format format, long bindFla
 
 Texture* VKRenderSystem::CreateTexture(const TextureDescriptor& textureDesc, const ImageView* initialImage)
 {
-    /* Determine size of image for staging buffer */
+    /* Determine size of image for staging buffer (block-aware overload: the texel-count one
+       returns 0 for extents that don't tile the block size, e.g. pow2 extents with 6x6 blocks) */
     const std::uint32_t imageSize       = NumMipTexels(textureDesc, 0);
-    const std::size_t   initialDataSize = GetMemoryFootprint(textureDesc.format, imageSize);
+    const std::size_t   initialDataSize = GetMemoryFootprint(textureDesc.type, textureDesc.format, textureDesc.extent, TextureSubresource{ 0, textureDesc.arrayLayers, 0, 1 });
     const std::uint32_t bytesPerPixel   = static_cast<std::uint32_t>(GetMemoryFootprint(textureDesc.format, 1));
     const auto&         formatAttribs   = GetFormatAttribs(textureDesc.format);
     const Extent3D      extent          = CalcTextureExtent(textureDesc.type, textureDesc.extent, textureDesc.arrayLayers);
@@ -525,7 +526,9 @@ void VKRenderSystem::WriteTexture(Texture& texture, const TextureRegion& texture
     VkImage                     image           = textureVK.GetVkImage();
     const std::uint32_t         imageSize       = extent.width * extent.height * extent.depth;
     const void*                 imageData       = nullptr;
-    const VkDeviceSize          imageDataSize   = static_cast<VkDeviceSize>(GetMemoryFootprint(format, imageSize));
+    /* Block-aware size: the texel-count overload returns 0 for regions that don't tile the
+       block size (pow2 extents with 6x6 blocks, or MIP levels smaller than one block) */
+    const VkDeviceSize          imageDataSize   = static_cast<VkDeviceSize>(GetMemoryFootprint(textureVK.GetType(), format, textureRegion.extent, subresource));
     const std::uint32_t         bytesPerPixel   = static_cast<std::uint32_t>(GetMemoryFootprint(format, 1));
 
     /* Check if image data must be converted */
@@ -623,7 +626,8 @@ void VKRenderSystem::ReadTexture(Texture& texture, const TextureRegion& textureR
     }
     else
     {
-        stagingBufferSize = static_cast<VkDeviceSize>(GetMemoryFootprint(format, imageNumTexels));
+        /* Block-aware size (see WriteTexture) */
+        stagingBufferSize = static_cast<VkDeviceSize>(GetMemoryFootprint(textureVK.GetType(), format, textureRegion.extent, subresource));
     }
 
     /* Create staging buffer */

--- a/sources/Renderer/Vulkan/VKRenderSystem.cpp
+++ b/sources/Renderer/Vulkan/VKRenderSystem.cpp
@@ -527,8 +527,12 @@ void VKRenderSystem::WriteTexture(Texture& texture, const TextureRegion& texture
     const std::uint32_t         imageSize       = extent.width * extent.height * extent.depth;
     const void*                 imageData       = nullptr;
     /* Block-aware size: the texel-count overload returns 0 for regions that don't tile the
-       block size (pow2 extents with 6x6 blocks, or MIP levels smaller than one block) */
-    const VkDeviceSize          imageDataSize   = static_cast<VkDeviceSize>(GetMemoryFootprint(textureVK.GetType(), format, textureRegion.extent, subresource));
+       block size (pow2 extents with 6x6 blocks, or MIP levels smaller than one block).
+       NOTE: the extent-based overload treats its extent as the base (MIP 0) extent, but
+       textureRegion.extent is already resolved to the region's MIP level - so the MIP range
+       must be rebased to 0 or the size is scaled down a second time. */
+    const TextureSubresource    sizeSubresource { subresource.baseArrayLayer, subresource.numArrayLayers, 0, subresource.numMipLevels };
+    const VkDeviceSize          imageDataSize   = static_cast<VkDeviceSize>(GetMemoryFootprint(textureVK.GetType(), format, textureRegion.extent, sizeSubresource));
     const std::uint32_t         bytesPerPixel   = static_cast<std::uint32_t>(GetMemoryFootprint(format, 1));
 
     /* Check if image data must be converted */
@@ -626,8 +630,10 @@ void VKRenderSystem::ReadTexture(Texture& texture, const TextureRegion& textureR
     }
     else
     {
-        /* Block-aware size (see WriteTexture) */
-        stagingBufferSize = static_cast<VkDeviceSize>(GetMemoryFootprint(textureVK.GetType(), format, textureRegion.extent, subresource));
+        /* Block-aware size; MIP range rebased to 0 - textureRegion.extent is already the
+           region's MIP-level extent (see WriteTexture) */
+        const TextureSubresource sizeSubresource{ subresource.baseArrayLayer, subresource.numArrayLayers, 0, subresource.numMipLevels };
+        stagingBufferSize = static_cast<VkDeviceSize>(GetMemoryFootprint(textureVK.GetType(), format, textureRegion.extent, sizeSubresource));
     }
 
     /* Create staging buffer */


### PR DESCRIPTION
g_formatAttribs is indexed positionally by the Format enum, but the table jumped from BC5SNorm straight to ASTC4x4 while the enum declares BC6HUFloat, BC6HSFloat, BC7UNorm and BC7UNorm_sRGB in between.

Every format at or after ASTC4x4 therefore resolved to the wrong row, so GetFormatAttribs/GetMemoryFootprint reported incorrect block dimensions and bit sizes for all ASTC and ETC formats. BC7 and BC6H themselves were already mapped by every backend (Vulkan, D3D, GL, Metal) and reported by VKPhysicalDevice, so only the shared table was missing.

Table and enum are now 1:1 (115 active rows each).