### PR TITLE
Color output msaa

### DIFF
--- a/examples/Cpp/HelloOpenXR/Example.cpp
+++ b/examples/Cpp/HelloOpenXR/Example.cpp
@@ -63,7 +63,7 @@ class MyXRRenderer
 
     // When true, render both eyes in a single pass using multiview (VK_KHR_multiview / D3D12 view instancing)
     // instead of looping over per-eye swap-chains. Requested on the command line and only enabled if the active
-    // renderer reports RenderingFeatures::hasMultiView.
+    // renderer reports RenderingFeatures::hasMultiview.
     bool                            useMultiview    = false;
 
     LLGL::Buffer*                   vertexBuffer    = nullptr;
@@ -182,7 +182,7 @@ MyXRRenderer::MyXRRenderer(const char* rendererModule, bool requestMultiview)
     if (requestMultiview)
     {
         const LLGL::RenderingCapabilities& caps = renderer->GetRenderingCaps();
-        if (caps.features.hasMultiView && caps.limits.maxViews >= viewCount)
+        if (caps.features.hasMultiview && caps.limits.maxViews >= viewCount)
         {
             useMultiview = true;
             LLGL::Log::Printf("Multiview: enabled (single-pass stereo, %u views)\n", viewCount);

--- a/examples/Cpp/HelloOpenXR/Example.cpp
+++ b/examples/Cpp/HelloOpenXR/Example.cpp
@@ -250,10 +250,6 @@ void MyXRRenderer::CreateSwapChains()
     // swap-chain transparently falls back to a private depth texture that is not submitted.
     const LLGL::ArrayView<LLGL::Format> depthFormats = session->GetSupportedDepthFormats();
     const LLGL::Format depthFormat = (depthFormats.empty() ? LLGL::Format::D32Float : depthFormats[0]);
-    LLGL::Log::Printf(
-        "Depth submission: %s\n",
-        depthFormats.empty() ? "disabled (runtime does not support XR_KHR_composition_layer_depth)" : "enabled"
-    );
 
     // Clamp the requested sample count to what this renderer can provide. The swap-chain renders into its own
     // multi-sampled attachments and resolves into the runtime's images (which are always single-sampled, since
@@ -269,6 +265,16 @@ void MyXRRenderer::CreateSwapChains()
             sampleCount = 1;
     }
     LLGL::Log::Printf("Multi-sampling: %ux\n", sampleCount);
+
+    // Reported after the sample count is known, because it is not decided by the runtime alone: submitting depth
+    // needs XR_KHR_composition_layer_depth AND no multi-sampling (a multi-sampled depth attachment cannot be
+    // resolved into the runtime's single-sampled depth image), so with MSAA the swap-chain keeps depth private.
+    LLGL::Log::Printf(
+        "Depth submission: %s\n",
+        depthFormats.empty()  ? "disabled (runtime does not support XR_KHR_composition_layer_depth)" :
+        sampleCount > 1       ? "disabled (not available with multi-sampling)" :
+                                "enabled"
+    );
 
     // Requesting a depth-stencil format makes the swap-chain provision and manage the depth buffer and per-image
     // render targets internally (see XRSwapChain::GetRenderTarget).

--- a/examples/Cpp/HelloOpenXR/Example.cpp
+++ b/examples/Cpp/HelloOpenXR/Example.cpp
@@ -20,6 +20,7 @@
 #include <FileUtils.h>
 #include <LLGL/XR/XRSystem.h>
 #include <cstring>
+#include <cstdlib>
 
 /*
  * Helpers
@@ -66,6 +67,13 @@ class MyXRRenderer
     // renderer reports RenderingFeatures::hasMultiview.
     bool                            useMultiview    = false;
 
+    // Multi-sample count for the XR swap-chains; 1 disables MSAA. MSAA is the anti-aliasing method of
+    // choice in VR - edge shimmer is far more objectionable in a headset than on a monitor, and on the
+    // tile-based GPUs standalone headsets use the resolve happens in tile memory, so it costs much less
+    // than it would on a desktop GPU. Set from the command line / system property, then clamped in
+    // CreateSwapChains to what the renderer reports.
+    std::uint32_t                   sampleCount     = 4;
+
     LLGL::Buffer*                   vertexBuffer    = nullptr;
     LLGL::Buffer*                   indexBuffer     = nullptr;
     LLGL::Buffer*                   viewProjBuffer  = nullptr;
@@ -91,7 +99,8 @@ public:
 
     // Brings up the XR runtime, the render system, the session, and the swap-chains.
     // If requestMultiview is true and the renderer supports it, both eyes are rendered in a single pass.
-    MyXRRenderer(const char* rendererModule, bool requestMultiview);
+    // requestSampleCount selects multi-sampling (1 disables it); it is clamped to the renderer's limits.
+    MyXRRenderer(const char* rendererModule, bool requestMultiview, std::uint32_t requestSampleCount);
 
     ~MyXRRenderer();
 
@@ -124,8 +133,10 @@ private:
 
 };
 
-MyXRRenderer::MyXRRenderer(const char* rendererModule, bool requestMultiview)
+MyXRRenderer::MyXRRenderer(const char* rendererModule, bool requestMultiview, std::uint32_t requestSampleCount)
 {
+    sampleCount = (requestSampleCount > 0 ? requestSampleCount : 1);
+
     std::int32_t xrSystemDescFlags = 0;
 #if defined(_DEBUG)
     xrSystemDescFlags = LLGL::XRSystemFlags::DebugDevice;
@@ -244,6 +255,21 @@ void MyXRRenderer::CreateSwapChains()
         depthFormats.empty() ? "disabled (runtime does not support XR_KHR_composition_layer_depth)" : "enabled"
     );
 
+    // Clamp the requested sample count to what this renderer can provide. The swap-chain renders into its own
+    // multi-sampled attachments and resolves into the runtime's images (which are always single-sampled, since
+    // they belong to the compositor), so both the color and depth limits apply.
+    const LLGL::RenderingLimits& limits = renderer->GetRenderingCaps().limits;
+    {
+        std::uint32_t maxSamples = limits.maxColorBufferSamples;
+        if (limits.maxDepthBufferSamples < maxSamples)
+            maxSamples = limits.maxDepthBufferSamples;
+        if (maxSamples > 0 && sampleCount > maxSamples)
+            sampleCount = maxSamples;
+        if (sampleCount == 0)
+            sampleCount = 1;
+    }
+    LLGL::Log::Printf("Multi-sampling: %ux\n", sampleCount);
+
     // Requesting a depth-stencil format makes the swap-chain provision and manage the depth buffer and per-image
     // render targets internally (see XRSwapChain::GetRenderTarget).
     if (useMultiview)
@@ -255,6 +281,7 @@ void MyXRRenderer::CreateSwapChains()
         swapChainDesc.depthStencilFormat = depthFormat;
         swapChainDesc.resolution         = { viewConfigs[0].recommendedImageExtent.width, viewConfigs[0].recommendedImageExtent.height };
         swapChainDesc.arrayLayers        = viewCount;
+        swapChainDesc.sampleCount        = sampleCount;
 
         swapChains.resize(1);
         swapChains[0] = session->CreateSwapChain(swapChainDesc);
@@ -271,6 +298,7 @@ void MyXRRenderer::CreateSwapChains()
             swapChainDesc.format             = colorFormat;
             swapChainDesc.depthStencilFormat = depthFormat;
             swapChainDesc.resolution         = { viewConfigs[eye].recommendedImageExtent.width, viewConfigs[eye].recommendedImageExtent.height };
+            swapChainDesc.sampleCount        = sampleCount;
 
             swapChains[eye] = session->CreateSwapChain(swapChainDesc);
             if (swapChains[eye] == nullptr)
@@ -328,6 +356,10 @@ void MyXRRenderer::CreateResources()
     pipelineDesc.depth.compareOp        = LLGL::CompareOp::Less;
     pipelineDesc.rasterizer.cullMode    = LLGL::CullMode::Back;
     pipelineDesc.rasterizer.frontCCW    = true;
+    // Required whenever the swap-chains are multi-sampled: a PSO's sample count must match the render pass
+    // it is used with, and LLGL only takes it from the render pass when multi-sampling is enabled here -
+    // otherwise the PSO is built for a single sample and mismatches a multi-sampled pass.
+    pipelineDesc.rasterizer.multiSampleEnabled = (sampleCount > 1);
     // Vulkan needs the PSO to know the render pass it'll be used with. All XR render targets share
     // the same color/depth attachment formats, so any swap-chain's render pass is compatible.
     pipelineDesc.renderPass = swapChains.front()->GetRenderPass();
@@ -589,11 +621,11 @@ bool MyXRRenderer::RenderFrame()
  * Main function
  */
 
-static void RunHelloOpenXR(const char* rendererModule, bool requestMultiview)
+static void RunHelloOpenXR(const char* rendererModule, bool requestMultiview, std::uint32_t requestSampleCount)
 {
     LLGL::Log::Printf("Requesting renderer module: %s\n", rendererModule);
 
-    MyXRRenderer xrRenderer{ rendererModule, requestMultiview };
+    MyXRRenderer xrRenderer{ rendererModule, requestMultiview, requestSampleCount };
     xrRenderer.CreateResources();
 
     // Main loop: Surface::ProcessEvents drives the OS/Android application lifecycle, while
@@ -624,6 +656,23 @@ static bool AndroidRequestMultiview()
     return true; // default: request multiview (falls back to per-eye if unsupported)
 }
 
+// Reads the requested multi-sample count from the "debug.llgl.samples" system property, so MSAA can be
+// toggled on the headset without rebuilding (e.g. to A/B its cost, or to isolate a rendering problem):
+//   adb shell setprop debug.llgl.samples 1   # no multi-sampling
+//   adb shell setprop debug.llgl.samples 4   # 4x MSAA (also the default when the property is unset)
+// The property must be set before the app launches (it is read once at startup).
+static std::uint32_t AndroidRequestSampleCount()
+{
+    char value[PROP_VALUE_MAX] = {};
+    if (__system_property_get("debug.llgl.samples", value) > 0)
+    {
+        const int samples = std::atoi(value);
+        if (samples > 0)
+            return static_cast<std::uint32_t>(samples);
+    }
+    return 4; // default: 4x MSAA (clamped to the renderer's limits at swap-chain creation)
+}
+
 void android_main(android_app* state)
 {
     LLGL::Log::RegisterCallbackStd();
@@ -638,7 +687,11 @@ void android_main(android_app* state)
         // forced off via the debug.llgl.multiview system property (see AndroidRequestMultiview).
         const bool requestMultiview = AndroidRequestMultiview();
         LLGL::Log::Printf("Android multiview request: %s (debug.llgl.multiview)\n", requestMultiview ? "on" : "off (per-eye)");
-        RunHelloOpenXR("Vulkan", requestMultiview);
+
+        const std::uint32_t requestSampleCount = AndroidRequestSampleCount();
+        LLGL::Log::Printf("Android sample count request: %u (debug.llgl.samples)\n", requestSampleCount);
+
+        RunHelloOpenXR("Vulkan", requestMultiview, requestSampleCount);
     }
     catch (const std::exception& e)
     {
@@ -652,22 +705,30 @@ int main(int argc, char* argv[])
 {
     LLGL::Log::RegisterCallbackStd();
 
-    // Command line: an optional renderer module name and an optional "--multiview" (or "-mv") flag, in any order.
+    // Command line: an optional renderer module name, an optional "--multiview" (or "-mv") flag, and an
+    // optional "--samples=N", in any order.
     // The renderer module defaults to Vulkan. Supported XR backends: "Vulkan", "Direct3D11", "Direct3D12".
     // Multiview (single-pass stereo) is supported by Vulkan and Direct3D12; it falls back to per-eye otherwise.
+    // Multi-sampling defaults to 4x; "--samples=1" disables it. The count is clamped to the renderer's limits.
     const char* rendererModule = "Vulkan";
     bool requestMultiview = false;
+    std::uint32_t requestSampleCount = 4;
     for (int i = 1; i < argc; ++i)
     {
         if (std::strcmp(argv[i], "--multiview") == 0 || std::strcmp(argv[i], "-mv") == 0)
             requestMultiview = true;
+        else if (std::strncmp(argv[i], "--samples=", 10) == 0)
+        {
+            const int samples = std::atoi(argv[i] + 10);
+            requestSampleCount = (samples > 0 ? static_cast<std::uint32_t>(samples) : 1);
+        }
         else
             rendererModule = argv[i];
     }
 
     try
     {
-        RunHelloOpenXR(rendererModule, requestMultiview);
+        RunHelloOpenXR(rendererModule, requestMultiview, requestSampleCount);
     }
     catch (const std::exception& e)
     {

--- a/include/LLGL-C/LLGLWrapper.h
+++ b/include/LLGL-C/LLGLWrapper.h
@@ -1608,6 +1608,7 @@ typedef struct LLGLSwapChainDescriptor
 {
     const char*  debugName;   /* = NULL */
     LLGLExtent2D resolution;
+    LLGLFormat   format;      /* = LLGLFormatUndefined */
     int          colorBits;   /* = 32 */
     int          depthBits;   /* = 24 */
     int          stencilBits; /* = 8 */

--- a/include/LLGL-C/LLGLWrapper.h
+++ b/include/LLGL-C/LLGLWrapper.h
@@ -1558,12 +1558,16 @@ LLGLRenderSystemDescriptor;
 
 typedef struct LLGLRenderingCapabilities
 {
-    LLGLScreenOrigin           screenOrigin;        /* = LLGLScreenOriginUpperLeft */
-    LLGLClippingRange          clippingRange;       /* = LLGLClippingRangeZeroToOne */
-    size_t                     numShadingLanguages; /* = 0 */
-    const LLGLShadingLanguage* shadingLanguages;    /* = NULL */
-    size_t                     numTextureFormats;   /* = 0 */
-    const LLGLFormat*          textureFormats;      /* = NULL */
+    LLGLScreenOrigin           screenOrigin;                    /* = LLGLScreenOriginUpperLeft */
+    LLGLClippingRange          clippingRange;                   /* = LLGLClippingRangeZeroToOne */
+    size_t                     numShadingLanguages;             /* = 0 */
+    const LLGLShadingLanguage* shadingLanguages;                /* = NULL */
+    size_t                     numTextureFormats;               /* = 0 */
+    const LLGLFormat*          textureFormats;                  /* = NULL */
+    size_t                     numSwapChainColorFormats;        /* = 0 */
+    const LLGLFormat*          swapChainColorFormats;           /* = NULL */
+    size_t                     numSwapChainDepthStencilFormats; /* = 0 */
+    const LLGLFormat*          swapChainDepthStencilFormats;    /* = NULL */
     LLGLRenderingFeatures      features;
     LLGLRenderingLimits        limits;
 }
@@ -1606,16 +1610,17 @@ LLGLComputeShaderAttributes;
 
 typedef struct LLGLSwapChainDescriptor
 {
-    const char*  debugName;   /* = NULL */
+    const char*  debugName;          /* = NULL */
     LLGLExtent2D resolution;
-    LLGLFormat   format;      /* = LLGLFormatUndefined */
-    int          colorBits;   /* = 32 */
-    int          depthBits;   /* = 24 */
-    int          stencilBits; /* = 8 */
-    uint32_t     samples;     /* = 1 */
-    uint32_t     swapBuffers; /* = 2 */
-    bool         fullscreen;  /* = false */
-    bool         resizable;   /* = false */
+    LLGLFormat   colorFormat;        /* = LLGLFormatUndefined */
+    LLGLFormat   depthStencilFormat; /* = LLGLFormatUndefined */
+    int          colorBits;          /* = 32 */
+    int          depthBits;          /* = 24 */
+    int          stencilBits;        /* = 8 */
+    uint32_t     samples;            /* = 1 */
+    uint32_t     swapBuffers;        /* = 2 */
+    bool         fullscreen;         /* = false */
+    bool         resizable;          /* = false */
 }
 LLGLSwapChainDescriptor;
 

--- a/include/LLGL/RenderSystemFlags.h
+++ b/include/LLGL/RenderSystemFlags.h
@@ -929,6 +929,36 @@ struct RenderingCapabilities
     std::vector<Format>             textureFormats;
 
     /**
+    \brief Specifies the list of color formats a swap-chain color buffer can have.
+    \remarks This is the set of formats SwapChain::GetColorFormat can return, i.e. a subset of \c textureFormats,
+    since a swap-chain color buffer must also be presentable and not every renderable format can be scanned out
+    by the display hardware. Requesting a format from this list via SwapChainDescriptor::colorFormat is a preference,
+    not a guarantee: if the renderer cannot honor it, it falls back to its automatic selection.
+    Use SwapChain::GetColorFormat to determine the format that was actually used.
+    \note With Vulkan, final support also depends on the presentation surface, which is not known until a swap-chain
+    is created, so a format listed here may still be rejected by a particular surface.
+    \note With Direct3D 11, Direct3D 12, and OpenGL, SwapChainDescriptor::colorFormat is currently not honored at all
+    and the color buffer always uses the format the backend picks itself.
+    \see SwapChainDescriptor::colorFormat
+    \see SwapChain::GetColorFormat
+    */
+    std::vector<Format>             swapChainColorFormats;
+
+    /**
+    \brief Specifies the list of depth-stencil formats a swap-chain depth-stencil buffer can have.
+    \remarks This is the set of formats SwapChain::GetDepthStencilFormat can return and the set of formats that can be
+    requested via SwapChainDescriptor::depthStencilFormat, i.e. a subset of Format::D16UNorm, Format::D24UNormS8UInt,
+    Format::D32Float, and Format::D32FloatS8X24UInt. If a requested format is not in this list, the renderer falls back
+    to its automatic selection. Use SwapChain::GetDepthStencilFormat to determine the format that was actually used.
+    \note With OpenGL, the depth-stencil buffer belongs to the pixel format the windowing system selects, so a request
+    is only a hint for that selection and the driver commonly substitutes a different format. Only the format that can
+    be relied upon is reported here; SwapChain::GetDepthStencilFormat may still return another one.
+    \see SwapChainDescriptor::depthStencilFormat
+    \see SwapChain::GetDepthStencilFormat
+    */
+    std::vector<Format>             swapChainDepthStencilFormats;
+
+    /**
     \brief Specifies all supported hardware features.
     \remarks Especially with OpenGL these features can vary between different hardware and GL versions.
     */

--- a/include/LLGL/SwapChainFlags.h
+++ b/include/LLGL/SwapChainFlags.h
@@ -66,7 +66,7 @@ struct SwapChainDescriptor
     \remarks The final name of the native hardware resource is implementation defined.
     \see RenderSystemChild::SetDebugName
     */
-    const char*     debugName       = nullptr;
+    const char*     debugName           = nullptr;
 
     /**
     \brief Screen resolution (in pixels).
@@ -77,38 +77,54 @@ struct SwapChainDescriptor
 
     /**
     \brief Preferred color format for the swap-chain buffers. By default Format::Undefined.
-    \remarks If this is Format::Undefined, the renderer picks a format automatically (the default behavior).
+    \remarks If this is Format::Undefined, the renderer picks a format automatically from the deprecated \c colorBits field (the default behavior).
     Otherwise the renderer uses this format if the presentation surface supports it, and falls back to its
     automatic selection if it does not. This is primarily intended to request an sRGB format (e.g.
     Format::BGRA8UNorm_sRGB), so the hardware performs the linear-to-sRGB conversion on write.
     To determine the actual color format of a swap-chain, use the SwapChain::GetColorFormat function.
     \see SwapChain::GetColorFormat
     */
-    Format          format          = Format::Undefined;
+    Format          colorFormat         = Format::Undefined;
+
+    /**
+    \brief Preferred depth-stencil format for the swap-chain. By default Format::Undefined.
+    \remarks If this is Format::Undefined, the renderer picks a format automatically from the deprecated \c depthBits and \c stencilBits fields (the default behavior).
+    Otherwise this must be one of the depth-stencil formats, i.e. Format::D16UNorm, Format::D24UNormS8UInt, Format::D32Float, or Format::D32FloatS8X24UInt.
+    The renderer uses this format if the hardware supports it and falls back to its automatic selection if it does not.
+    To determine the actual depth-stencil format of a swap-chain, use the SwapChain::GetDepthStencilFormat function.
+    \see SwapChain::GetDepthStencilFormat
+    */
+    Format          depthStencilFormat  = Format::Undefined;
 
     /**
     \brief Number of bits for each pixel in the color buffer. Should be 24 or 32. By default 32.
     \remarks This is only a hint to the renderer and there is no guarantee which hardware format is finally used for the color buffer.
     To determine the actual color format of a swap-chain, use the SwapChain::GetColorFormat function.
+    \note This field is deprecated and ignored if \c colorFormat is not Format::Undefined; Use \c colorFormat instead!
+    \see colorFormat
     \see SwapChain::GetColorFormat
     */
-    int             colorBits       = 32;
+    int             colorBits           = 32;
 
     /**
     \brief Number of bits for each pixel in the depth buffer. Should be 24, 32, or zero to disable depth buffer. By default 24.
     \remarks This is only a hint to the renderer and there is no guarantee which hardware format is finally used for the depth buffer.
     To determine the actual depth-stencil format of a swap-chain, use the SwapChain::GetDepthStencilFormat function.
+    \note This field is deprecated and ignored if \c depthStencilFormat is not Format::Undefined; Use \c depthStencilFormat instead!
+    \see depthStencilFormat
     \see SwapChain::GetDepthStencilFormat
     */
-    int             depthBits       = 24;
+    int             depthBits           = 24;
 
     /**
     \brief Number of bits for each pixel in the stencil buffer. Should be 8, or zero to disable stencil buffer. By default 8.
     \remarks This is only a hint to the renderer and there is no guarantee which hardware format is finally used for the stencil buffer.
     To determine the actual depth-stencil format of a swap-chain, use the SwapChain::GetDepthStencilFormat function.
+    \note This field is deprecated and ignored if \c depthStencilFormat is not Format::Undefined; Use \c depthStencilFormat instead!
+    \see depthStencilFormat
     \see SwapChain::GetDepthStencilFormat
     */
-    int             stencilBits     = 8;
+    int             stencilBits         = 8;
 
     /**
     \brief Number of samples for the swap-chain buffers. By default 1.
@@ -116,7 +132,7 @@ struct SwapChainDescriptor
     The actual number of samples can be queried by the \c GetSamples function of the RenderTarget interface.
     \see RenderTarget::GetSamples
     */
-    std::uint32_t   samples         = 1;
+    std::uint32_t   samples             = 1;
 
     /**
     \brief Number of swap buffers. By default 2 (for double-buffering).
@@ -125,21 +141,21 @@ struct SwapChainDescriptor
     \see SwapChain::GetCurrentSwapIndex
     \see SwapChain::GetNumSwapBuffers
     */
-    std::uint32_t   swapBuffers     = 2;
+    std::uint32_t   swapBuffers         = 2;
 
     /**
     \brief Specifies whether to create the swap-chain initially in fullscreen mode or windowed mode otherwise.
     \see SwapChain::ResizeBuffers
     \see ResizeBuffersFlags::FullscreenMode
     */
-    bool            fullscreen      = false;
+    bool            fullscreen          = false;
 
     /**
     \brief Specifies whether to create the default surface for the swap-chain with the resizable attribute.
     \remarks If a custom surface is specified, this field is ignored.
     \see WindowFlags::Resizable
     */
-    bool            resizable       = false;
+    bool            resizable           = false;
 };
 
 

--- a/include/LLGL/SwapChainFlags.h
+++ b/include/LLGL/SwapChainFlags.h
@@ -10,6 +10,7 @@
 
 
 #include <LLGL/Types.h>
+#include <LLGL/Format.h>
 #include <cstdint>
 
 
@@ -73,6 +74,17 @@ struct SwapChainDescriptor
     \see RenderTarget::GetResolution
     */
     Extent2D        resolution;
+
+    /**
+    \brief Preferred color format for the swap-chain buffers. By default Format::Undefined.
+    \remarks If this is Format::Undefined, the renderer picks a format automatically (the default behavior).
+    Otherwise the renderer uses this format if the presentation surface supports it, and falls back to its
+    automatic selection if it does not. This is primarily intended to request an sRGB format (e.g.
+    Format::BGRA8UNorm_sRGB), so the hardware performs the linear-to-sRGB conversion on write.
+    To determine the actual color format of a swap-chain, use the SwapChain::GetColorFormat function.
+    \see SwapChain::GetColorFormat
+    */
+    Format          format          = Format::Undefined;
 
     /**
     \brief Number of bits for each pixel in the color buffer. Should be 24 or 32. By default 32.

--- a/sources/Renderer/DXCommon/DXCore.cpp
+++ b/sources/Renderer/DXCommon/DXCore.cpp
@@ -512,8 +512,18 @@ Format DXGetSignatureParameterType(D3D_REGISTER_COMPONENT_TYPE componentType, BY
     LLGL_TRAP("failed to map Direct3D signature parameter to LLGL::Format");
 }
 
-DXGI_FORMAT DXPickDepthStencilFormat(int depthBits, int stencilBits)
+DXGI_FORMAT DXPickDepthStencilFormat(Format depthStencilFormat, int depthBits, int stencilBits)
 {
+    /* Honor an explicitly requested depth-stencil format */
+    switch (depthStencilFormat)
+    {
+        case Format::D16UNorm:          return DXGI_FORMAT_D16_UNORM;
+        case Format::D24UNormS8UInt:    return DXGI_FORMAT_D24_UNORM_S8_UINT;
+        case Format::D32Float:          return DXGI_FORMAT_D32_FLOAT;
+        case Format::D32FloatS8X24UInt: return DXGI_FORMAT_D32_FLOAT_S8X24_UINT;
+        default:                        break;
+    }
+
     /* Only return unknown format if depth-stencil is explicitly disabled */
     if (depthBits == 0 && stencilBits == 0)
         return DXGI_FORMAT_UNKNOWN;

--- a/sources/Renderer/DXCommon/DXCore.h
+++ b/sources/Renderer/DXCommon/DXCore.h
@@ -78,8 +78,11 @@ VideoAdapterInfo DXGetVideoAdapterInfo(IDXGIFactory* factory, long preferredAdap
 // Returns the format for the specified signature parameter type (by its component type and mask).
 Format DXGetSignatureParameterType(D3D_REGISTER_COMPONENT_TYPE componentType, BYTE componentMask);
 
-// Returns a suitable DXGI format for the specified depth-stencil mode.
-DXGI_FORMAT DXPickDepthStencilFormat(int depthBits, int stencilBits);
+/*
+Returns a suitable DXGI format for the specified depth-stencil mode.
+If 'depthStencilFormat' is Format::Undefined, the format is deduced from the deprecated depth/stencil bit sizes.
+*/
+DXGI_FORMAT DXPickDepthStencilFormat(Format depthStencilFormat, int depthBits, int stencilBits);
 
 // Returns true if the specified DXGI swap-chain is in fullscreen mode.
 bool DXGetFullscreenState(IDXGISwapChain* swapChain);

--- a/sources/Renderer/DebugLayer/DbgRenderSystem.cpp
+++ b/sources/Renderer/DebugLayer/DbgRenderSystem.cpp
@@ -58,6 +58,9 @@ bool DbgRenderSystem::IsVulkan() const
 
 SwapChain* DbgRenderSystem::CreateSwapChain(const SwapChainDescriptor& swapChainDesc, const std::shared_ptr<Surface>& surface)
 {
+    if (LLGL_DBG_SOURCE())
+        ValidateSwapChainDesc(swapChainDesc);
+
     /* Create swap-chain and flush frame profile on SwapChain::Present() calls  */
     return swapChains_.emplace<DbgSwapChain>(
         *instance_->CreateSwapChain(swapChainDesc, surface),
@@ -762,6 +765,46 @@ void DbgRenderSystem::ValidateResourceCPUAccess(long cpuAccessFlags, const CPUAc
                 ErrorType::InvalidState,
                 "cannot map %s with CPU write access, because the resource was not created with 'LLGL::CPUAccessFlags::Write' flag",
                 resourceTypeName
+            );
+        }
+    }
+}
+
+void DbgRenderSystem::ValidateSwapChainDesc(const SwapChainDescriptor& swapChainDesc)
+{
+    /*
+    Both format fields are optional and Format::Undefined means the backend picks a format automatically,
+    but any other format must be of the matching kind. Backends silently fall back to their automatic
+    selection for a mismatching format, so the requested format would otherwise be ignored without notice.
+    */
+    if (swapChainDesc.colorFormat != Format::Undefined)
+    {
+        if (!IsColorFormat(swapChainDesc.colorFormat))
+        {
+            LLGL_DBG_ERROR(
+                ErrorType::InvalidArgument,
+                "cannot use depth-stencil format for swap-chain color buffer: %s",
+                ToString(swapChainDesc.colorFormat)
+            );
+        }
+        else if (IsCompressedFormat(swapChainDesc.colorFormat))
+        {
+            LLGL_DBG_ERROR(
+                ErrorType::InvalidArgument,
+                "cannot use compressed format for swap-chain color buffer: %s",
+                ToString(swapChainDesc.colorFormat)
+            );
+        }
+    }
+
+    if (swapChainDesc.depthStencilFormat != Format::Undefined)
+    {
+        if (!IsDepthOrStencilFormat(swapChainDesc.depthStencilFormat))
+        {
+            LLGL_DBG_ERROR(
+                ErrorType::InvalidArgument,
+                "cannot use color format for swap-chain depth-stencil buffer: %s",
+                ToString(swapChainDesc.depthStencilFormat)
             );
         }
     }

--- a/sources/Renderer/DebugLayer/DbgRenderSystem.h
+++ b/sources/Renderer/DebugLayer/DbgRenderSystem.h
@@ -61,6 +61,8 @@ class DbgRenderSystem final : public RenderSystem
         void ValidateMiscFlags(long flags, long validFlags, const char* contextDesc = nullptr);
         void ValidateResourceCPUAccess(long cpuAccessFlags, const CPUAccess access, const char* resourceTypeName);
 
+        void ValidateSwapChainDesc(const SwapChainDescriptor& swapChainDesc);
+
         void ValidateCommandBufferDesc(const CommandBufferDescriptor& commandBufferDesc);
 
         void ValidateBufferDesc(const BufferDescriptor& bufferDesc, std::uint32_t* formatSizeOut = nullptr);

--- a/sources/Renderer/Direct3D11/D3D11RenderSystem.cpp
+++ b/sources/Renderer/Direct3D11/D3D11RenderSystem.cpp
@@ -949,6 +949,25 @@ static std::vector<Format> GetDefaultSupportedDXTextureFormats(D3D_FEATURE_LEVEL
     return formats;
 }
 
+/*
+D3D11SwapChain always creates its back buffer as DXGI_FORMAT_R8G8B8A8_UNORM and ignores
+SwapChainDescriptor::colorFormat, so this is the only format the color buffer can have.
+*/
+static std::vector<Format> GetSupportedDXSwapChainColorFormats()
+{
+    return { Format::RGBA8UNorm };
+}
+
+// Returns the depth-stencil formats DXPickDepthStencilFormat can produce on the given feature level.
+static std::vector<Format> GetSupportedDXSwapChainDepthStencilFormats(D3D_FEATURE_LEVEL featureLevel)
+{
+    /* DXGI_FORMAT_D32_FLOAT and DXGI_FORMAT_D32_FLOAT_S8X24_UINT require feature level 10.0 */
+    if (featureLevel >= D3D_FEATURE_LEVEL_10_0)
+        return { Format::D16UNorm, Format::D24UNormS8UInt, Format::D32Float, Format::D32FloatS8X24UInt };
+    else
+        return { Format::D16UNorm, Format::D24UNormS8UInt };
+}
+
 static std::uint32_t GetMaxTextureDimension(D3D_FEATURE_LEVEL featureLevel)
 {
     if (featureLevel >= D3D_FEATURE_LEVEL_11_0) return 16384; // D3D11_REQ_TEXTURE2D_U_OR_V_DIMENSION
@@ -992,6 +1011,8 @@ void D3D11RenderSystem::QueryRenderingCaps(RenderingCapabilities& caps)
     caps.clippingRange                              = ClippingRange::ZeroToOne;
     caps.shadingLanguages                           = DXGetHLSLVersions(featureLevel);
     caps.textureFormats                             = GetDefaultSupportedDXTextureFormats(featureLevel);
+    caps.swapChainColorFormats                      = GetSupportedDXSwapChainColorFormats();
+    caps.swapChainDepthStencilFormats               = GetSupportedDXSwapChainDepthStencilFormats(featureLevel);
 
     caps.features.hasRenderTargets                  = true;
     caps.features.has3DTextures                     = true;

--- a/sources/Renderer/Direct3D11/D3D11SwapChain.cpp
+++ b/sources/Renderer/Direct3D11/D3D11SwapChain.cpp
@@ -28,11 +28,11 @@ D3D11SwapChain::D3D11SwapChain(
     SwapChain            { desc                                                       },
     device_              { device                                                     },
     renderSystem_        { renderSystem                                               },
-    depthStencilFormat_  { DXPickDepthStencilFormat(desc.depthBits, desc.stencilBits) },
-    renderTargetHandles_ { 1u, (depthStencilFormat_ != DXGI_FORMAT_UNKNOWN)           },
-    tearingSupported_    { renderSystem.IsTearingSupported()                          },
-    colorBufferLocator_  { ResourceType::Texture, BindFlags::ColorAttachment          },
-    depthBufferLocator_  { ResourceType::Texture, BindFlags::DepthStencilAttachment   }
+    depthStencilFormat_  { DXPickDepthStencilFormat(desc.depthStencilFormat, desc.depthBits, desc.stencilBits) },
+    renderTargetHandles_ { 1u, (depthStencilFormat_ != DXGI_FORMAT_UNKNOWN)                                    },
+    tearingSupported_    { renderSystem.IsTearingSupported()                                                   },
+    colorBufferLocator_  { ResourceType::Texture, BindFlags::ColorAttachment                                   },
+    depthBufferLocator_  { ResourceType::Texture, BindFlags::DepthStencilAttachment                            }
 {
     /* Setup surface for the swap-chain */
     SetOrCreateSurface(surface, SwapChain::BuildDefaultSurfaceTitle(renderSystem.GetRendererInfo()), desc);

--- a/sources/Renderer/Direct3D12/D3D12RenderSystem.cpp
+++ b/sources/Renderer/Direct3D12/D3D12RenderSystem.cpp
@@ -804,6 +804,21 @@ static std::vector<Format> GetDefaultSupportedDXTextureFormats()
     return formats;
 }
 
+/*
+D3D12SwapChain always creates its back buffer as DXGI_FORMAT_R8G8B8A8_UNORM and ignores
+SwapChainDescriptor::colorFormat, so this is the only format the color buffer can have.
+*/
+static std::vector<Format> GetSupportedDXSwapChainColorFormats()
+{
+    return { Format::RGBA8UNorm };
+}
+
+// Returns the depth-stencil formats DXPickDepthStencilFormat can produce; Direct3D 12 requires feature level 11.0 or later.
+static std::vector<Format> GetSupportedDXSwapChainDepthStencilFormats()
+{
+    return { Format::D16UNorm, Format::D24UNormS8UInt, Format::D32Float, Format::D32FloatS8X24UInt };
+}
+
 static std::uint32_t GetMaxTextureDimension(D3D_FEATURE_LEVEL featureLevel)
 {
     if (featureLevel >= D3D_FEATURE_LEVEL_11_0) return 16384; // D3D11_REQ_TEXTURE2D_U_OR_V_DIMENSION
@@ -863,6 +878,8 @@ void D3D12RenderSystem::QueryRenderingCaps(RenderingCapabilities& caps)
     caps.clippingRange                              = ClippingRange::ZeroToOne;
     caps.shadingLanguages                           = DXGetHLSLVersions(device_.GetShaderModel());
     caps.textureFormats                             = GetDefaultSupportedDXTextureFormats();
+    caps.swapChainColorFormats                      = GetSupportedDXSwapChainColorFormats();
+    caps.swapChainDepthStencilFormats               = GetSupportedDXSwapChainDepthStencilFormats();
 
     caps.features.hasRenderTargets                  = true;
     caps.features.has3DTextures                     = true;

--- a/sources/Renderer/Direct3D12/D3D12SwapChain.cpp
+++ b/sources/Renderer/Direct3D12/D3D12SwapChain.cpp
@@ -35,10 +35,10 @@ D3D12SwapChain::D3D12SwapChain(
 :
     SwapChain           { desc                                                           },
     renderSystem_       { renderSystem                                                   },
-    depthStencilFormat_ { DXPickDepthStencilFormat(desc.depthBits, desc.stencilBits)     },
-    frameFence_         { renderSystem.GetDXDevice()                                     },
-    numColorBuffers_    { Clamp<UINT>(desc.swapBuffers, 2u, DXGI_MAX_SWAP_CHAIN_BUFFERS) },
-    tearingSupported_   { renderSystem.GetDeviceCaps().isTearingSupported                }
+    depthStencilFormat_ { DXPickDepthStencilFormat(desc.depthStencilFormat, desc.depthBits, desc.stencilBits) },
+    frameFence_         { renderSystem.GetDXDevice()                                                          },
+    numColorBuffers_    { Clamp<UINT>(desc.swapBuffers, 2u, DXGI_MAX_SWAP_CHAIN_BUFFERS)                      },
+    tearingSupported_   { renderSystem.GetDeviceCaps().isTearingSupported                                     }
 {
     /* Store reference to command queue */
     commandQueue_ = LLGL_CAST(D3D12CommandQueue*, renderSystem_.GetCommandQueue());

--- a/sources/Renderer/Metal/MTFeatureSet.mm
+++ b/sources/Renderer/Metal/MTFeatureSet.mm
@@ -133,6 +133,22 @@ void LoadFeatureSetCaps(id<MTLDevice> device, MTLFeatureSet fset, RenderingCapab
     }
     #endif
 
+    /*
+    Query supported swap-chain formats.
+    The color formats are the ones a CAMetalLayer can be configured with; MTSwapChain takes its
+    color format from MTRenderPass, which maps SwapChainDescriptor::colorFormat directly.
+    */
+    caps.swapChainColorFormats = { Format::BGRA8UNorm, Format::BGRA8UNorm_sRGB, Format::RGBA16Float };
+
+    /* These are the formats MTRenderPass can produce for a swap-chain; see GetDepthStencilMTLPixelFormat */
+    caps.swapChainDepthStencilFormats = { Format::D32Float, Format::D32FloatS8X24UInt };
+
+    if (g_formatCaps.hasD24S8UIntFormat)
+        caps.swapChainDepthStencilFormats.push_back(Format::D24UNormS8UInt);
+
+    if (@available(macOS 10.12, iOS 13.0, *))
+        caps.swapChainDepthStencilFormats.push_back(Format::D16UNorm);
+
     /* Specify supported shading languages */
     const int version = FeatureSetToVersion(fset);
 

--- a/sources/Renderer/Metal/RenderState/MTRenderPass.mm
+++ b/sources/Renderer/Metal/RenderState/MTRenderPass.mm
@@ -118,28 +118,53 @@ static MTAttachmentFormat MakeDefaultMTAttachmentFormat(MTLPixelFormat format)
     return fmt;
 }
 
-static MTLPixelFormat GetColorMTLPixelFormat(int /*colorBits*/)
+static MTLPixelFormat GetColorMTLPixelFormat(const SwapChainDescriptor& desc)
 {
+    /* Honor an explicitly requested color format and ignore the deprecated 'colorBits' field otherwise */
+    if (IsColorFormat(desc.colorFormat))
+        return MTTypes::ToMTLPixelFormat(desc.colorFormat);
     return MTLPixelFormatBGRA8Unorm;
 }
 
-static MTLPixelFormat GetDepthStencilMTLPixelFormat(int depthBits, int stencilBits, id<MTLDevice> device)
+static MTLPixelFormat GetDepth24Stencil8MTLPixelFormat(id<MTLDevice> device)
 {
-    if (stencilBits == 8)
+    #ifdef LLGL_OS_MACOS
+    if (device != nil && device.depth24Stencil8PixelFormatSupported)
+        return MTLPixelFormatDepth24Unorm_Stencil8;
+    #endif
+    return MTLPixelFormatDepth32Float_Stencil8;
+}
+
+static MTLPixelFormat GetDepth16MTLPixelFormat()
+{
+    if (@available(iOS 13.0, *))
+        return MTLPixelFormatDepth16Unorm;
+    return MTLPixelFormatDepth32Float;
+}
+
+static MTLPixelFormat GetDepthStencilMTLPixelFormat(const SwapChainDescriptor& desc, id<MTLDevice> device)
+{
+    /* Honor an explicitly requested depth-stencil format */
+    switch (desc.depthStencilFormat)
     {
-        #ifdef LLGL_OS_MACOS
-        if (depthBits == 24 && device != nil && device.depth24Stencil8PixelFormatSupported)
-            return MTLPixelFormatDepth24Unorm_Stencil8;
-        #endif
+        case Format::D16UNorm:          return GetDepth16MTLPixelFormat();
+        case Format::D24UNormS8UInt:    return GetDepth24Stencil8MTLPixelFormat(device);
+        case Format::D32Float:          return MTLPixelFormatDepth32Float;
+        case Format::D32FloatS8X24UInt: return MTLPixelFormatDepth32Float_Stencil8;
+        default:                        break;
+    }
+
+    /* Deduce the format from the deprecated depth/stencil bit sizes */
+    if (desc.stencilBits == 8)
+    {
+        if (desc.depthBits == 24)
+            return GetDepth24Stencil8MTLPixelFormat(device);
         return MTLPixelFormatDepth32Float_Stencil8;
     }
     else
     {
-        if (@available(iOS 13.0, *))
-        {
-            if (depthBits == 16)
-                return MTLPixelFormatDepth16Unorm;
-        }
+        if (desc.depthBits == 16)
+            return GetDepth16MTLPixelFormat();
         return MTLPixelFormatDepth32Float;
     }
 }
@@ -148,14 +173,28 @@ static MTLPixelFormat GetDepthStencilMTLPixelFormat(int depthBits, int stencilBi
 MTRenderPass::MTRenderPass(id<MTLDevice> device, const SwapChainDescriptor& desc) :
     sampleCount_ { GetMTRenderPassSampleCount(device, desc.samples) }
 {
-    const MTLPixelFormat colorFormat        = GetColorMTLPixelFormat(desc.colorBits);
-    const MTLPixelFormat depthStencilFormat = GetDepthStencilMTLPixelFormat(desc.depthBits, desc.stencilBits, device);
+    const MTLPixelFormat colorFormat        = GetColorMTLPixelFormat(desc);
+    const MTLPixelFormat depthStencilFormat = GetDepthStencilMTLPixelFormat(desc, device);
 
     colorAttachments_ = { MakeDefaultMTAttachmentFormat(colorFormat) };
 
-    if (desc.depthBits > 0)
+    /* Determine which attachments are used from the requested format or the deprecated bit sizes otherwise */
+    const bool hasDepthAttachment =
+    (
+        desc.depthStencilFormat != Format::Undefined ?
+            IsDepthFormat(desc.depthStencilFormat) :
+            desc.depthBits > 0
+    );
+    const bool hasStencilAttachment =
+    (
+        desc.depthStencilFormat != Format::Undefined ?
+            IsStencilFormat(desc.depthStencilFormat) :
+            desc.stencilBits > 0
+    );
+
+    if (hasDepthAttachment)
         depthAttachment_ = MakeDefaultMTAttachmentFormat(depthStencilFormat);
-    if (desc.stencilBits > 0)
+    if (hasStencilAttachment)
         stencilAttachment_ = MakeDefaultMTAttachmentFormat(depthStencilFormat);
 }
 

--- a/sources/Renderer/Null/NullRenderSystem.cpp
+++ b/sources/Renderer/Null/NullRenderSystem.cpp
@@ -37,6 +37,21 @@ static void InitNullRendererTextureFormats(std::vector<Format>& textureFormats)
         textureFormats.push_back(static_cast<Format>(firstFormatIndex + i));
 }
 
+static void InitNullRendererSwapChainFormats(std::vector<Format>& colorFormats, std::vector<Format>& depthStencilFormats)
+{
+    /* NullSwapChain accepts any color and depth-stencil format the descriptor requests */
+    colorFormats =
+    {
+        Format::RGBA8UNorm, Format::RGBA8UNorm_sRGB,
+        Format::BGRA8UNorm, Format::BGRA8UNorm_sRGB,
+        Format::RGB10A2UNorm, Format::RGBA16Float,
+    };
+    depthStencilFormats =
+    {
+        Format::D16UNorm, Format::D24UNormS8UInt, Format::D32Float, Format::D32FloatS8X24UInt,
+    };
+}
+
 static void InitNullRendererFeatures(RenderingFeatures& features)
 {
     features.hasRenderTargets               = true;
@@ -102,6 +117,7 @@ static void GetNullRenderingCaps(RenderingCapabilities& caps)
 {
     InitNullRendererShadingLanguages(caps.shadingLanguages);
     InitNullRendererTextureFormats(caps.textureFormats);
+    InitNullRendererSwapChainFormats(caps.swapChainColorFormats, caps.swapChainDepthStencilFormats);
     InitNullRendererFeatures(caps.features);
     InitNullRendererLimits(caps.limits);
 }

--- a/sources/Renderer/Null/NullSwapChain.cpp
+++ b/sources/Renderer/Null/NullSwapChain.cpp
@@ -12,23 +12,31 @@ namespace LLGL
 {
 
 
-static Format ChooseColorFormat(int /*colorBits*/)
+static Format ChooseColorFormat(const SwapChainDescriptor& desc)
 {
+    /* Honor an explicitly requested color format and ignore the deprecated 'colorBits' field otherwise */
+    if (IsColorFormat(desc.colorFormat))
+        return desc.colorFormat;
     return Format::RGBA8UNorm;
 }
 
-static Format ChooseDepthStencilFormat(int depthBits, int stencilBits)
+static Format ChooseDepthStencilFormat(const SwapChainDescriptor& desc)
 {
-    if (depthBits == 32)
+    /* Honor an explicitly requested depth-stencil format */
+    if (IsDepthOrStencilFormat(desc.depthStencilFormat))
+        return desc.depthStencilFormat;
+
+    /* Deduce the format from the deprecated depth/stencil bit sizes */
+    if (desc.depthBits == 32)
     {
-        if (stencilBits != 0)
+        if (desc.stencilBits != 0)
             return Format::D32FloatS8X24UInt;
         else
             return Format::D32Float;
     }
     else
     {
-        if (stencilBits != 0)
+        if (desc.stencilBits != 0)
             return Format::D24UNormS8UInt;
         else
             return Format::D32Float;
@@ -42,8 +50,8 @@ NullSwapChain::NullSwapChain(
 :
     SwapChain           { desc                                                       },
     samples_            { desc.samples                                               },
-    colorFormat_        { ChooseColorFormat(desc.colorBits)                          },
-    depthStencilFormat_ { ChooseDepthStencilFormat(desc.depthBits, desc.stencilBits) }
+    colorFormat_        { ChooseColorFormat(desc)                                    },
+    depthStencilFormat_ { ChooseDepthStencilFormat(desc)                             }
 {
     SetOrCreateSurface(surface, SwapChain::BuildDefaultSurfaceTitle(rendererInfo), desc);
 

--- a/sources/Renderer/OpenGL/GLRenderingCaps.h
+++ b/sources/Renderer/OpenGL/GLRenderingCaps.h
@@ -10,6 +10,7 @@
 
 
 #include <LLGL/RenderSystemFlags.h>
+#include <LLGL/Platform/Platform.h>
 #include <vector>
 
 
@@ -19,6 +20,34 @@ namespace LLGL
 
 // Queries all OpenGL rendering capacilities.
 void GLQueryRenderingCaps(RenderingCapabilities& caps);
+
+/*
+Returns the color formats a GL swap-chain color buffer can have.
+The GL backend does not honor SwapChainDescriptor::colorFormat; the format is determined by the
+platform's pixel format and then labeled by GLContext::DeduceColorFormat/SetDefaultColorFormat.
+*/
+inline std::vector<Format> GLGetSupportedSwapChainColorFormats()
+{
+    #ifdef LLGL_OS_WIN32
+    /* Win32 deduces the format from the pixel format's component shifts, which can yield either component order */
+    return { Format::RGBA8UNorm, Format::BGRA8UNorm };
+    #else
+    /* All other platforms use GLContext::SetDefaultColorFormat */
+    return { Format::RGBA8UNorm };
+    #endif
+}
+
+/*
+Returns the depth-stencil formats a GL swap-chain depth-stencil buffer can have.
+GLContext::DeduceDepthStencilFormat can label any of the four LLGL depth-stencil formats, but the GL backend does not
+choose the format: it belongs to the pixel format the windowing system selects, and every platform LLGL supports
+requests a 24-bit depth and 8-bit stencil buffer by default. Drivers reliably provide that combination and commonly
+substitute it for anything else that is requested, so it is the only format an application can count on here.
+*/
+inline std::vector<Format> GLGetSupportedSwapChainDepthStencilFormats()
+{
+    return { Format::D24UNormS8UInt };
+}
 
 // Queries a string used to identify invalidated pipeline caches. This includes the shader binary format.
 void GLQueryPipelineCacheID(std::vector<char>& cacheID);

--- a/sources/Renderer/OpenGL/GLSwapChain.cpp
+++ b/sources/Renderer/OpenGL/GLSwapChain.cpp
@@ -41,6 +41,37 @@ static GLint GetFramebufferHeight(const Extent2D& resolution)
     return static_cast<GLint>(resolution.height);
 }
 
+// Returns the number of color bits, either from the requested color format or the deprecated 'colorBits' field.
+static int GetGLColorBits(const SwapChainDescriptor& desc)
+{
+    if (IsColorFormat(desc.colorFormat))
+        return static_cast<int>(GetFormatAttribs(desc.colorFormat).bitSize);
+    return desc.colorBits;
+}
+
+// Returns the number of depth and stencil bits, either from the requested depth-stencil format or the deprecated bit-size fields.
+static void GetGLDepthStencilBits(const SwapChainDescriptor& desc, int& outDepthBits, int& outStencilBits)
+{
+    switch (desc.depthStencilFormat)
+    {
+        case Format::D16UNorm:
+            outDepthBits = 16; outStencilBits = 0;
+            break;
+        case Format::D24UNormS8UInt:
+            outDepthBits = 24; outStencilBits = 8;
+            break;
+        case Format::D32Float:
+            outDepthBits = 32; outStencilBits = 0;
+            break;
+        case Format::D32FloatS8X24UInt:
+            outDepthBits = 32; outStencilBits = 8;
+            break;
+        default:
+            outDepthBits = desc.depthBits; outStencilBits = desc.stencilBits;
+            break;
+    }
+}
+
 GLSwapChain::GLSwapChain(
     GLRenderSystem&                 renderSystem,
     const SwapChainDescriptor&      desc,
@@ -51,9 +82,8 @@ GLSwapChain::GLSwapChain(
 {
     /* Set up pixel format for GL context */
     GLPixelFormat pixelFormat;
-    pixelFormat.colorBits   = desc.colorBits;
-    pixelFormat.depthBits   = desc.depthBits;
-    pixelFormat.stencilBits = desc.stencilBits;
+    pixelFormat.colorBits   = GetGLColorBits(desc);
+    GetGLDepthStencilBits(desc, pixelFormat.depthBits, pixelFormat.stencilBits);
     pixelFormat.samples     = static_cast<int>(GetClampedSamples(desc.samples));
 
     #ifdef LLGL_OS_LINUX

--- a/sources/Renderer/OpenGL/Platform/GLContext.cpp
+++ b/sources/Renderer/OpenGL/Platform/GLContext.cpp
@@ -93,14 +93,26 @@ void GLContext::DeduceColorFormat(int /*rBits*/, int rShift, int /*gBits*/, int 
 
 void GLContext::DeduceDepthStencilFormat(int depthBits, int stencilBits)
 {
-    if (depthBits == 24 && stencilBits == 8)
-        depthStencilFormat_ = Format::D24UNormS8UInt;
-    else if (depthBits == 32 && stencilBits == 8)
-        depthStencilFormat_ = Format::D32FloatS8X24UInt;
-    else if (depthBits == 16 && stencilBits == 0)
-        depthStencilFormat_ = Format::D16UNorm;
-    else if (depthBits == 32 && stencilBits == 0)
-        depthStencilFormat_ = Format::D32Float;
+    /*
+    The bit sizes come from the pixel format the windowing system selected, which is not restricted to the
+    combinations LLGL can request. Map every combination that has a depth or stencil component onto the
+    closest LLGL format, so GetDepthStencilFormat() never reports Format::Undefined for a buffer that exists.
+    */
+    if (depthBits == 0 && stencilBits == 0)
+    {
+        /* Pixel format has neither a depth nor a stencil buffer */
+        depthStencilFormat_ = Format::Undefined;
+    }
+    else if (stencilBits > 0)
+    {
+        /* LLGL has no stencil-only format, so a stencil buffer always implies a combined depth-stencil format */
+        depthStencilFormat_ = (depthBits > 24 ? Format::D32FloatS8X24UInt : Format::D24UNormS8UInt);
+    }
+    else
+    {
+        /* LLGL has no 24-bit depth-only format, so report anything above 16 bits as 32-bit depth */
+        depthStencilFormat_ = (depthBits > 16 ? Format::D32Float : Format::D16UNorm);
+    }
 }
 
 void GLContext::SetDefaultColorFormat()

--- a/sources/Renderer/OpenGL/Profile/GLCompat/GLCompatProfileCaps.cpp
+++ b/sources/Renderer/OpenGL/Profile/GLCompat/GLCompatProfileCaps.cpp
@@ -341,6 +341,8 @@ void GLQueryRenderingCaps(RenderingCapabilities& caps)
 {
     GLGetRenderingAttribs(caps);
     GLGetSupportedTextureFormats(caps.textureFormats);
+    caps.swapChainColorFormats          = GLGetSupportedSwapChainColorFormats();
+    caps.swapChainDepthStencilFormats   = GLGetSupportedSwapChainDepthStencilFormats();
     GLGetSupportedFeatures(caps.features);
     GLGetFeatureLimits(caps.features, caps.limits);
     GLGetTextureLimits(caps.features, caps.limits);

--- a/sources/Renderer/OpenGL/Profile/GLCore/GLCoreProfileCaps.cpp
+++ b/sources/Renderer/OpenGL/Profile/GLCore/GLCoreProfileCaps.cpp
@@ -403,6 +403,8 @@ void GLQueryRenderingCaps(RenderingCapabilities& caps)
 {
     GLGetRenderingAttribs(caps);
     GLGetSupportedTextureFormats(caps.textureFormats);
+    caps.swapChainColorFormats          = GLGetSupportedSwapChainColorFormats();
+    caps.swapChainDepthStencilFormats   = GLGetSupportedSwapChainDepthStencilFormats();
     GLGetSupportedFeatures(caps.features);
     GLGetFeatureLimits(caps.features, caps.limits);
     GLGetTextureLimits(caps.features, caps.limits);

--- a/sources/Renderer/OpenGL/Profile/GLES/GLESProfileCaps.cpp
+++ b/sources/Renderer/OpenGL/Profile/GLES/GLESProfileCaps.cpp
@@ -234,6 +234,8 @@ void GLQueryRenderingCaps(RenderingCapabilities& caps)
     const GLint version = GetGLESVersion();
     GLGetRenderingAttribs(caps, version);
     GLGetSupportedTextureFormats(caps.textureFormats);
+    caps.swapChainColorFormats          = GLGetSupportedSwapChainColorFormats();
+    caps.swapChainDepthStencilFormats   = GLGetSupportedSwapChainDepthStencilFormats();
     GLGetSupportedFeatures(caps.features, version);
     GLGetFeatureLimits(caps.limits, version);
     GLGetTextureLimits(caps.features, caps.limits, version);

--- a/sources/Renderer/OpenGL/Profile/WebGL/WebGLProfileCaps.cpp
+++ b/sources/Renderer/OpenGL/Profile/WebGL/WebGLProfileCaps.cpp
@@ -234,6 +234,8 @@ void GLQueryRenderingCaps(RenderingCapabilities& caps)
     const GLint version = GetGLESVersion();
     GLGetRenderingAttribs(caps, version);
     GLGetSupportedTextureFormats(caps.textureFormats);
+    caps.swapChainColorFormats          = GLGetSupportedSwapChainColorFormats();
+    caps.swapChainDepthStencilFormats   = GLGetSupportedSwapChainDepthStencilFormats();
     GLGetSupportedFeatures(caps.features, version);
     GLGetFeatureLimits(caps.limits, version);
     GLGetTextureLimits(caps.features, caps.limits, version);

--- a/sources/Renderer/OpenGL/Texture/GLTexture.cpp
+++ b/sources/Renderer/OpenGL/Texture/GLTexture.cpp
@@ -36,29 +36,14 @@ static bool IsRenderbufferSufficient(const TextureDescriptor& desc)
 {
     /*
     Renderbuffers can only be used under the following conditions:
-    - Texture must be 2D or 2D-multisampled
-    - Only a single MIP-map level
-    - Only used as attachment
-    - No initial image data is specified
+    - Only used as attachment, with a single MIP-map level and no initial image data
+      (shared with the other backends, see IsAttachmentOnlyTexture)
+    - Texture must be 2D or 2D-multisampled, since a renderbuffer has no array layers
     */
-    const long attachmentBindFlags =
-    (
-        desc.bindFlags &
-        (
-            BindFlags::Sampled                  |
-            BindFlags::Storage                  |
-            BindFlags::ColorAttachment          |
-            BindFlags::DepthStencilAttachment   |
-            BindFlags::CopySrc                  |
-            BindFlags::CopyDst
-        )
-    );
     return
     (
-        desc.mipLevels == 1 &&
-        (desc.type == TextureType::Texture2D || desc.type == TextureType::Texture2DMS) &&
-        (attachmentBindFlags == BindFlags::ColorAttachment || attachmentBindFlags == BindFlags::DepthStencilAttachment) &&
-        ((desc.miscFlags & MiscFlags::NoInitialData) != 0)
+        IsAttachmentOnlyTexture(desc) &&
+        (desc.type == TextureType::Texture2D || desc.type == TextureType::Texture2DMS)
     );
 }
 

--- a/sources/Renderer/RenderSystemFlags.cpp
+++ b/sources/Renderer/RenderSystemFlags.cpp
@@ -66,6 +66,36 @@ LLGL_EXPORT bool ValidateRenderingCaps(
         }
     }
 
+    /* Validate swap-chain color formats */
+    for_range(i, requiredCaps.swapChainColorFormats.size())
+    {
+        const Format colorFormat = requiredCaps.swapChainColorFormats[i];
+        if (!Contains(presentCaps.swapChainColorFormats, colorFormat))
+        {
+            bool continueValidation = ReportValidationFailure(
+                callback,
+                "swap-chain color format not supported: " + std::string(ToString(colorFormat)),
+                "swapChainColorFormats[" + std::to_string(i) + ']'
+            );
+            LLGL_CONTINUE_VALIDATION_IF(continueValidation);
+        }
+    }
+
+    /* Validate swap-chain depth-stencil formats */
+    for_range(i, requiredCaps.swapChainDepthStencilFormats.size())
+    {
+        const Format depthStencilFormat = requiredCaps.swapChainDepthStencilFormats[i];
+        if (!Contains(presentCaps.swapChainDepthStencilFormats, depthStencilFormat))
+        {
+            bool continueValidation = ReportValidationFailure(
+                callback,
+                "swap-chain depth-stencil format not supported: " + std::string(ToString(depthStencilFormat)),
+                "swapChainDepthStencilFormats[" + std::to_string(i) + ']'
+            );
+            LLGL_CONTINUE_VALIDATION_IF(continueValidation);
+        }
+    }
+
     /* Validate features */
     #define LLGL_VALIDATE_FEATURE(ATTRIB, INFO)                             \
         if (requiredCaps.features.ATTRIB && !presentCaps.features.ATTRIB)   \

--- a/sources/Renderer/TextureUtils.cpp
+++ b/sources/Renderer/TextureUtils.cpp
@@ -129,6 +129,29 @@ LLGL_EXPORT SubresourceFootprint CalcPackedSubresourceFootprint(
     return footprint;
 }
 
+LLGL_EXPORT bool IsAttachmentOnlyTexture(const TextureDescriptor& textureDesc)
+{
+    /* The texture must be bound as exactly one kind of attachment and nothing else */
+    const long relevantBindFlags =
+    (
+        textureDesc.bindFlags &
+        (
+            BindFlags::Sampled                  |
+            BindFlags::Storage                  |
+            BindFlags::ColorAttachment          |
+            BindFlags::DepthStencilAttachment   |
+            BindFlags::CopySrc                  |
+            BindFlags::CopyDst
+        )
+    );
+    return
+    (
+        textureDesc.mipLevels == 1 &&
+        (relevantBindFlags == BindFlags::ColorAttachment || relevantBindFlags == BindFlags::DepthStencilAttachment) &&
+        ((textureDesc.miscFlags & MiscFlags::NoInitialData) != 0)
+    );
+}
+
 LLGL_EXPORT bool MustGenerateMipsOnCreate(const TextureDescriptor& textureDesc)
 {
     return

--- a/sources/Renderer/TextureUtils.h
+++ b/sources/Renderer/TextureUtils.h
@@ -87,6 +87,23 @@ LLGL_EXPORT SubresourceFootprint CalcPackedSubresourceFootprint(
     std::uint32_t       alignment = 1
 );
 
+/*
+Returns true if the specified texture is only ever used as a render-target attachment,
+i.e. it is never sampled, written as storage, or used as a copy source/destination, has a
+single MIP-map level, and is not initialized with image data.
+
+Backends use this to select a cheaper representation for such a texture, but each adds its
+own condition on top:
+- OpenGL additionally requires a non-arrayed 2D type, because a renderbuffer cannot
+  represent array layers (see IsRenderbufferSufficient).
+- Vulkan additionally requires a multi-sampled type before treating the texture as a
+  transient attachment, because lazily-allocated memory does not preserve contents beyond
+  the render pass that wrote them. A single-sampled attachment may legitimately be
+  re-attached with AttachmentLoadOp::Load in a later pass, whereas raw multi-sample
+  contents are only ever consumed by a resolve within their own pass.
+*/
+LLGL_EXPORT bool IsAttachmentOnlyTexture(const TextureDescriptor& textureDesc);
+
 // Returns true if the specified flags for texture creation require MIP-map generation at creation time.
 LLGL_EXPORT bool MustGenerateMipsOnCreate(const TextureDescriptor& textureDesc);
 

--- a/sources/Renderer/Vulkan/Memory/VKDeviceMemoryManager.cpp
+++ b/sources/Renderer/Vulkan/Memory/VKDeviceMemoryManager.cpp
@@ -110,6 +110,12 @@ void VKDeviceMemoryManager::PrintBlocks(std::ostream& s, const std::string& titl
 #endif
 
 
+bool VKDeviceMemoryManager::SupportsMemoryType(std::uint32_t memoryTypeBits, VkMemoryPropertyFlags properties) const
+{
+    return VKHasMemoryType(memoryProperties_, memoryTypeBits, properties);
+}
+
+
 /*
  * ======= Private: =======
  */

--- a/sources/Renderer/Vulkan/Memory/VKDeviceMemoryManager.h
+++ b/sources/Renderer/Vulkan/Memory/VKDeviceMemoryManager.h
@@ -44,6 +44,11 @@ class VKDeviceMemoryManager
         VKDeviceMemoryManager(const VKDeviceMemoryManager&) = delete;
         VKDeviceMemoryManager& operator = (const VKDeviceMemoryManager&) = delete;
 
+        // Returns true if this device exposes a memory type with the specified bits and properties.
+        // Allocate() traps when no such type exists, so probe with this before requesting memory
+        // properties that are optional (e.g. VK_MEMORY_PROPERTY_LAZILY_ALLOCATED_BIT).
+        bool SupportsMemoryType(std::uint32_t memoryTypeBits, VkMemoryPropertyFlags properties) const;
+
         // Allocates a new device memory block of the specified size and with the specified attributes.
         VKDeviceMemoryRegion* Allocate(
             VkDeviceSize            size,

--- a/sources/Renderer/Vulkan/OpenXR/VKOpenXRGraphicsBinding.cpp
+++ b/sources/Renderer/Vulkan/OpenXR/VKOpenXRGraphicsBinding.cpp
@@ -433,7 +433,9 @@ bool VKOpenXRGraphicsBinding::EnumerateSwapchainImages(
     params.extent           = { swapChainDesc.resolution.width, swapChainDesc.resolution.height, 1u };
     params.numMipLevels     = 1;
     params.numArrayLayers   = swapChainDesc.arrayLayers;
-    params.sampleCountBits  = VKTypes::ToVkSampleCountBits(swapChainDesc.sampleCount);
+    /* Runtime images are single-sampled regardless of the requested sample count; with MSAA
+       they are the resolve target, not the render target (see OpenXRSession::CreateSwapchain). */
+    params.sampleCountBits  = VK_SAMPLE_COUNT_1_BIT;
     params.initialLayout    = VK_IMAGE_LAYOUT_UNDEFINED;
 
     if (kind == SwapchainKind::DepthStencil)

--- a/sources/Renderer/Vulkan/Texture/VKDeviceImage.cpp
+++ b/sources/Renderer/Vulkan/Texture/VKDeviceImage.cpp
@@ -40,20 +40,42 @@ VKDeviceImage& VKDeviceImage::operator = (VKDeviceImage&& rhs)
     return *this;
 }
 
-void VKDeviceImage::AllocateMemoryRegion(VKDeviceMemoryManager& deviceMemoryMngr)
+void VKDeviceImage::AllocateMemoryRegion(VKDeviceMemoryManager& deviceMemoryMngr, bool preferLazilyAllocated)
 {
     VkDevice device = deviceMemoryMngr.GetVkDevice();
 
     /* Get memory requirements for the image */
     vkGetImageMemoryRequirements(device, image_, &memoryRequirements_);
 
+    /* For a transient attachment, prefer memory the implementation only backs on demand: tile-based GPUs can then
+       keep the attachment entirely on chip. Desktop GPUs typically expose no such memory type, so the support is
+       probed first and this falls through to regular device-local memory below.
+
+       The probe is not optional: Allocate() resolves the memory type through VKFindMemoryType, which TRAPS when
+       nothing matches rather than returning null, so requesting lazily-allocated memory unconditionally would
+       abort on every implementation that lacks it instead of falling back. */
+    constexpr VkMemoryPropertyFlags lazilyAllocatedProperties = (VK_MEMORY_PROPERTY_LAZILY_ALLOCATED_BIT | VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT);
+
+    if (preferLazilyAllocated && deviceMemoryMngr.SupportsMemoryType(memoryRequirements_.memoryTypeBits, lazilyAllocatedProperties))
+    {
+        memoryRegion_ = deviceMemoryMngr.Allocate(
+            memoryRequirements_.size,
+            memoryRequirements_.alignment,
+            memoryRequirements_.memoryTypeBits,
+            lazilyAllocatedProperties
+        );
+    }
+
     /* Allocate device memory */
-    memoryRegion_ = deviceMemoryMngr.Allocate(
-        memoryRequirements_.size,
-        memoryRequirements_.alignment,
-        memoryRequirements_.memoryTypeBits,
-        VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT
-    );
+    if (memoryRegion_ == nullptr)
+    {
+        memoryRegion_ = deviceMemoryMngr.Allocate(
+            memoryRequirements_.size,
+            memoryRequirements_.alignment,
+            memoryRequirements_.memoryTypeBits,
+            VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT
+        );
+    }
 
     /* Bind image to device memory region */
     if (memoryRegion_ == nullptr)

--- a/sources/Renderer/Vulkan/Texture/VKDeviceImage.h
+++ b/sources/Renderer/Vulkan/Texture/VKDeviceImage.h
@@ -41,7 +41,12 @@ class VKDeviceImage
         VKDeviceImage(const VKDeviceImage&) = delete;
         VKDeviceImage& operator = (const VKDeviceImage&) = delete;
 
-        void AllocateMemoryRegion(VKDeviceMemoryManager& deviceMemoryMngr);
+        /*
+        Allocates the backing device memory for this image.
+        When 'preferLazilyAllocated' is true (transient attachments), memory that the implementation only backs
+        on demand is requested first, falling back to regular device-local memory where no such type exists.
+        */
+        void AllocateMemoryRegion(VKDeviceMemoryManager& deviceMemoryMngr, bool preferLazilyAllocated = false);
         void ReleaseMemoryRegion(VKDeviceMemoryManager& deviceMemoryMngr);
 
         void BindMemoryRegion(VkDevice device, VKDeviceMemoryRegion* memoryRegion);

--- a/sources/Renderer/Vulkan/Texture/VKRenderTarget.cpp
+++ b/sources/Renderer/Vulkan/Texture/VKRenderTarget.cpp
@@ -193,6 +193,17 @@ void VKRenderTarget::CreateRenderPass(
             {
                 VkFormat format = VKTypes::Map(GetAttachmentFormat(resolveAttachment));
                 InitVkAttachmentDesc(attachmentDescs[numTargetAttachments + i], format, bindFlags, VK_SAMPLE_COUNT_1_BIT, VK_ATTACHMENT_LOAD_OP_DONT_CARE);
+
+                /*
+                The multi-sampled color attachment is resolved into the attachment above, so its own contents are
+                never read after the pass and storing them is pure bandwidth - on a tile-based GPU this is what
+                lets the multi-sample surface stay on chip and never reach main memory.
+
+                Only for the DONT_CARE variant: the secondary render pass loads its attachments to resume a
+                paused pass, and discarding the contents it is about to reload would lose them.
+                */
+                if (attachmentsLoadOp != VK_ATTACHMENT_LOAD_OP_LOAD)
+                    attachmentDescs[i].storeOp = VK_ATTACHMENT_STORE_OP_DONT_CARE;
             }
             else
             {

--- a/sources/Renderer/Vulkan/Texture/VKTexture.cpp
+++ b/sources/Renderer/Vulkan/Texture/VKTexture.cpp
@@ -30,6 +30,22 @@ static VKSwizzleFormat MapToVKSwizzleFormat(const Format format)
         return VKSwizzleFormat::RGBA;
 }
 
+/*
+Returns true if the texture can be created as a transient attachment, i.e. one whose contents
+are produced and consumed entirely within a single render pass. Such an image can carry
+VK_IMAGE_USAGE_TRANSIENT_ATTACHMENT_BIT and be backed by lazily-allocated memory, which on a
+tile-based GPU may never be written out to main memory at all.
+
+Beyond being attachment-only, the texture must be multi-sampled: lazily-allocated memory does
+not preserve contents outside the render pass that wrote them, and a single-sampled attachment
+may legitimately be re-attached with AttachmentLoadOp::Load in a later pass. Raw multi-sample
+contents have no such use - they are only ever consumed by a resolve within their own pass.
+*/
+static bool IsTransientAttachment(const TextureDescriptor& desc)
+{
+    return (IsAttachmentOnlyTexture(desc) && IsMultiSampleTexture(desc.type));
+}
+
 VKTexture::VKTexture(
     VkDevice                    device,
     VKDeviceMemoryManager&      deviceMemoryMngr,
@@ -44,7 +60,7 @@ VKTexture::VKTexture(
 {
     /* Create Vulkan image and allocate memory region */
     CreateImage(device, desc);
-    image_.AllocateMemoryRegion(deviceMemoryMngr);
+    image_.AllocateMemoryRegion(deviceMemoryMngr, IsTransientAttachment(desc));
     if (desc.debugName != nullptr)
         SetDebugName(desc.debugName);
 }
@@ -477,6 +493,17 @@ static VkSampleCountFlagBits GetVkImageSampleCountFlags(const TextureDescriptor&
 
 static VkImageUsageFlags GetVkImageUsageFlags(const TextureDescriptor& desc)
 {
+    /* A transient attachment must carry no usage beyond the attachment bits - Vulkan forbids combining
+       TRANSIENT_ATTACHMENT with transfer, sampled, or storage usage, since its contents never leave the
+       render pass. Handled up front so the transfer bits below are not applied. */
+    if (IsTransientAttachment(desc))
+    {
+        if ((desc.bindFlags & BindFlags::DepthStencilAttachment) != 0)
+            return VK_IMAGE_USAGE_TRANSIENT_ATTACHMENT_BIT | VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT;
+        else
+            return VK_IMAGE_USAGE_TRANSIENT_ATTACHMENT_BIT | VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT;
+    }
+
     VkImageUsageFlags usageFlags = VK_IMAGE_USAGE_TRANSFER_DST_BIT | VK_IMAGE_USAGE_TRANSFER_SRC_BIT;
 
     /* Enable TRANSFER_SRC_BIT image usage when MIP-maps are enabled, CPU read access or copy source binding is requested */

--- a/sources/Renderer/Vulkan/VKCore.cpp
+++ b/sources/Renderer/Vulkan/VKCore.cpp
@@ -22,29 +22,29 @@ namespace LLGL
 
     /* ----- Basic Functions ----- */
 
-    static const char *VKResultToStr(const VkResult result)
+    static const char* VKResultToStr(const VkResult result)
     {
-        // see https://www.khronos.org/registry/vulkan/specs/1.0/man/html/VkResult.html
-        switch (result)
-        {
-            LLGL_CASE_TO_STR(VK_SUCCESS);
-            LLGL_CASE_TO_STR(VK_NOT_READY);
-            LLGL_CASE_TO_STR(VK_TIMEOUT);
-            LLGL_CASE_TO_STR(VK_EVENT_SET);
-            LLGL_CASE_TO_STR(VK_EVENT_RESET);
-            LLGL_CASE_TO_STR(VK_INCOMPLETE);
-            LLGL_CASE_TO_STR(VK_ERROR_OUT_OF_HOST_MEMORY);
-            LLGL_CASE_TO_STR(VK_ERROR_OUT_OF_DEVICE_MEMORY);
-            LLGL_CASE_TO_STR(VK_ERROR_INITIALIZATION_FAILED);
-            LLGL_CASE_TO_STR(VK_ERROR_DEVICE_LOST);
-            LLGL_CASE_TO_STR(VK_ERROR_MEMORY_MAP_FAILED);
-            LLGL_CASE_TO_STR(VK_ERROR_LAYER_NOT_PRESENT);
-            LLGL_CASE_TO_STR(VK_ERROR_EXTENSION_NOT_PRESENT);
-            LLGL_CASE_TO_STR(VK_ERROR_FEATURE_NOT_PRESENT);
-            LLGL_CASE_TO_STR(VK_ERROR_INCOMPATIBLE_DRIVER);
-            LLGL_CASE_TO_STR(VK_ERROR_TOO_MANY_OBJECTS);
-            LLGL_CASE_TO_STR(VK_ERROR_FORMAT_NOT_SUPPORTED);
-            LLGL_CASE_TO_STR(VK_ERROR_FRAGMENTED_POOL);
+    // see https://www.khronos.org/registry/vulkan/specs/1.0/man/html/VkResult.html
+    switch (result)
+    {
+        LLGL_CASE_TO_STR( VK_SUCCESS );
+        LLGL_CASE_TO_STR( VK_NOT_READY );
+        LLGL_CASE_TO_STR( VK_TIMEOUT );
+        LLGL_CASE_TO_STR( VK_EVENT_SET );
+        LLGL_CASE_TO_STR( VK_EVENT_RESET );
+        LLGL_CASE_TO_STR( VK_INCOMPLETE );
+        LLGL_CASE_TO_STR( VK_ERROR_OUT_OF_HOST_MEMORY );
+        LLGL_CASE_TO_STR( VK_ERROR_OUT_OF_DEVICE_MEMORY );
+        LLGL_CASE_TO_STR( VK_ERROR_INITIALIZATION_FAILED );
+        LLGL_CASE_TO_STR( VK_ERROR_DEVICE_LOST );
+        LLGL_CASE_TO_STR( VK_ERROR_MEMORY_MAP_FAILED );
+        LLGL_CASE_TO_STR( VK_ERROR_LAYER_NOT_PRESENT );
+        LLGL_CASE_TO_STR( VK_ERROR_EXTENSION_NOT_PRESENT );
+        LLGL_CASE_TO_STR( VK_ERROR_FEATURE_NOT_PRESENT );
+        LLGL_CASE_TO_STR( VK_ERROR_INCOMPATIBLE_DRIVER );
+        LLGL_CASE_TO_STR( VK_ERROR_TOO_MANY_OBJECTS );
+        LLGL_CASE_TO_STR( VK_ERROR_FORMAT_NOT_SUPPORTED );
+        LLGL_CASE_TO_STR( VK_ERROR_FRAGMENTED_POOL );
         #if VK_HEADER_VERSION >= 131
         LLGL_CASE_TO_STR( VK_ERROR_UNKNOWN );
         #endif

--- a/sources/Renderer/Vulkan/VKCore.cpp
+++ b/sources/Renderer/Vulkan/VKCore.cpp
@@ -334,6 +334,16 @@ VkFormat VKFindSupportedImageFormat(VkPhysicalDevice device, const VkFormat* can
     LLGL_TRAP("failed to find suitable image format");
 }
 
+bool VKHasMemoryType(const VkPhysicalDeviceMemoryProperties& memoryProperties, std::uint32_t memoryTypeBits, VkMemoryPropertyFlags properties)
+{
+    for_range(i, memoryProperties.memoryTypeCount)
+    {
+        if ((memoryTypeBits & (1 << i)) != 0 && (memoryProperties.memoryTypes[i].propertyFlags & properties) == properties)
+            return true;
+    }
+    return false;
+}
+
 std::uint32_t VKFindMemoryType(const VkPhysicalDeviceMemoryProperties& memoryProperties, std::uint32_t memoryTypeBits, VkMemoryPropertyFlags properties)
 {
     for_range(i, memoryProperties.memoryTypeCount)

--- a/sources/Renderer/Vulkan/VKCore.cpp
+++ b/sources/Renderer/Vulkan/VKCore.cpp
@@ -17,32 +17,34 @@
 namespace LLGL
 {
 
+    // Returned by VKGetMemoryTypeIndex() to indicate that the memory type was not found
+    static constexpr std::uint32_t kInvalidMemoryIndex = ~0u;
 
-/* ----- Basic Functions ----- */
+    /* ----- Basic Functions ----- */
 
-static const char* VKResultToStr(const VkResult result)
-{
-    // see https://www.khronos.org/registry/vulkan/specs/1.0/man/html/VkResult.html
-    switch (result)
+    static const char *VKResultToStr(const VkResult result)
     {
-        LLGL_CASE_TO_STR( VK_SUCCESS );
-        LLGL_CASE_TO_STR( VK_NOT_READY );
-        LLGL_CASE_TO_STR( VK_TIMEOUT );
-        LLGL_CASE_TO_STR( VK_EVENT_SET );
-        LLGL_CASE_TO_STR( VK_EVENT_RESET );
-        LLGL_CASE_TO_STR( VK_INCOMPLETE );
-        LLGL_CASE_TO_STR( VK_ERROR_OUT_OF_HOST_MEMORY );
-        LLGL_CASE_TO_STR( VK_ERROR_OUT_OF_DEVICE_MEMORY );
-        LLGL_CASE_TO_STR( VK_ERROR_INITIALIZATION_FAILED );
-        LLGL_CASE_TO_STR( VK_ERROR_DEVICE_LOST );
-        LLGL_CASE_TO_STR( VK_ERROR_MEMORY_MAP_FAILED );
-        LLGL_CASE_TO_STR( VK_ERROR_LAYER_NOT_PRESENT );
-        LLGL_CASE_TO_STR( VK_ERROR_EXTENSION_NOT_PRESENT );
-        LLGL_CASE_TO_STR( VK_ERROR_FEATURE_NOT_PRESENT );
-        LLGL_CASE_TO_STR( VK_ERROR_INCOMPATIBLE_DRIVER );
-        LLGL_CASE_TO_STR( VK_ERROR_TOO_MANY_OBJECTS );
-        LLGL_CASE_TO_STR( VK_ERROR_FORMAT_NOT_SUPPORTED );
-        LLGL_CASE_TO_STR( VK_ERROR_FRAGMENTED_POOL );
+        // see https://www.khronos.org/registry/vulkan/specs/1.0/man/html/VkResult.html
+        switch (result)
+        {
+            LLGL_CASE_TO_STR(VK_SUCCESS);
+            LLGL_CASE_TO_STR(VK_NOT_READY);
+            LLGL_CASE_TO_STR(VK_TIMEOUT);
+            LLGL_CASE_TO_STR(VK_EVENT_SET);
+            LLGL_CASE_TO_STR(VK_EVENT_RESET);
+            LLGL_CASE_TO_STR(VK_INCOMPLETE);
+            LLGL_CASE_TO_STR(VK_ERROR_OUT_OF_HOST_MEMORY);
+            LLGL_CASE_TO_STR(VK_ERROR_OUT_OF_DEVICE_MEMORY);
+            LLGL_CASE_TO_STR(VK_ERROR_INITIALIZATION_FAILED);
+            LLGL_CASE_TO_STR(VK_ERROR_DEVICE_LOST);
+            LLGL_CASE_TO_STR(VK_ERROR_MEMORY_MAP_FAILED);
+            LLGL_CASE_TO_STR(VK_ERROR_LAYER_NOT_PRESENT);
+            LLGL_CASE_TO_STR(VK_ERROR_EXTENSION_NOT_PRESENT);
+            LLGL_CASE_TO_STR(VK_ERROR_FEATURE_NOT_PRESENT);
+            LLGL_CASE_TO_STR(VK_ERROR_INCOMPATIBLE_DRIVER);
+            LLGL_CASE_TO_STR(VK_ERROR_TOO_MANY_OBJECTS);
+            LLGL_CASE_TO_STR(VK_ERROR_FORMAT_NOT_SUPPORTED);
+            LLGL_CASE_TO_STR(VK_ERROR_FRAGMENTED_POOL);
         #if VK_HEADER_VERSION >= 131
         LLGL_CASE_TO_STR( VK_ERROR_UNKNOWN );
         #endif
@@ -334,23 +336,27 @@ VkFormat VKFindSupportedImageFormat(VkPhysicalDevice device, const VkFormat* can
     LLGL_TRAP("failed to find suitable image format");
 }
 
-bool VKHasMemoryType(const VkPhysicalDeviceMemoryProperties& memoryProperties, std::uint32_t memoryTypeBits, VkMemoryPropertyFlags properties)
-{
-    for_range(i, memoryProperties.memoryTypeCount)
-    {
-        if ((memoryTypeBits & (1 << i)) != 0 && (memoryProperties.memoryTypes[i].propertyFlags & properties) == properties)
-            return true;
-    }
-    return false;
-}
-
-std::uint32_t VKFindMemoryType(const VkPhysicalDeviceMemoryProperties& memoryProperties, std::uint32_t memoryTypeBits, VkMemoryPropertyFlags properties)
+static std::uint32_t VKGetMemoryTypeIndex(const VkPhysicalDeviceMemoryProperties &memoryProperties, std::uint32_t memoryTypeBits, VkMemoryPropertyFlags properties)
 {
     for_range(i, memoryProperties.memoryTypeCount)
     {
         if ((memoryTypeBits & (1 << i)) != 0 && (memoryProperties.memoryTypes[i].propertyFlags & properties) == properties)
             return i;
     }
+    return kInvalidMemoryIndex;
+}
+
+bool VKHasMemoryType(const VkPhysicalDeviceMemoryProperties &memoryProperties, std::uint32_t memoryTypeBits, VkMemoryPropertyFlags properties)
+{
+    return VKGetMemoryTypeIndex(memoryProperties, memoryTypeBits, properties) != kInvalidMemoryIndex;
+}
+
+std::uint32_t VKFindMemoryType(const VkPhysicalDeviceMemoryProperties &memoryProperties, std::uint32_t memoryTypeBits, VkMemoryPropertyFlags properties)
+{
+    std::uint32_t index = VKGetMemoryTypeIndex(memoryProperties, memoryTypeBits, properties);
+    if (index != kInvalidMemoryIndex)
+        return index;
+
     LLGL_TRAP("failed to find suitable Vulkan memory type");
 }
 

--- a/sources/Renderer/Vulkan/VKCore.h
+++ b/sources/Renderer/Vulkan/VKCore.h
@@ -98,6 +98,10 @@ VKSurfaceSupportDetails VKQuerySurfaceSupport(VkPhysicalDevice device, VkSurface
 VKQueueFamilyIndices VKFindQueueFamilies(VkPhysicalDevice device, const VkQueueFlags flags, VkSurfaceKHR* surface = nullptr);
 VkFormat VKFindSupportedImageFormat(VkPhysicalDevice device, const VkFormat* candidates, std::size_t numCandidates, VkImageTiling tiling, VkFormatFeatureFlags features);
 
+// Returns true if the implementation exposes a memory type supporting the specified type bits and properties.
+// Use this to probe for optional memory properties: VKFindMemoryType traps rather than reporting failure.
+bool VKHasMemoryType(const VkPhysicalDeviceMemoryProperties& memoryProperties, std::uint32_t memoryTypeBits, VkMemoryPropertyFlags properties);
+
 // Returns the memory type index that supports the specified type bits and properties, or traps program execution on failure.
 std::uint32_t VKFindMemoryType(const VkPhysicalDeviceMemoryProperties& memoryProperties, std::uint32_t memoryTypeBits, VkMemoryPropertyFlags properties);
 

--- a/sources/Renderer/Vulkan/VKPhysicalDevice.cpp
+++ b/sources/Renderer/Vulkan/VKPhysicalDevice.cpp
@@ -256,6 +256,54 @@ struct VKPipelineCacheID
     std::uint8_t  pipelineCacheUUID[VK_UUID_SIZE];  // VkPhysicalDeviceProperties::pipelineCacheUUID
 };
 
+/*
+Returns the subset of 'candidates' the physical device supports with the specified format features
+for optimally tiled images. Used to report which swap-chain formats VKSwapChain can actually pick.
+*/
+static std::vector<Format> FilterVKSupportedFormats(
+    VkPhysicalDevice            physicalDevice,
+    const ArrayView<Format>&    candidates,
+    VkFormatFeatureFlags        formatFeatures)
+{
+    std::vector<Format> formats;
+    formats.reserve(candidates.size());
+
+    for (const Format format : candidates)
+    {
+        VkFormatProperties formatProps = {};
+        vkGetPhysicalDeviceFormatProperties(physicalDevice, VKTypes::Map(format), &formatProps);
+        if ((formatProps.optimalTilingFeatures & formatFeatures) == formatFeatures)
+            formats.push_back(format);
+    }
+
+    return formats;
+}
+
+static std::vector<Format> GetSupportedVKSwapChainColorFormats(VkPhysicalDevice physicalDevice)
+{
+    /*
+    Color formats VKSwapChain::PickSwapSurfaceFormat can select, filtered by device support.
+    Presentation support additionally depends on the surface, which is not known at this point.
+    */
+    static const Format candidates[] =
+    {
+        Format::RGBA8UNorm, Format::RGBA8UNorm_sRGB,
+        Format::BGRA8UNorm, Format::BGRA8UNorm_sRGB,
+        Format::RGB10A2UNorm, Format::RGBA16Float,
+    };
+    return FilterVKSupportedFormats(physicalDevice, candidates, VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT);
+}
+
+static std::vector<Format> GetSupportedVKSwapChainDepthStencilFormats(VkPhysicalDevice physicalDevice)
+{
+    /* Depth-stencil formats VKSwapChain::PickDepthStencilFormat can select, filtered by device support */
+    static const Format candidates[] =
+    {
+        Format::D16UNorm, Format::D24UNormS8UInt, Format::D32Float, Format::D32FloatS8X24UInt,
+    };
+    return FilterVKSupportedFormats(physicalDevice, candidates, VK_FORMAT_FEATURE_DEPTH_STENCIL_ATTACHMENT_BIT);
+}
+
 static void GetVKPipelineCacheID(const VkPhysicalDeviceProperties& properties, std::vector<char>& outCacheID)
 {
     outCacheID.resize(sizeof(VKPipelineCacheID));
@@ -288,6 +336,8 @@ void VKPhysicalDevice::QueryRenderingCaps(RenderingCapabilities& caps)
     caps.clippingRange                              = ClippingRange::ZeroToOne;
     caps.shadingLanguages                           = { ShadingLanguage::SPIRV, ShadingLanguage::SPIRV_100 };
     caps.textureFormats                             = GetDefaultSupportedVKTextureFormats();
+    caps.swapChainColorFormats                      = GetSupportedVKSwapChainColorFormats(physicalDevice_);
+    caps.swapChainDepthStencilFormats               = GetSupportedVKSwapChainDepthStencilFormats(physicalDevice_);
 
     if (features_.textureCompressionBC != VK_FALSE)
     {

--- a/sources/Renderer/Vulkan/VKSwapChain.cpp
+++ b/sources/Renderer/Vulkan/VKSwapChain.cpp
@@ -52,28 +52,27 @@ static VKPtr<VkFence> NullVkFence(VkDevice device)
 }
 
 VKSwapChain::VKSwapChain(
-    VkInstance                      instance,
-    VkPhysicalDevice                physicalDevice,
-    VkDevice                        device,
-    VKDeviceMemoryManager&          deviceMemoryMngr,
-    const VKSharedCommandQueueSPtr& graphicsQueue,
-    const SwapChainDescriptor&      desc,
-    const std::shared_ptr<Surface>& surface,
-    const RendererInfo&             rendererInfo)
-:
-    SwapChain                { desc                                      },
-    instance_                { instance                                  },
-    physicalDevice_          { physicalDevice                            },
-    device_                  { device                                    },
-    deviceMemoryMngr_        { deviceMemoryMngr                          },
-    surface_                 { instance, vkDestroySurfaceKHR             },
-    swapChain_               { device, vkDestroySwapchainKHR             },
-    swapChainRenderPass_     { device                                    },
-    requestedColorFormat_    { desc.colorFormat                          },
-    swapChainSamples_        { GetClampedSamples(desc.samples)           },
-    secondaryRenderPass_     { device                                    },
-    depthStencilBuffer_      { device                                    },
-    graphicsQueue_           { graphicsQueue                             }
+    VkInstance instance,
+    VkPhysicalDevice physicalDevice,
+    VkDevice device,
+    VKDeviceMemoryManager &deviceMemoryMngr,
+    const VKSharedCommandQueueSPtr &graphicsQueue,
+    const SwapChainDescriptor &desc,
+    const std::shared_ptr<Surface> &surface,
+    const RendererInfo &rendererInfo)
+    : SwapChain{desc},
+      instance_{instance},
+      physicalDevice_{physicalDevice},
+      device_{device},
+      deviceMemoryMngr_{deviceMemoryMngr},
+      surface_{instance, vkDestroySurfaceKHR},
+      swapChain_{device, vkDestroySwapchainKHR},
+      swapChainRenderPass_{device},
+      requestedColorFormat_{VKTypes::Map(desc.colorFormat)},
+      swapChainSamples_{GetClampedSamples(desc.samples)},
+      secondaryRenderPass_{device},
+      depthStencilBuffer_{device},
+      graphicsQueue_{graphicsQueue}
 {
     SetOrCreateSurface(surface, SwapChain::BuildDefaultSurfaceTitle(rendererInfo), desc);
 
@@ -715,16 +714,14 @@ VkSurfaceFormatKHR VKSwapChain::PickSwapSurfaceFormat(const std::vector<VkSurfac
     /* Honor an explicitly requested format when the surface supports it.
        This is how an application asks for an sRGB swap-chain, so the hardware performs the
        linear-to-sRGB conversion on write instead of the shader. */
-    if (requestedColorFormat_ != Format::Undefined)
+    if (requestedColorFormat_ != VK_FORMAT_UNDEFINED)
     {
-        const VkFormat requestedVkFormat = VKTypes::Map(requestedColorFormat_);
-
         if (surfaceFormats.size() == 1 && surfaceFormats.front().format == VK_FORMAT_UNDEFINED)
-            return { requestedVkFormat, VK_COLOR_SPACE_SRGB_NONLINEAR_KHR };
+            return {requestedColorFormat_, VK_COLOR_SPACE_SRGB_NONLINEAR_KHR};
 
         for (const VkSurfaceFormatKHR& format : surfaceFormats)
         {
-            if (format.format == requestedVkFormat && format.colorSpace == VK_COLOR_SPACE_SRGB_NONLINEAR_KHR)
+            if (format.format == requestedColorFormat_ && format.colorSpace == VK_COLOR_SPACE_SRGB_NONLINEAR_KHR)
                 return format;
         }
 

--- a/sources/Renderer/Vulkan/VKSwapChain.cpp
+++ b/sources/Renderer/Vulkan/VKSwapChain.cpp
@@ -69,6 +69,7 @@ VKSwapChain::VKSwapChain(
     surface_                 { instance, vkDestroySurfaceKHR             },
     swapChain_               { device, vkDestroySwapchainKHR             },
     swapChainRenderPass_     { device                                    },
+    requestedColorFormat_    { desc.format                               },
     swapChainSamples_        { GetClampedSamples(desc.samples)           },
     secondaryRenderPass_     { device                                    },
     depthStencilBuffer_      { device                                    },
@@ -710,6 +711,25 @@ VkSurfaceFormatKHR VKSwapChain::PickSwapSurfaceFormat(const std::vector<VkSurfac
 {
     if (surfaceFormats.empty())
         LLGL_TRAP("no Vulkan surface formats available");
+
+    /* Honor an explicitly requested format when the surface supports it.
+       This is how an application asks for an sRGB swap-chain, so the hardware performs the
+       linear-to-sRGB conversion on write instead of the shader. */
+    if (requestedColorFormat_ != Format::Undefined)
+    {
+        const VkFormat requestedVkFormat = VKTypes::Map(requestedColorFormat_);
+
+        if (surfaceFormats.size() == 1 && surfaceFormats.front().format == VK_FORMAT_UNDEFINED)
+            return { requestedVkFormat, VK_COLOR_SPACE_SRGB_NONLINEAR_KHR };
+
+        for (const VkSurfaceFormatKHR& format : surfaceFormats)
+        {
+            if (format.format == requestedVkFormat && format.colorSpace == VK_COLOR_SPACE_SRGB_NONLINEAR_KHR)
+                return format;
+        }
+
+        /* Not supported by this surface - fall through to the automatic selection below. */
+    }
 
     if (surfaceFormats.size() == 1 && surfaceFormats.front().format == VK_FORMAT_UNDEFINED)
         return { VK_FORMAT_B8G8R8A8_UNORM, VK_COLOR_SPACE_SRGB_NONLINEAR_KHR };

--- a/sources/Renderer/Vulkan/VKSwapChain.cpp
+++ b/sources/Renderer/Vulkan/VKSwapChain.cpp
@@ -69,7 +69,7 @@ VKSwapChain::VKSwapChain(
     surface_                 { instance, vkDestroySurfaceKHR             },
     swapChain_               { device, vkDestroySwapchainKHR             },
     swapChainRenderPass_     { device                                    },
-    requestedColorFormat_    { desc.format                               },
+    requestedColorFormat_    { desc.colorFormat                          },
     swapChainSamples_        { GetClampedSamples(desc.samples)           },
     secondaryRenderPass_     { device                                    },
     depthStencilBuffer_      { device                                    },
@@ -81,7 +81,7 @@ VKSwapChain::VKSwapChain(
 
     /* Pick image count for swap-chain and depth-stencil format */
     numPreferredColorBuffers_   = PickSwapChainSize(desc.swapBuffers);
-    depthStencilFormat_         = PickDepthStencilFormat(desc.depthBits, desc.stencilBits);
+    depthStencilFormat_         = PickDepthStencilFormat(desc);
 
     /* Create Vulkan render passes, swap-chain, depth-stencil buffer, and multisampling color buffers */
     CreateDefaultAndSecondaryRenderPass();
@@ -752,24 +752,43 @@ VkExtent2D VKSwapChain::PickSwapExtent(const VkSurfaceCapabilitiesKHR& surfaceCa
     };
 }
 
-static std::vector<VkFormat> GetDepthStencilFormatPreference(int depthBits, int stencilBits)
+static std::vector<VkFormat> GetDepthStencilFormatPreference(const SwapChainDescriptor& desc)
 {
-    if (stencilBits == 0)
+    /*
+    Honor an explicitly requested depth-stencil format and list the closest matches as fallback
+    in case the physical device does not support the requested one.
+    */
+    switch (desc.depthStencilFormat)
     {
-        if (depthBits == 32)
+        case Format::D16UNorm:
+            return { VK_FORMAT_D16_UNORM, VK_FORMAT_D24_UNORM_S8_UINT, VK_FORMAT_D32_SFLOAT };
+        case Format::D24UNormS8UInt:
+            return { VK_FORMAT_D24_UNORM_S8_UINT, VK_FORMAT_D32_SFLOAT_S8_UINT };
+        case Format::D32Float:
+            return { VK_FORMAT_D32_SFLOAT, VK_FORMAT_D32_SFLOAT_S8_UINT, VK_FORMAT_D24_UNORM_S8_UINT, VK_FORMAT_D16_UNORM };
+        case Format::D32FloatS8X24UInt:
+            return { VK_FORMAT_D32_SFLOAT_S8_UINT, VK_FORMAT_D24_UNORM_S8_UINT };
+        default:
+            break;
+    }
+
+    /* Deduce the format from the deprecated depth/stencil bit sizes */
+    if (desc.stencilBits == 0)
+    {
+        if (desc.depthBits == 32)
             return { VK_FORMAT_D32_SFLOAT, VK_FORMAT_D32_SFLOAT_S8_UINT, VK_FORMAT_D24_UNORM_S8_UINT, VK_FORMAT_D16_UNORM };
     }
     else
     {
-        if (depthBits == 32)
+        if (desc.depthBits == 32)
             return { VK_FORMAT_D32_SFLOAT_S8_UINT, VK_FORMAT_D24_UNORM_S8_UINT };
     }
     return { VK_FORMAT_D24_UNORM_S8_UINT, VK_FORMAT_D32_SFLOAT, VK_FORMAT_D16_UNORM };
 }
 
-VkFormat VKSwapChain::PickDepthStencilFormat(int depthBits, int stencilBits) const
+VkFormat VKSwapChain::PickDepthStencilFormat(const SwapChainDescriptor& desc) const
 {
-    const std::vector<VkFormat> formats = GetDepthStencilFormatPreference(depthBits, stencilBits);
+    const std::vector<VkFormat> formats = GetDepthStencilFormatPreference(desc);
     return VKFindSupportedImageFormat(
         physicalDevice_,
         formats.data(),

--- a/sources/Renderer/Vulkan/VKSwapChain.h
+++ b/sources/Renderer/Vulkan/VKSwapChain.h
@@ -141,7 +141,7 @@ class VKSwapChain final : public SwapChain
         VKPtr<VkSwapchainKHR>               swapChain_;
         VKRenderPass                        swapChainRenderPass_;
         VkSurfaceFormatKHR                  swapChainFormat_                            = {};
-        Format                              requestedColorFormat_                       = Format::Undefined; // SwapChainDescriptor::colorFormat; Undefined = pick automatically
+        VkFormat                            requestedColorFormat_ = VK_FORMAT_UNDEFINED; // SwapChainDescriptor::colorFormat; Undefined = pick automatically
         std::uint32_t                       swapChainSamples_                           = 1;
         VkExtent2D                          swapChainExtent_                            = { 0, 0 };
         std::vector<VkImage>                swapChainImages_;

--- a/sources/Renderer/Vulkan/VKSwapChain.h
+++ b/sources/Renderer/Vulkan/VKSwapChain.h
@@ -141,6 +141,7 @@ class VKSwapChain final : public SwapChain
         VKPtr<VkSwapchainKHR>               swapChain_;
         VKRenderPass                        swapChainRenderPass_;
         VkSurfaceFormatKHR                  swapChainFormat_                            = {};
+        Format                              requestedColorFormat_                       = Format::Undefined; // SwapChainDescriptor::format; Undefined = pick automatically
         std::uint32_t                       swapChainSamples_                           = 1;
         VkExtent2D                          swapChainExtent_                            = { 0, 0 };
         std::vector<VkImage>                swapChainImages_;

--- a/sources/Renderer/Vulkan/VKSwapChain.h
+++ b/sources/Renderer/Vulkan/VKSwapChain.h
@@ -118,7 +118,7 @@ class VKSwapChain final : public SwapChain
 
         VkSurfaceFormatKHR PickSwapSurfaceFormat(const std::vector<VkSurfaceFormatKHR>& surfaceFormats) const;
         VkExtent2D PickSwapExtent(const VkSurfaceCapabilitiesKHR& surfaceCaps, const Extent2D& resolution) const;
-        VkFormat PickDepthStencilFormat(int depthBits, int stencilBits) const;
+        VkFormat PickDepthStencilFormat(const SwapChainDescriptor& desc) const;
         std::uint32_t PickSwapChainSize(std::uint32_t swapBuffers) const;
 
         void AcquireNextColorBuffer();
@@ -141,7 +141,7 @@ class VKSwapChain final : public SwapChain
         VKPtr<VkSwapchainKHR>               swapChain_;
         VKRenderPass                        swapChainRenderPass_;
         VkSurfaceFormatKHR                  swapChainFormat_                            = {};
-        Format                              requestedColorFormat_                       = Format::Undefined; // SwapChainDescriptor::format; Undefined = pick automatically
+        Format                              requestedColorFormat_                       = Format::Undefined; // SwapChainDescriptor::colorFormat; Undefined = pick automatically
         std::uint32_t                       swapChainSamples_                           = 1;
         VkExtent2D                          swapChainExtent_                            = { 0, 0 };
         std::vector<VkImage>                swapChainImages_;

--- a/sources/XR/OpenXR/OpenXRSession.cpp
+++ b/sources/XR/OpenXR/OpenXRSession.cpp
@@ -233,8 +233,17 @@ XRSwapChain* OpenXRSession::CreateSwapChain(const XRSwapChainDescriptor& swapCha
     {
         bool depthReady = false;
 
+        /*
+        Depth cannot be submitted while multi-sampling: the swap-chain renders into its own multi-sampled depth
+        attachment, and resolving that into the runtime's single-sampled depth image needs depth-stencil resolve,
+        which is not implemented here. Creating the companion anyway would hand the compositor an image nothing
+        ever writes to, and it would be used for reprojection - so fall through to the private depth texture,
+        which is honest about not being submitted.
+        */
+        const bool depthSubmissionPossible = (depthSubmissionEnabled_ && swapChainDesc.sampleCount <= 1);
+
         // Prefer a depth swap-chain submitted to the runtime for reprojection, if the runtime supports it.
-        if (depthSubmissionEnabled_)
+        if (depthSubmissionPossible)
         {
             XRSwapChainDescriptor depthDesc;
             depthDesc.format        = swapChainDesc.depthStencilFormat;

--- a/sources/XR/OpenXR/OpenXRSession.cpp
+++ b/sources/XR/OpenXR/OpenXRSession.cpp
@@ -179,7 +179,11 @@ bool OpenXRSession::CreateNativeSwapChain(
     XrSwapchainCreateInfo createInfo{ XR_TYPE_SWAPCHAIN_CREATE_INFO };
     createInfo.usageFlags       = usageFlags;
     createInfo.format           = nativeFormat;
-    createInfo.sampleCount      = swapChainDesc.sampleCount;
+    /* Runtime images are always single-sampled: they are what the compositor consumes, and
+       multisampled swap-chains are inconsistently supported across runtimes. When the
+       application asks for MSAA, the swap-chain renders into its own multisampled attachment
+       and resolves into these images instead (see OpenXRSwapChain::CreateRenderTargets). */
+    createInfo.sampleCount      = 1;
     createInfo.width            = swapChainDesc.resolution.width;
     createInfo.height           = swapChainDesc.resolution.height;
     createInfo.faceCount        = 1;

--- a/sources/XR/OpenXR/OpenXRSwapChain.cpp
+++ b/sources/XR/OpenXR/OpenXRSwapChain.cpp
@@ -56,6 +56,14 @@ OpenXRSwapChain::~OpenXRSwapChain()
     }
     renderTargets_.clear();
 
+    // The render pass belongs to the first render target, so it is gone with them.
+    renderPass_ = nullptr;
+
+    if (msaaColorTexture_ != nullptr)
+        renderSystem_.Release(*msaaColorTexture_);
+    if (msaaDepthTexture_ != nullptr)
+        renderSystem_.Release(*msaaDepthTexture_);
+
     if (depthTexture_ != nullptr)
         renderSystem_.Release(*depthTexture_);
 
@@ -248,6 +256,70 @@ bool OpenXRSwapChain::BuildRenderTargets()
     // COLOR_ATTACHMENT_OPTIMAL, depth in DEPTH_STENCIL_ATTACHMENT_OPTIMAL), exactly like the single-view path.
     const std::uint32_t numViews = (desc_.arrayLayers > 1 ? desc_.arrayLayers : 1);
 
+    // MSAA: the runtime's images are single-sampled (they are the compositor's), so rendering targets our own
+    // multi-sampled attachments and resolves into the acquired image. LLGL requires real textures rather than
+    // anonymous internal buffers here, because those are single-layer and this may be a multiview target.
+    // One attachment set is shared by every swap-chain image; only the resolve target rotates.
+    //
+    // These are attachment-only, single-MIP, multi-sampled textures with no initial data, so a backend can
+    // infer that their contents never outlive the render pass - the Vulkan backend gives them
+    // VK_IMAGE_USAGE_TRANSIENT_ATTACHMENT_BIT and lazily-allocated memory on that basis, which is what makes
+    // multi-sampling affordable on a tile-based GPU. Nothing needs to be requested explicitly.
+    const bool hasMultiSampling = (desc_.sampleCount > 1);
+    if (hasMultiSampling)
+    {
+        TextureDescriptor msaaColorDesc;
+        {
+            msaaColorDesc.debugName     = "XRSwapChain.MSAAColor";
+            msaaColorDesc.type          = (numViews > 1 ? TextureType::Texture2DMSArray : TextureType::Texture2DMS);
+            msaaColorDesc.bindFlags     = BindFlags::ColorAttachment;
+            msaaColorDesc.miscFlags     = MiscFlags::FixedSamples | MiscFlags::NoInitialData;
+            msaaColorDesc.format        = desc_.format;
+            msaaColorDesc.extent        = { desc_.resolution.width, desc_.resolution.height, 1 };
+            msaaColorDesc.arrayLayers   = numViews;
+            msaaColorDesc.mipLevels     = 1;
+            msaaColorDesc.samples       = desc_.sampleCount;
+        }
+        msaaColorTexture_ = renderSystem_.CreateTexture(msaaColorDesc);
+        if (msaaColorTexture_ == nullptr)
+            return false;
+
+        // Depth must match the color attachment's sample count. Note this displaces depth submission: a
+        // multi-sampled depth buffer cannot be resolved into the runtime's single-sampled depth image without
+        // depth-resolve support, so with MSAA the depth companion (if any) is not rendered into and depth
+        // reprojection is unavailable.
+        if (hasDepth)
+        {
+            Texture* depthReference = depthTextures.front();
+
+            TextureDescriptor msaaDepthDesc;
+            {
+                msaaDepthDesc.debugName     = "XRSwapChain.MSAADepth";
+                msaaDepthDesc.type          = (numViews > 1 ? TextureType::Texture2DMSArray : TextureType::Texture2DMS);
+                msaaDepthDesc.bindFlags     = BindFlags::DepthStencilAttachment;
+                msaaDepthDesc.miscFlags     = MiscFlags::FixedSamples | MiscFlags::NoInitialData;
+                msaaDepthDesc.format        = depthReference->GetFormat();
+                msaaDepthDesc.extent        = { desc_.resolution.width, desc_.resolution.height, 1 };
+                msaaDepthDesc.arrayLayers   = numViews;
+                msaaDepthDesc.mipLevels     = 1;
+                msaaDepthDesc.samples       = desc_.sampleCount;
+            }
+            msaaDepthTexture_ = renderSystem_.CreateTexture(msaaDepthDesc);
+            if (msaaDepthTexture_ == nullptr)
+                return false;
+        }
+
+        /* The render pass is left to the render target below. Do NOT build one from a RenderPassDescriptor here:
+           that path is shaped for swap-chains and gives every color attachment a final layout of
+           VK_IMAGE_LAYOUT_PRESENT_SRC_KHR, which is only valid for images owned by a VkSwapchainKHR. The runtime's
+           images are ordinary VkImages handed to us by OpenXR, so that layout is invalid for them - desktop drivers
+           tolerate it, Adreno faults inside vkCmdBeginRenderPass. It would also propagate the color attachment's
+           store op onto the resolve attachment, discarding the very image being resolved into.
+
+           Discarding the multi-sampled contents at end of pass - the tile-memory win - is handled by
+           VKRenderTarget::CreateRenderPass, which knows which color attachments have a resolve target. */
+    }
+
     renderTargets_.resize(texturePtrs_.size());
     for (std::size_t colorIndex = 0; colorIndex < texturePtrs_.size(); ++colorIndex)
     {
@@ -257,9 +329,22 @@ bool OpenXRSwapChain::BuildRenderTargets()
             RenderTargetDescriptor renderTargetDesc;
             renderTargetDesc.resolution          = desc_.resolution;
             renderTargetDesc.views               = numViews;
-            renderTargetDesc.colorAttachments[0] = AttachmentDescriptor{ texturePtrs_[colorIndex] };
-            if (hasDepth)
-                renderTargetDesc.depthStencilAttachment = AttachmentDescriptor{ depthTextures[depthIndex] };
+
+            if (hasMultiSampling)
+            {
+                /* Render into the multi-sampled attachments and resolve into the runtime's image. */
+                renderTargetDesc.samples               = desc_.sampleCount;
+                renderTargetDesc.colorAttachments[0]   = AttachmentDescriptor{ msaaColorTexture_ };
+                renderTargetDesc.resolveAttachments[0] = AttachmentDescriptor{ texturePtrs_[colorIndex] };
+                if (msaaDepthTexture_ != nullptr)
+                    renderTargetDesc.depthStencilAttachment = AttachmentDescriptor{ msaaDepthTexture_ };
+            }
+            else
+            {
+                renderTargetDesc.colorAttachments[0] = AttachmentDescriptor{ texturePtrs_[colorIndex] };
+                if (hasDepth)
+                    renderTargetDesc.depthStencilAttachment = AttachmentDescriptor{ depthTextures[depthIndex] };
+            }
 
             // Every render target shares one render pass object (created by the first target): all targets have
             // identical attachment formats, so reusing it avoids redundant render passes and guarantees GetRenderPass

--- a/sources/XR/OpenXR/OpenXRSwapChain.h
+++ b/sources/XR/OpenXR/OpenXRSwapChain.h
@@ -138,6 +138,12 @@ class OpenXRSwapChain final : public XRSwapChain
         std::unique_ptr<OpenXRSwapChain>            depthCompanion_;
         Texture*                                    depthTexture_   = nullptr;
 
+        // Multi-sampled attachments used when desc_.sampleCount > 1. The runtime's images are single-sampled
+        // (the compositor's), so rendering targets these instead and resolves into the acquired runtime image.
+        // One set is shared by every swap-chain image: only the resolve target rotates. Owned by this swap-chain.
+        Texture*                                    msaaColorTexture_ = nullptr;
+        Texture*                                    msaaDepthTexture_ = nullptr;
+
         // Render targets indexed [colorImageIndex][depthImageIndex]; the depth axis has a single slot when depth is a
         // private texture or absent. Owned by this swap-chain.
         SmallVector<SmallVector<RenderTarget*>>     renderTargets_;

--- a/wrapper/C99/C99Bridge.cpp
+++ b/wrapper/C99/C99Bridge.cpp
@@ -53,12 +53,22 @@ void ConvertRenderingCaps(RenderingCapabilitiesC99Wrapper& wrapper, LLGLRenderin
     wrapper.textureFormats.resize(src.textureFormats.size());
     ::memcpy(wrapper.textureFormats.data(), src.textureFormats.data(), sizeof(LLGLFormat) * src.textureFormats.size());
 
-    dst.screenOrigin        = static_cast<LLGLScreenOrigin>(src.screenOrigin);
-    dst.clippingRange       = static_cast<LLGLClippingRange>(src.clippingRange);
-    dst.numShadingLanguages = wrapper.shadingLanguages.size();
-    dst.shadingLanguages    = wrapper.shadingLanguages.data();
-    dst.numTextureFormats   = wrapper.textureFormats.size();
-    dst.textureFormats      = wrapper.textureFormats.data();
+    wrapper.swapChainColorFormats.resize(src.swapChainColorFormats.size());
+    ::memcpy(wrapper.swapChainColorFormats.data(), src.swapChainColorFormats.data(), sizeof(LLGLFormat) * src.swapChainColorFormats.size());
+
+    wrapper.swapChainDepthStencilFormats.resize(src.swapChainDepthStencilFormats.size());
+    ::memcpy(wrapper.swapChainDepthStencilFormats.data(), src.swapChainDepthStencilFormats.data(), sizeof(LLGLFormat) * src.swapChainDepthStencilFormats.size());
+
+    dst.screenOrigin                        = static_cast<LLGLScreenOrigin>(src.screenOrigin);
+    dst.clippingRange                       = static_cast<LLGLClippingRange>(src.clippingRange);
+    dst.numShadingLanguages                 = wrapper.shadingLanguages.size();
+    dst.shadingLanguages                    = wrapper.shadingLanguages.data();
+    dst.numTextureFormats                   = wrapper.textureFormats.size();
+    dst.textureFormats                      = wrapper.textureFormats.data();
+    dst.numSwapChainColorFormats            = wrapper.swapChainColorFormats.size();
+    dst.swapChainColorFormats               = wrapper.swapChainColorFormats.data();
+    dst.numSwapChainDepthStencilFormats     = wrapper.swapChainDepthStencilFormats.size();
+    dst.swapChainDepthStencilFormats        = wrapper.swapChainDepthStencilFormats.data();
     ::memcpy(&(dst.features), &(src.features), sizeof(LLGLRenderingFeatures));
     ::memcpy(&(dst.limits), &(src.limits), sizeof(LLGLRenderingLimits));
 }

--- a/wrapper/C99/C99Bridge.h
+++ b/wrapper/C99/C99Bridge.h
@@ -29,6 +29,8 @@ struct RenderingCapabilitiesC99Wrapper
 {
     std::vector<LLGLShadingLanguage>    shadingLanguages;
     std::vector<LLGLFormat>             textureFormats;
+    std::vector<LLGLFormat>             swapChainColorFormats;
+    std::vector<LLGLFormat>             swapChainDepthStencilFormats;
 };
 
 void ConvertRenderSystemDesc(LLGL::RenderSystemDescriptor& dst, const LLGLRenderSystemDescriptor& src);

--- a/wrapper/C99/C99TypeAssertions.cpp
+++ b/wrapper/C99/C99TypeAssertions.cpp
@@ -921,6 +921,8 @@ LLGL_STATIC_ASSERT_OFFSET(SubresourceFootprint, layerStride);
 LLGL_STATIC_ASSERT_SIZE(SwapChainDescriptor);
 LLGL_STATIC_ASSERT_OFFSET(SwapChainDescriptor, debugName);
 LLGL_STATIC_ASSERT_OFFSET(SwapChainDescriptor, resolution);
+LLGL_STATIC_ASSERT_OFFSET(SwapChainDescriptor, colorFormat);
+LLGL_STATIC_ASSERT_OFFSET(SwapChainDescriptor, depthStencilFormat);
 LLGL_STATIC_ASSERT_OFFSET(SwapChainDescriptor, colorBits);
 LLGL_STATIC_ASSERT_OFFSET(SwapChainDescriptor, depthBits);
 LLGL_STATIC_ASSERT_OFFSET(SwapChainDescriptor, stencilBits);

--- a/wrapper/CSharp/LLGLWrapper.cs
+++ b/wrapper/CSharp/LLGLWrapper.cs
@@ -2355,10 +2355,11 @@ namespace LLGL
     {
         public SwapChainDescriptor() { }
 
-        public SwapChainDescriptor(string debugName = null, Extent2D resolution = new Extent2D(), int colorBits = 32, int depthBits = 24, int stencilBits = 8, int samples = 1, int swapBuffers = 2, bool fullscreen = false, bool resizable = false)
+        public SwapChainDescriptor(string debugName = null, Extent2D resolution = new Extent2D(), Format format = Format.Undefined, int colorBits = 32, int depthBits = 24, int stencilBits = 8, int samples = 1, int swapBuffers = 2, bool fullscreen = false, bool resizable = false)
         {
             DebugName   = debugName;
             Resolution  = resolution;
+            Format      = format;
             ColorBits   = colorBits;
             DepthBits   = depthBits;
             StencilBits = stencilBits;
@@ -2370,6 +2371,7 @@ namespace LLGL
 
         public AnsiString DebugName { get; set; }   = null;
         public Extent2D   Resolution { get; set; }  = new Extent2D();
+        public Format     Format { get; set; }      = Format.Undefined;
         public int        ColorBits { get; set; }   = 32;
         public int        DepthBits { get; set; }   = 24;
         public int        StencilBits { get; set; } = 8;
@@ -2390,6 +2392,7 @@ namespace LLGL
                         native.debugName = debugNamePtr;
                     }
                     native.resolution  = Resolution;
+                    native.format      = Format;
                     native.colorBits   = ColorBits;
                     native.depthBits   = DepthBits;
                     native.stencilBits = StencilBits;
@@ -4201,6 +4204,7 @@ namespace LLGL
         {
             public byte*    debugName;   /* = null */
             public Extent2D resolution;
+            public Format   format;      /* = Format.Undefined */
             public int      colorBits;   /* = 32 */
             public int      depthBits;   /* = 24 */
             public int      stencilBits; /* = 8 */

--- a/wrapper/CSharp/LLGLWrapper.cs
+++ b/wrapper/CSharp/LLGLWrapper.cs
@@ -2174,12 +2174,14 @@ namespace LLGL
 
     public class RenderingCapabilities
     {
-        public ScreenOrigin      ScreenOrigin { get; set; }     = ScreenOrigin.UpperLeft;
-        public ClippingRange     ClippingRange { get; set; }    = ClippingRange.ZeroToOne;
+        public ScreenOrigin      ScreenOrigin { get; set; }                 = ScreenOrigin.UpperLeft;
+        public ClippingRange     ClippingRange { get; set; }                = ClippingRange.ZeroToOne;
         public ShadingLanguage[] ShadingLanguages { get; set; }
         public Format[]          TextureFormats { get; set; }
-        public RenderingFeatures Features { get; set; }         = new RenderingFeatures();
-        public RenderingLimits   Limits { get; set; }           = new RenderingLimits();
+        public Format[]          SwapChainColorFormats { get; set; }
+        public Format[]          SwapChainDepthStencilFormats { get; set; }
+        public RenderingFeatures Features { get; set; }                     = new RenderingFeatures();
+        public RenderingLimits   Limits { get; set; }                       = new RenderingLimits();
 
         public RenderingCapabilities() { }
 
@@ -2194,20 +2196,30 @@ namespace LLGL
             {
                 unsafe
                 {
-                    ScreenOrigin     = value.screenOrigin;
-                    ClippingRange    = value.clippingRange;
-                    ShadingLanguages = new ShadingLanguage[(int)value.numShadingLanguages];
+                    ScreenOrigin                 = value.screenOrigin;
+                    ClippingRange                = value.clippingRange;
+                    ShadingLanguages             = new ShadingLanguage[(int)value.numShadingLanguages];
                     for (int i = 0; i < ShadingLanguages.Length; ++i)
                     {
                         ShadingLanguages[i] = value.shadingLanguages[i];
                     }
-                    TextureFormats   = new Format[(int)value.numTextureFormats];
+                    TextureFormats               = new Format[(int)value.numTextureFormats];
                     for (int i = 0; i < TextureFormats.Length; ++i)
                     {
                         TextureFormats[i] = value.textureFormats[i];
                     }
-                    Features.Native  = value.features;
-                    Limits.Native    = value.limits;
+                    SwapChainColorFormats        = new Format[(int)value.numSwapChainColorFormats];
+                    for (int i = 0; i < SwapChainColorFormats.Length; ++i)
+                    {
+                        SwapChainColorFormats[i] = value.swapChainColorFormats[i];
+                    }
+                    SwapChainDepthStencilFormats = new Format[(int)value.numSwapChainDepthStencilFormats];
+                    for (int i = 0; i < SwapChainDepthStencilFormats.Length; ++i)
+                    {
+                        SwapChainDepthStencilFormats[i] = value.swapChainDepthStencilFormats[i];
+                    }
+                    Features.Native              = value.features;
+                    Limits.Native                = value.limits;
                 }
             }
         }
@@ -2355,30 +2367,32 @@ namespace LLGL
     {
         public SwapChainDescriptor() { }
 
-        public SwapChainDescriptor(string debugName = null, Extent2D resolution = new Extent2D(), Format format = Format.Undefined, int colorBits = 32, int depthBits = 24, int stencilBits = 8, int samples = 1, int swapBuffers = 2, bool fullscreen = false, bool resizable = false)
+        public SwapChainDescriptor(string debugName = null, Extent2D resolution = new Extent2D(), Format colorFormat = Format.Undefined, Format depthStencilFormat = Format.Undefined, int colorBits = 32, int depthBits = 24, int stencilBits = 8, int samples = 1, int swapBuffers = 2, bool fullscreen = false, bool resizable = false)
         {
-            DebugName   = debugName;
-            Resolution  = resolution;
-            Format      = format;
-            ColorBits   = colorBits;
-            DepthBits   = depthBits;
-            StencilBits = stencilBits;
-            Samples     = samples;
-            SwapBuffers = swapBuffers;
-            Fullscreen  = fullscreen;
-            Resizable   = resizable;
+            DebugName          = debugName;
+            Resolution         = resolution;
+            ColorFormat        = colorFormat;
+            DepthStencilFormat = depthStencilFormat;
+            ColorBits          = colorBits;
+            DepthBits          = depthBits;
+            StencilBits        = stencilBits;
+            Samples            = samples;
+            SwapBuffers        = swapBuffers;
+            Fullscreen         = fullscreen;
+            Resizable          = resizable;
         }
 
-        public AnsiString DebugName { get; set; }   = null;
-        public Extent2D   Resolution { get; set; }  = new Extent2D();
-        public Format     Format { get; set; }      = Format.Undefined;
-        public int        ColorBits { get; set; }   = 32;
-        public int        DepthBits { get; set; }   = 24;
-        public int        StencilBits { get; set; } = 8;
-        public int        Samples { get; set; }     = 1;
-        public int        SwapBuffers { get; set; } = 2;
-        public bool       Fullscreen { get; set; }  = false;
-        public bool       Resizable { get; set; }   = false;
+        public AnsiString DebugName { get; set; }          = null;
+        public Extent2D   Resolution { get; set; }         = new Extent2D();
+        public Format     ColorFormat { get; set; }        = Format.Undefined;
+        public Format     DepthStencilFormat { get; set; } = Format.Undefined;
+        public int        ColorBits { get; set; }          = 32;
+        public int        DepthBits { get; set; }          = 24;
+        public int        StencilBits { get; set; }        = 8;
+        public int        Samples { get; set; }            = 1;
+        public int        SwapBuffers { get; set; }        = 2;
+        public bool       Fullscreen { get; set; }         = false;
+        public bool       Resizable { get; set; }          = false;
 
         internal NativeLLGL.SwapChainDescriptor Native
         {
@@ -2391,15 +2405,16 @@ namespace LLGL
                     {
                         native.debugName = debugNamePtr;
                     }
-                    native.resolution  = Resolution;
-                    native.format      = Format;
-                    native.colorBits   = ColorBits;
-                    native.depthBits   = DepthBits;
-                    native.stencilBits = StencilBits;
-                    native.samples     = Samples;
-                    native.swapBuffers = SwapBuffers;
-                    native.fullscreen  = Fullscreen;
-                    native.resizable   = Resizable;
+                    native.resolution         = Resolution;
+                    native.colorFormat        = ColorFormat;
+                    native.depthStencilFormat = DepthStencilFormat;
+                    native.colorBits          = ColorBits;
+                    native.depthBits          = DepthBits;
+                    native.stencilBits        = StencilBits;
+                    native.samples            = Samples;
+                    native.swapBuffers        = SwapBuffers;
+                    native.fullscreen         = Fullscreen;
+                    native.resizable          = Resizable;
                 }
                 return native;
             }
@@ -4156,12 +4171,16 @@ namespace LLGL
 
         public unsafe struct RenderingCapabilities
         {
-            public ScreenOrigin      screenOrigin;        /* = ScreenOrigin.UpperLeft */
-            public ClippingRange     clippingRange;       /* = ClippingRange.ZeroToOne */
+            public ScreenOrigin      screenOrigin;                    /* = ScreenOrigin.UpperLeft */
+            public ClippingRange     clippingRange;                   /* = ClippingRange.ZeroToOne */
             public IntPtr            numShadingLanguages;
             public ShadingLanguage*  shadingLanguages;
             public IntPtr            numTextureFormats;
             public Format*           textureFormats;
+            public IntPtr            numSwapChainColorFormats;
+            public Format*           swapChainColorFormats;
+            public IntPtr            numSwapChainDepthStencilFormats;
+            public Format*           swapChainDepthStencilFormats;
             public RenderingFeatures features;
             public RenderingLimits   limits;
         }
@@ -4202,18 +4221,19 @@ namespace LLGL
 
         public unsafe struct SwapChainDescriptor
         {
-            public byte*    debugName;   /* = null */
+            public byte*    debugName;          /* = null */
             public Extent2D resolution;
-            public Format   format;      /* = Format.Undefined */
-            public int      colorBits;   /* = 32 */
-            public int      depthBits;   /* = 24 */
-            public int      stencilBits; /* = 8 */
-            public int      samples;     /* = 1 */
-            public int      swapBuffers; /* = 2 */
+            public Format   colorFormat;        /* = Format.Undefined */
+            public Format   depthStencilFormat; /* = Format.Undefined */
+            public int      colorBits;          /* = 32 */
+            public int      depthBits;          /* = 24 */
+            public int      stencilBits;        /* = 8 */
+            public int      samples;            /* = 1 */
+            public int      swapBuffers;        /* = 2 */
             [MarshalAs(UnmanagedType.I1)]
-            public bool     fullscreen;  /* = false */
+            public bool     fullscreen;         /* = false */
             [MarshalAs(UnmanagedType.I1)]
-            public bool     resizable;   /* = false */
+            public bool     resizable;          /* = false */
         }
 
         public unsafe struct TextureDescriptor

--- a/wrapper/Go/LLGLBridge.go
+++ b/wrapper/Go/LLGLBridge.go
@@ -19,6 +19,8 @@ func convertSwapChainDescriptor(dst *C.LLGLSwapChainDescriptor, src *SwapChainDe
 	dst.debugName			= C.CString(src.DebugName)
 	dst.resolution.width	= C.uint32_t(src.Resolution.Width)
 	dst.resolution.height	= C.uint32_t(src.Resolution.Height)
+	dst.colorFormat			= C.LLGLFormat(src.ColorFormat)
+	dst.depthStencilFormat	= C.LLGLFormat(src.DepthStencilFormat)
 	dst.colorBits			= C.int(src.ColorBits)
 	dst.depthBits			= C.int(src.DepthBits)
 	dst.stencilBits			= C.int(src.StencilBits)

--- a/wrapper/Go/LLGLWrapper.go
+++ b/wrapper/Go/LLGLWrapper.go
@@ -1439,6 +1439,7 @@ type ComputeShaderAttributes struct {
 type SwapChainDescriptor struct {
     DebugName   string   /* = "" */
     Resolution  Extent2D
+    Format      Format   /* = FormatUndefined */
     ColorBits   int      /* = 32 */
     DepthBits   int      /* = 24 */
     StencilBits int      /* = 8 */

--- a/wrapper/Go/LLGLWrapper.go
+++ b/wrapper/Go/LLGLWrapper.go
@@ -1399,12 +1399,14 @@ type RenderSystemDescriptor struct {
 }
 
 type RenderingCapabilities struct {
-    ScreenOrigin     ScreenOrigin      /* = ScreenOriginUpperLeft */
-    ClippingRange    ClippingRange     /* = ClippingRangeZeroToOne */
-    ShadingLanguages []ShadingLanguage /* = nil */
-    TextureFormats   []Format          /* = nil */
-    Features         RenderingFeatures
-    Limits           RenderingLimits
+    ScreenOrigin                 ScreenOrigin      /* = ScreenOriginUpperLeft */
+    ClippingRange                ClippingRange     /* = ClippingRangeZeroToOne */
+    ShadingLanguages             []ShadingLanguage /* = nil */
+    TextureFormats               []Format          /* = nil */
+    SwapChainColorFormats        []Format          /* = nil */
+    SwapChainDepthStencilFormats []Format          /* = nil */
+    Features                     RenderingFeatures
+    Limits                       RenderingLimits
 }
 
 type AttachmentDescriptor struct {
@@ -1437,16 +1439,17 @@ type ComputeShaderAttributes struct {
 }
 
 type SwapChainDescriptor struct {
-    DebugName   string   /* = "" */
-    Resolution  Extent2D
-    Format      Format   /* = FormatUndefined */
-    ColorBits   int      /* = 32 */
-    DepthBits   int      /* = 24 */
-    StencilBits int      /* = 8 */
-    Samples     uint32   /* = 1 */
-    SwapBuffers uint32   /* = 2 */
-    Fullscreen  bool     /* = false */
-    Resizable   bool     /* = false */
+    DebugName          string   /* = "" */
+    Resolution         Extent2D
+    ColorFormat        Format   /* = FormatUndefined */
+    DepthStencilFormat Format   /* = FormatUndefined */
+    ColorBits          int      /* = 32 */
+    DepthBits          int      /* = 24 */
+    StencilBits        int      /* = 8 */
+    Samples            uint32   /* = 1 */
+    SwapBuffers        uint32   /* = 2 */
+    Fullscreen         bool     /* = false */
+    Resizable          bool     /* = false */
 }
 
 type TextureSwizzleRGBA struct {


### PR DESCRIPTION
Adds multi-sampling support to OpenXR swap-chains, plus the swap-chain colour format control it depends on.
- `SwapChainDescriptor::format`: request a specific back-buffer format (e.g. an  sRGB one, so the hardware performs the linear→sRGB conversion on write).  `Format::Undefined` keeps the existing auto-pick, so no existing caller changes.
- XR swap-chains honor `sampleCount`. The runtime owns only the final image and it is always single-sampled, so the swap-chain allocates its own multi-sampled attachments and resolves into the acquired image.
- Transient attachments are **inferred rather than requested**: a texture that is  attachment-only, single-MIP, multi-sampled and has no initial data can only be consumed by a resolve inside its own render pass, so Vulkan gives it `TRANSIENT_ATTACHMENT` usage and prefers lazily-allocated memory. The structural half of that test is shared as `IsAttachmentOnlyTexture`, which OpenGL's existing  `IsRenderbufferSufficient` now builds on.
- `HelloOpenXR` demonstrates MSAA (`--samples=N`, or the `debug.llgl.samples`  system property on Android). It also fixes a `hasMultiView` → `hasMultiview`  typo that meant the example did not compile at all — unnoticed because examples  and OpenXR are both off by default.

Known limitation: depth submission (reprojection) is unavailable while multi-sampling, because multi-sampled depth cannot be resolved into the runtime's single-sampled depth image without `VK_KHR_depth_stencil_resolve`. This is reported at runtime rather than silently submitting an unwritten image. A follow-up PR lifts the restriction.